### PR TITLE
Fixed StreamDeck Bug

### DIFF
--- a/nodecg-io-streamdeck/extension/index.ts
+++ b/nodecg-io-streamdeck/extension/index.ts
@@ -14,7 +14,7 @@ export interface StreamdeckServiceClient {
 }
 
 module.exports = (nodecg: NodeCG): ServiceProvider<StreamdeckServiceClient> | undefined => {
-    const service = new StreamdeckServiceBundle(nodecg, "streamdeck", __dirname, "streamdeck-schema.json");
+    const service = new StreamdeckServiceBundle(nodecg, "streamdeck", __dirname, "../streamdeck-schema.json");
     return service.register();
 };
 


### PR DESCRIPTION
By starting nodecg, nodecg can't find the schema, because the file name was set incorrectly.