### PR TITLE
Move bootstrapping using lerna into a separate npm script

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -7,8 +7,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
-    - name: Install system dependencies
-      run: sudo apt-get -y install libasound2-dev
     - name: Install nodejs dependencies
       run: npm i
     - name: Run ESLint

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io",
     "private": true,
     "scripts": {
-        "postinstall": "lerna bootstrap --hoist --nohoist monaco-editor",
+        "bootstrap": "lerna bootstrap --hoist --nohoist monaco-editor",
         "build": "lerna run build --parallel",
         "watch": "lerna run --parallel watch",
         "lint": "eslint . --ext ts",


### PR DESCRIPTION
Moves bootstrapping using lerna into a seperate script called "bootstrap" instead of automatically being run using postinstall.

Before this PR the install routine would look like this:
1. npm installs lerna, eslint, prettier and stuff like that defined in
   `package.json`
2. npm calls postinstall which then calls `lerna bootstrap`
3. Lerna bootstrap installs everything and writes the `package-lock.json` with all hoisted dependencies.
4. npm overwrites package-lock.json with the dependencies of
   package.json, meaning lerna, eslint and so on. But this lock file
doesn't include all hoisted dependencies.

This is the reason why thef package-lock.json currently changed about
4000 lines depending if the dev used `npm install` or `npm run
     postinstall`. This could be sawn here as an example: https://github.com/codeoverflow-org/nodecg-io/pull/71#issuecomment-663862115.

This PR fixes this issue by moving the bootstrap command into its own
script, which ensures that the lockfile doesn't change because of this.