### PR TITLE
Reduce boilerplate for bundles using services

### DIFF
--- a/nodecg-io-ahk/extension/index.ts
+++ b/nodecg-io-ahk/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import { AHK } from "./AHK";
 
@@ -13,10 +12,10 @@ export interface AHKServiceClient {
     getRawClient(): AHK;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<AHKServiceClient> | undefined => {
-    const ahkService = new AhkService(nodecg, "ahk", __dirname, "../ahk-schema.json");
-    return ahkService.register();
+module.exports = (nodecg: NodeCG) => {
+    new AhkService(nodecg, "ahk", __dirname, "../ahk-schema.json").register();
 };
+
 class AhkService extends ServiceBundle<AHKServiceConfig, AHKServiceClient> {
     async validateConfig(config: AHKServiceConfig): Promise<Result<void>> {
         const ahk = new AHK(config.host, config.port);

--- a/nodecg-io-core/extension/bundleManager.ts
+++ b/nodecg-io-core/extension/bundleManager.ts
@@ -62,7 +62,7 @@ export class BundleManager {
      * @param service the service that the bundle depends upon.
      * @param clientUpdate the callback that should be called if a client becomes available or gets updated.
      */
-    private registerServiceDependency<C>(
+    registerServiceDependency<C>(
         bundleName: string,
         service: Service<unknown, C>,
         clientUpdate: (client?: C) => void,

--- a/nodecg-io-core/extension/bundleManager.ts
+++ b/nodecg-io-core/extension/bundleManager.ts
@@ -1,5 +1,5 @@
 import { NodeCG, ReplicantServer } from "nodecg/types/server";
-import { ObjectMap, Service, ServiceDependency, ServiceInstance, ServiceProvider } from "./types";
+import { ObjectMap, Service, ServiceDependency, ServiceInstance } from "./types";
 import { emptySuccess, error, Result } from "./utils/result";
 
 /**
@@ -13,32 +13,6 @@ export class BundleManager {
             persistent: false,
             defaultValue: {},
         });
-    }
-
-    /**
-     * Creates a object which allows bundles to register them for a specific service.
-     * Indented to be called by services to allow registering by giving bundles this service provider.
-     * Dependencies on the service are registered using {@link registerServiceDependency}
-     *
-     * @param service the service that the bundle should register for and depend on.
-     * @return a service provider which offers a function for bundles to register and depend on the passed service.
-     */
-    createServiceProvider<C>(service: Service<unknown, C>): ServiceProvider<C> {
-        return {
-            requireService: (
-                bundleName: string,
-                clientAvailable: (client: C) => void,
-                clientUnavailable: () => void,
-            ) => {
-                this.registerServiceDependency(bundleName, service, (client) => {
-                    if (client === undefined) {
-                        clientUnavailable();
-                    } else {
-                        clientAvailable(client);
-                    }
-                });
-            },
-        };
     }
 
     /**

--- a/nodecg-io-core/extension/index.ts
+++ b/nodecg-io-core/extension/index.ts
@@ -7,9 +7,6 @@ import { Service, ServiceProvider } from "./types";
 import { PersistenceManager } from "./persistenceManager";
 import { ServiceClientWrapper } from "./serviceClientWrapper";
 
-// Re-export requireService function for better usability
-export { requireService } from "./serviceClientWrapper";
-
 /**
  * Main type of NodeCG extension that the core bundle exposes.
  * Contains references to all internal modules.

--- a/nodecg-io-core/extension/index.ts
+++ b/nodecg-io-core/extension/index.ts
@@ -3,7 +3,7 @@ import { ServiceManager } from "./serviceManager";
 import { BundleManager } from "./bundleManager";
 import { MessageManager } from "./messageManager";
 import { InstanceManager } from "./instanceManager";
-import { Service, ServiceProvider } from "./types";
+import { Service } from "./types";
 import { PersistenceManager } from "./persistenceManager";
 import { ServiceClientWrapper } from "./serviceClientWrapper";
 
@@ -12,7 +12,7 @@ import { ServiceClientWrapper } from "./serviceClientWrapper";
  * Contains references to all internal modules.
  */
 export interface NodeCGIOCore {
-    registerService<R, C>(service: Service<R, C>): ServiceProvider<C>;
+    registerService<R, C>(service: Service<R, C>): void;
     requireService<C>(nodecg: NodeCG, serviceType: string): ServiceClientWrapper<C> | undefined;
 }
 
@@ -31,9 +31,8 @@ module.exports = (nodecg: NodeCG): NodeCGIOCore => {
     // We use a extra object instead of returning a object containing all the managers and so on, because
     // any loaded bundle would be able to call any (public or private) of the managers which is not intended.
     return {
-        registerService<R, C>(service: Service<R, C>): ServiceProvider<C> {
+        registerService<R, C>(service: Service<R, C>): void {
             serviceManager.registerService(service);
-            return bundleManager.createServiceProvider(service);
         },
         requireService<C>(nodecg: NodeCG, serviceType: string): ServiceClientWrapper<C> | undefined {
             const svc = serviceManager.getService(serviceType);

--- a/nodecg-io-core/extension/serviceClientWrapper.ts
+++ b/nodecg-io-core/extension/serviceClientWrapper.ts
@@ -2,22 +2,38 @@ import { EventEmitter } from "events";
 import { NodeCGIOCore } from "./index";
 import { NodeCG } from "nodecg/types/server";
 
+/**
+ * A wrapper around a ServiceClient that has helper functions for setting up callbacks and
+ * a function which just returns the current ServiceClient.
+ * This class gets its client updates through the framework, namely using the {@link ServiceDependency.clientUpdateCallback}.
+ */
 export class ServiceClientWrapper<C> extends EventEmitter {
     private currentClient: C | undefined;
 
     constructor() {
         super();
+        // The update event gets emitted by requireService function that is defined in NodeCGIOCore
         this.on("update", (client: C | undefined) => {
             this.currentClient = client;
         });
     }
 
+    /**
+     * Returns the current client from the assigned service instance or undefined if it failed to create one or
+     * the current bundle has no service instance assigned to it.
+     * @return {C | undefined} the current client or undefined it there was an error or there is no assigned service instance.
+     */
     getClient(): C | undefined {
         return this.currentClient;
     }
 
     // TODO: add getRawClient function, requires https://github.com/codeoverflow-org/nodecg-io/pull/68
 
+    /**
+     * Registers a callback that gets fired everytime the available client gets updated and is available,
+     * meaning the bundle has an assigned service instance and it didn't produce an error while creating the client.
+     * @param {(client: C) => void} handler a handler that gets called everytime the client gets available.
+     */
     onAvailable(handler: (client: C) => void): void {
         this.on("update", (client: C | undefined) => {
             if (client !== undefined) {
@@ -26,6 +42,11 @@ export class ServiceClientWrapper<C> extends EventEmitter {
         });
     }
 
+    /**
+     * Registers a callback that is everytime called when there is no assigned service instance anymore or it tried
+     * to create a service client and failed.
+     * @param {() => void} handler a handler that gets called everytime the client gets unavailable.
+     */
     onUnavailable(handler: () => void): void {
         this.on("update", (client: C | undefined) => {
             if (client === undefined) {
@@ -35,6 +56,13 @@ export class ServiceClientWrapper<C> extends EventEmitter {
     }
 }
 
+/**
+ * Allows for bundles to require services.
+ * @param {NodeCG} nodecg the nodecg instance of your bundle. Is used to get the bundle name of the calling bundle.
+ * @param {string} serviceType the type of service you want to require, e.g. "twitch" or "spotify".
+ * @return {ServiceClientWrapper<C> | undefined} a service client wrapper for access to the service client
+ *                                               or undefined if the core wasn't loaded or the service type doesn't exist.
+ */
 export function requireService<C>(nodecg: NodeCG, serviceType: string): ServiceClientWrapper<C> | undefined {
     const core = (nodecg.extensions["nodecg-io-core"] as unknown) as NodeCGIOCore | undefined;
     if (core === undefined) {

--- a/nodecg-io-core/extension/serviceClientWrapper.ts
+++ b/nodecg-io-core/extension/serviceClientWrapper.ts
@@ -1,0 +1,48 @@
+import { EventEmitter } from "events";
+import { NodeCGIOCore } from "./index";
+import { NodeCG } from "nodecg/types/server";
+
+export class ServiceClientWrapper<C> extends EventEmitter {
+    private currentClient: C | undefined;
+
+    constructor() {
+        super();
+        this.on("update", (client: C | undefined) => {
+            this.currentClient = client;
+        });
+    }
+
+    getClient(): C | undefined {
+        return this.currentClient;
+    }
+
+    // TODO: add getRawClient function, requires https://github.com/codeoverflow-org/nodecg-io/pull/68
+
+    onAvailable(handler: (client: C) => void): void {
+        this.on("update", (client: C | undefined) => {
+            if (client !== undefined) {
+                handler(client);
+            }
+        });
+    }
+
+    onUnavailable(handler: () => void): void {
+        this.on("update", (client: C | undefined) => {
+            if (client === undefined) {
+                handler();
+            }
+        });
+    }
+}
+
+export function requireService<C>(nodecg: NodeCG, serviceType: string): ServiceClientWrapper<C> | undefined {
+    const core = (nodecg.extensions["nodecg-io-core"] as unknown) as NodeCGIOCore | undefined;
+    if (core === undefined) {
+        nodecg.log.error(
+            `nodecg-io-core isn't loaded! Can't require ${serviceType} service for bundle ${nodecg.bundleName}.`,
+        );
+        return;
+    }
+
+    return core.requireService(nodecg, serviceType);
+}

--- a/nodecg-io-core/extension/types.d.ts
+++ b/nodecg-io-core/extension/types.d.ts
@@ -84,28 +84,6 @@ export interface ServiceInstance<R, C> {
 }
 
 /**
- * A object which provides access of a service to a bundle.
- * @typeParam C the client object that the underlying service will give to the bundle.
- */
-export interface ServiceProvider<C> {
-    /**
-     * Registers the bundle as a consumer of the service.
-     *
-     * @param bundleName the name of the bundle that wants to get access to this service.
-     * @param clientAvailable the callback that is called once a service client is available or updated.
-     *                        The bundle should register handlers to the client here and hold a reference to the client if needed.
-     *                        If the bundle already got an client and this is called again, all references to the old client should be dropped.
-     * @param clientUnavailable the callback that is called when the bundle doesn't have a assigned service instance or it failed to create
-     *                          a service client.
-     */
-    readonly requireService(
-        bundleName: string,
-        clientAvailable: (client: C) => void,
-        clientUnavailable: () => void,
-    ): void;
-}
-
-/**
  * A dependency of a bundle on an instance of a service.
  */
 export interface ServiceDependency<C> {

--- a/nodecg-io-discord/extension/index.ts
+++ b/nodecg-io-discord/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import { Client } from "discord.js";
 
@@ -12,9 +11,8 @@ export interface DiscordServiceClient {
     getRawClient(): Client;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<DiscordServiceClient> | undefined => {
-    const discordService = new DiscordService(nodecg, "discord", __dirname, "../discord-schema.json");
-    return discordService.register();
+module.exports = (nodecg: NodeCG) => {
+    new DiscordService(nodecg, "discord", __dirname, "../discord-schema.json").register();
 };
 
 class DiscordService extends ServiceBundle<DiscordServiceConfig, DiscordServiceClient> {

--- a/nodecg-io-intellij/extension/index.ts
+++ b/nodecg-io-intellij/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import { IntelliJ } from "./intellij";
 
@@ -12,9 +11,8 @@ export interface IntelliJServiceClient {
     getRawClient(): IntelliJ;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<IntelliJServiceClient> | undefined => {
-    const intellijService = new IntellijService(nodecg, "intellij", __dirname, "../intellij-schema.json");
-    return intellijService.register();
+module.exports = (nodecg: NodeCG) => {
+    new IntellijService(nodecg, "intellij", __dirname, "../intellij-schema.json").register();
 };
 
 class IntellijService extends ServiceBundle<IntelliJServiceConfig, IntelliJServiceClient> {

--- a/nodecg-io-irc/extension/index.ts
+++ b/nodecg-io-irc/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import { Client as IRCClient } from "irc";
 
@@ -17,9 +16,8 @@ export interface IRCServiceClient {
     sendMessage(target: string, message: string): void;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<IRCServiceClient> | undefined => {
-    const ircService = new IRCService(nodecg, "irc", __dirname, "../irc-schema.json");
-    return ircService.register();
+module.exports = (nodecg: NodeCG) => {
+    new IRCService(nodecg, "irc", __dirname, "../irc-schema.json").register();
 };
 
 class IRCService extends ServiceBundle<IRCServiceConfig, IRCServiceClient> {

--- a/nodecg-io-midi-input/extension/index.ts
+++ b/nodecg-io-midi-input/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import * as easymidi from "easymidi";
 
@@ -12,9 +11,8 @@ export interface MidiInputServiceClient {
     getRawClient(): easymidi.Input;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<MidiInputServiceClient> | undefined => {
-    const midiService = new MidiService(nodecg, "midi-input", __dirname, "../midi-input-schema.json");
-    return midiService.register();
+module.exports = (nodecg: NodeCG) => {
+    new MidiService(nodecg, "midi-input", __dirname, "../midi-input-schema.json").register();
 };
 
 class MidiService extends ServiceBundle<MidiInputServiceConfig, MidiInputServiceClient> {

--- a/nodecg-io-midi-output/extension/index.ts
+++ b/nodecg-io-midi-output/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import * as easymidi from "easymidi";
 
@@ -12,9 +11,8 @@ export interface MidiOutputServiceClient {
     getRawClient(): easymidi.Output;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<MidiOutputServiceClient> | undefined => {
-    const midiService = new MidiService(nodecg, "midi-output", __dirname, "../midi-output-schema.json");
-    return midiService.register();
+module.exports = (nodecg: NodeCG) => {
+    new MidiService(nodecg, "midi-output", __dirname, "../midi-output-schema.json").register();
 };
 
 class MidiService extends ServiceBundle<MidiOutputServiceConfig, MidiOutputServiceClient> {

--- a/nodecg-io-philipshue/extension/index.ts
+++ b/nodecg-io-philipshue/extension/index.ts
@@ -1,11 +1,11 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { Result, emptySuccess, error, success } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import { v4 as ipv4 } from "is-ip";
 import { v3 } from "node-hue-api";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
 import Api = require("node-hue-api/lib/api/Api");
+
 const { api, discovery } = v3;
 
 const deviceName = "nodecg-io";
@@ -23,9 +23,8 @@ export interface PhilipsHueServiceClient {
     getRawClient(): Api;
 }
 
-module.exports = function (nodecg: NodeCG): ServiceProvider<PhilipsHueServiceClient> | undefined {
-    const philipshue = new PhilipsHueService(nodecg, "philips-hue", __dirname, "../philipshue-schema.json");
-    return philipshue.register();
+module.exports = (nodecg: NodeCG) => {
+    new PhilipsHueService(nodecg, "philips-hue", __dirname, "../philipshue-schema.json").register();
 };
 
 class PhilipsHueService extends ServiceBundle<PhilipsHueServiceConfig, PhilipsHueServiceClient> {

--- a/nodecg-io-rcon/extension/index.ts
+++ b/nodecg-io-rcon/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import { Rcon } from "rcon-client";
 
@@ -15,9 +14,8 @@ export interface RconServiceClient {
     sendMessage(message: string): Promise<string>;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<RconServiceClient> | undefined => {
-    const rconService = new RconService(nodecg, "rcon", __dirname, "../rcon-schema.json");
-    return rconService.register();
+module.exports = (nodecg: NodeCG) => {
+    new RconService(nodecg, "rcon", __dirname, "../rcon-schema.json").register();
 };
 
 class RconService extends ServiceBundle<RconServiceConfig, RconServiceClient> {

--- a/nodecg-io-slack/extension/index.ts
+++ b/nodecg-io-slack/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, error, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import { WebClient } from "@slack/web-api";
 
@@ -12,9 +11,8 @@ export interface SlackServiceClient {
     getRawClient(): WebClient;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<SlackServiceClient> | undefined => {
-    const slackService = new SlackService(nodecg, "slack", __dirname, "../slack-schema.json");
-    return slackService.register();
+module.exports = (nodecg: NodeCG) => {
+    new SlackService(nodecg, "slack", __dirname, "../slack-schema.json").register();
 };
 
 class SlackService extends ServiceBundle<SlackServiceConfig, SlackServiceClient> {

--- a/nodecg-io-spotify/extension/index.ts
+++ b/nodecg-io-spotify/extension/index.ts
@@ -1,11 +1,10 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, error, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import * as express from "express";
+import { Router } from "express";
 import SpotifyWebApi = require("spotify-web-api-node");
 import open = require("open");
-import { Router } from "express";
-import * as express from "express";
 
 interface SpotifyServiceConfig {
     clientId: string;
@@ -22,11 +21,10 @@ const callbackEndpoint = "/nodecg-io-spotify/spotifycallback";
 const defaultState = "defaultState";
 const refreshInterval = 1800000;
 
-module.exports = (nodecg: NodeCG): ServiceProvider<SpotifyServiceClient> | undefined => {
+module.exports = (nodecg: NodeCG) => {
     callbackUrl = `http://${nodecg.config.baseURL}${callbackEndpoint}`;
 
-    const spotifyService = new SpotifyService(nodecg, "spotify", __dirname, "../spotify-schema.json");
-    return spotifyService.register();
+    new SpotifyService(nodecg, "spotify", __dirname, "../spotify-schema.json").register();
 };
 
 class SpotifyService extends ServiceBundle<SpotifyServiceConfig, SpotifyServiceClient> {

--- a/nodecg-io-streamdeck/extension/index.ts
+++ b/nodecg-io-streamdeck/extension/index.ts
@@ -1,9 +1,8 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, error, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
-import { StreamDeck } from "elgato-stream-deck";
 import * as streamdeck from "elgato-stream-deck";
+import { StreamDeck } from "elgato-stream-deck";
 
 interface StreamdeckServiceConfig {
     device: string;
@@ -13,9 +12,8 @@ export interface StreamdeckServiceClient {
     getRawClient(): StreamDeck;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<StreamdeckServiceClient> | undefined => {
-    const service = new StreamdeckServiceBundle(nodecg, "streamdeck", __dirname, "../streamdeck-schema.json");
-    return service.register();
+module.exports = (nodecg: NodeCG) => {
+    new StreamdeckServiceBundle(nodecg, "streamdeck", __dirname, "../streamdeck-schema.json").register();
 };
 
 class StreamdeckServiceBundle extends ServiceBundle<StreamdeckServiceConfig, StreamdeckServiceClient> {

--- a/nodecg-io-streamelements/extension/index.ts
+++ b/nodecg-io-streamelements/extension/index.ts
@@ -23,8 +23,7 @@ export interface StreamElementsServiceClient {
 
 module.exports = (nodecg: NodeCG) => {
     const schemaPath = [__dirname, "../streamelements-schema.json"];
-    const streamElementsService = new StreamElementsService(nodecg, "streamelements", ...schemaPath);
-    return streamElementsService.register();
+    new StreamElementsService(nodecg, "streamelements", ...schemaPath).register();
 };
 
 class StreamElementsService extends ServiceBundle<StreamElementsServiceConfig, StreamElementsServiceClient> {

--- a/nodecg-io-telegram/extension/index.ts
+++ b/nodecg-io-telegram/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import TelegramBot = require("node-telegram-bot-api");
 
@@ -17,9 +16,8 @@ export interface TelegramServiceClient {
     getRawClient(): TelegramBot;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<TelegramServiceClient> | undefined => {
-    const telegramService = new TelegramService(nodecg, "telegram", __dirname, "../telegram-schema.json");
-    return telegramService.register();
+module.exports = (nodecg: NodeCG) => {
+    new TelegramService(nodecg, "telegram", __dirname, "../telegram-schema.json").register();
 };
 
 class TelegramService extends ServiceBundle<TelegramServiceConfig, TelegramServiceClient> {

--- a/nodecg-io-twitch/extension/index.ts
+++ b/nodecg-io-twitch/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import TwitchClient from "twitch";
 import ChatClient from "twitch-chat-client";
@@ -13,9 +12,8 @@ export interface TwitchServiceClient {
     getRawClient(): ChatClient;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<TwitchServiceClient> | undefined => {
-    const twitchService = new TwitchService(nodecg, "twitch", __dirname, "../twitch-schema.json");
-    return twitchService.register();
+module.exports = (nodecg: NodeCG) => {
+    new TwitchService(nodecg, "twitch", __dirname, "../twitch-schema.json").register();
 };
 
 class TwitchService extends ServiceBundle<TwitchServiceConfig, TwitchServiceClient> {

--- a/nodecg-io-twitter/extension/index.ts
+++ b/nodecg-io-twitter/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import Twitter = require("twitter");
 
@@ -15,9 +14,8 @@ export interface TwitterServiceClient {
     getRawClient(): Twitter;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<TwitterServiceClient> | undefined => {
-    const twitterService = new TwitterService(nodecg, "twitter", __dirname, "../twitter-schema.json");
-    return twitterService.register();
+module.exports = (nodecg: NodeCG) => {
+    new TwitterService(nodecg, "twitter", __dirname, "../twitter-schema.json").register();
 };
 
 class TwitterService extends ServiceBundle<TwitterServiceConfig, TwitterServiceClient> {

--- a/nodecg-io-ws-client/extension/index.ts
+++ b/nodecg-io-ws-client/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import * as WebSocket from "ws";
 
@@ -16,9 +15,8 @@ export interface WSClientServiceClient {
     onError(func: (error: Error) => void): void;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<WSClientServiceClient> | undefined => {
-    const wsClientService = new WSClientService(nodecg, "websocket-client", __dirname, "../ws-schema.json");
-    return wsClientService.register();
+module.exports = (nodecg: NodeCG) => {
+    new WSClientService(nodecg, "websocket-client", __dirname, "../ws-schema.json").register();
 };
 
 class WSClientService extends ServiceBundle<WSClientServiceConfig, WSClientServiceClient> {

--- a/nodecg-io-ws-server/extension/index.ts
+++ b/nodecg-io-ws-server/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, error, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import * as WebSocket from "ws";
 
@@ -12,9 +11,8 @@ export interface WSServerServiceClient {
     getRawClient(): WebSocket.Server;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<WSServerServiceClient> | undefined => {
-    const wsServerService = new WSServerService(nodecg, "websocket-server", __dirname, "../ws-schema.json");
-    return wsServerService.register();
+module.exports = (nodecg: NodeCG) => {
+    new WSServerService(nodecg, "websocket-server", __dirname, "../ws-schema.json").register();
 };
 
 class WSServerService extends ServiceBundle<WSServerServiceConfig, WSServerServiceClient> {

--- a/nodecg-io-xdotool/extension/index.ts
+++ b/nodecg-io-xdotool/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result, error } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
 import { Xdotool } from "./xdotool";
 
@@ -13,9 +12,8 @@ export interface XdotoolServiceClient {
     getRawClient(): Xdotool;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<XdotoolServiceClient> | undefined => {
-    const service = new XdotoolServiceBundle(nodecg, "xdotool", __dirname, "../xdotool-schema.json");
-    return service.register();
+module.exports = (nodecg: NodeCG) => {
+    new XdotoolServiceBundle(nodecg, "xdotool", __dirname, "../xdotool-schema.json").register();
 };
 
 class XdotoolServiceBundle extends ServiceBundle<XdotoolServiceConfig, XdotoolServiceClient> {

--- a/nodecg-io-youtube/extension/index.ts
+++ b/nodecg-io-youtube/extension/index.ts
@@ -1,8 +1,7 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, error, Result } from "nodecg-io-core/extension/utils/result";
+import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
-import { youtube_v3, google } from "googleapis";
+import { google, youtube_v3 } from "googleapis";
 import * as express from "express";
 import opn = require("open");
 
@@ -15,9 +14,8 @@ export interface YoutubeServiceClient {
     getRawClient(): youtube_v3.Youtube;
 }
 
-module.exports = (nodecg: NodeCG): ServiceProvider<YoutubeServiceClient> | undefined => {
-    const youtubeService = new YoutubeService(nodecg, "youtube", __dirname, "../youtube-schema.json");
-    return youtubeService.register();
+module.exports = (nodecg: NodeCG) => {
+    new YoutubeService(nodecg, "youtube", __dirname, "../youtube-schema.json").register();
 };
 
 class YoutubeService extends ServiceBundle<YoutubeServiceConfig, YoutubeServiceClient> {

--- a/samples/ahk/extension/index.ts
+++ b/samples/ahk/extension/index.ts
@@ -5,7 +5,7 @@ import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for AHK started");
 
-    const ahk = requireService<AHKServiceClient>(nodecg, "twitch");
+    const ahk = requireService<AHKServiceClient>(nodecg, "ahk");
 
     ahk?.onAvailable((client) => {
         nodecg.log.info("AHK client has been updated, sending Hello World Command.");

--- a/samples/ahk/extension/index.ts
+++ b/samples/ahk/extension/index.ts
@@ -1,20 +1,17 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { AHKServiceClient } from "nodecg-io-ahk/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for AHK started");
 
-    // This explicit cast determines the client type in the requireService call
-    const ahkClient = (nodecg.extensions["nodecg-io-ahk"] as unknown) as ServiceProvider<AHKServiceClient> | undefined;
+    const ahk = requireService<AHKServiceClient>(nodecg, "twitch");
 
-    ahkClient?.requireService(
-        "ahk",
-        (client) => {
-            nodecg.log.info("AHK client has been updated, sending Hello World Command.");
+    ahk?.onAvailable((client) => {
+        nodecg.log.info("AHK client has been updated, sending Hello World Command.");
 
-            client.getRawClient().sendCommand("HelloWorld");
-        },
-        () => nodecg.log.info("AHK client has been unset."),
-    );
+        client.getRawClient().sendCommand("HelloWorld");
+    });
+
+    ahk?.onUnavailable(() => nodecg.log.info("AHK client has been unset."));
 };

--- a/samples/discord-guild-chat/extension/index.ts
+++ b/samples/discord-guild-chat/extension/index.ts
@@ -1,22 +1,18 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { DiscordServiceClient } from "nodecg-io-discord/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for discord started");
 
-    const discord = (nodecg.extensions["nodecg-io-discord"] as unknown) as
-        | ServiceProvider<DiscordServiceClient>
-        | undefined;
+    const discord = requireService<DiscordServiceClient>(nodecg, "discord");
 
-    discord?.requireService(
-        "discord-guild-chat",
-        (client) => {
-            nodecg.log.info("Discord client has been updated, adding handlers for messages.");
-            addListeners(nodecg, client);
-        },
-        () => nodecg.log.info("Discord client has been unset."),
-    );
+    discord?.onAvailable((client) => {
+        nodecg.log.info("Discord client has been updated, adding handlers for messages.");
+        addListeners(nodecg, client);
+    });
+
+    discord?.onUnavailable(() => nodecg.log.info("Discord client has been unset."));
 };
 
 function addListeners(nodecg: NodeCG, client: DiscordServiceClient) {

--- a/samples/intellij/extension/index.ts
+++ b/samples/intellij/extension/index.ts
@@ -1,40 +1,35 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { IntelliJServiceClient } from "nodecg-io-intellij/extension";
 import * as intellij from "nodecg-io-intellij/extension/intellij";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for intellij started");
 
-    // This explicit cast determines the client type in the requireService call
-    const ij = (nodecg.extensions["nodecg-io-intellij"] as unknown) as
-        | ServiceProvider<IntelliJServiceClient>
-        | undefined;
+    const ij = requireService<IntelliJServiceClient>(nodecg, "intellij");
 
-    ij?.requireService(
-        "intellij-sample",
-        (intellij) => {
-            nodecg.log.info("IntelliJ client has been updated. Printing all plugins.");
+    ij?.onAvailable((intellij) => {
+        nodecg.log.info("IntelliJ client has been updated. Printing all plugins.");
 
-            intellij
-                .getRawClient()
-                .pluginManager.getPlugins(true)
-                .then((plugins) => {
-                    plugins.forEach((plugin: intellij.Plugin) => {
-                        plugin
-                            .getName()
-                            .then((name) => {
-                                nodecg.log.info(`Plugin ${name}`);
-                            })
-                            .catch((_) => {
-                                nodecg.log.info(`Plugin ${plugin.id}`);
-                            });
-                    });
-                })
-                .catch((err) => {
-                    nodecg.log.info(`Could not get plugins: ${String(err)}`);
+        intellij
+            .getRawClient()
+            .pluginManager.getPlugins(true)
+            .then((plugins) => {
+                plugins.forEach((plugin: intellij.Plugin) => {
+                    plugin
+                        .getName()
+                        .then((name) => {
+                            nodecg.log.info(`Plugin ${name}`);
+                        })
+                        .catch((_) => {
+                            nodecg.log.info(`Plugin ${plugin.id}`);
+                        });
                 });
-        },
-        () => nodecg.log.info("IntelliJ client has been unset."),
-    );
+            })
+            .catch((err) => {
+                nodecg.log.info(`Could not get plugins: ${String(err)}`);
+            });
+    });
+
+    ij?.onUnavailable(() => nodecg.log.info("IntelliJ client has been unset."));
 };

--- a/samples/philips-hue/extension/index.ts
+++ b/samples/philips-hue/extension/index.ts
@@ -1,25 +1,21 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { PhilipsHueServiceClient } from "nodecg-io-philipshue/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG): void {
     nodecg.log.info("sample bundle for Philips Hue started");
 
-    const hue = (nodecg.extensions["nodecg-io-philipshue"] as unknown) as
-        | ServiceProvider<PhilipsHueServiceClient>
-        | undefined;
+    const hue = requireService<PhilipsHueServiceClient>(nodecg, "philips-hue");
 
-    hue?.requireService(
-        "hue-sample",
-        (hue) => {
-            nodecg.log.info("Got Philips Hue client");
+    hue?.onAvailable((hue) => {
+        nodecg.log.info("Got Philips Hue client");
 
-            const client = hue.getRawClient();
+        const client = hue.getRawClient();
 
-            client.lights.getAll().then((lights) => {
-                nodecg.log.info(lights.length);
-            });
-        },
-        () => nodecg.log.info("Philips Hue client has been unset."),
-    );
+        client.lights.getAll().then((lights) => {
+            nodecg.log.info(lights.length);
+        });
+    });
+
+    hue?.onUnavailable(() => nodecg.log.info("Philips Hue client has been unset."));
 };

--- a/samples/slack/extension/index.ts
+++ b/samples/slack/extension/index.ts
@@ -1,33 +1,31 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { SlackServiceClient } from "nodecg-io-slack/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for Slack WebAPI started");
 
-    const slack = (nodecg.extensions["nodecg-io-slack"] as unknown) as ServiceProvider<SlackServiceClient> | undefined;
+    const slack = requireService<SlackServiceClient>(nodecg, "slack");
 
-    slack?.requireService(
-        "slack",
-        async (client) => {
-            // Get all channels
-            const channelListResponse = await client.getRawClient().conversations.list();
+    slack?.onAvailable(async (client) => {
+        // Get all channels
+        const channelListResponse = await client.getRawClient().conversations.list();
 
-            nodecg.log.info(JSON.stringify(channelListResponse.channels));
+        nodecg.log.info(JSON.stringify(channelListResponse.channels));
 
-            // Example for sending a message
-            const channel = "CHANNEL_ID";
+        // Example for sending a message
+        const channel = "CHANNEL_ID";
 
-            client
-                .getRawClient()
-                .chat.postMessage({ channel, text: "Hello world from nodecg.io" })
-                .then((messageResponse) => {
-                    nodecg.log.info(messageResponse);
-                })
-                .catch((err) => {
-                    nodecg.log.error(err);
-                });
-        },
-        () => nodecg.log.info("Sample bundle for Slack WebAPI unset."),
-    );
+        client
+            .getRawClient()
+            .chat.postMessage({ channel, text: "Hello world from nodecg.io" })
+            .then((messageResponse) => {
+                nodecg.log.info(messageResponse);
+            })
+            .catch((err) => {
+                nodecg.log.error(err);
+            });
+    });
+
+    slack?.onUnavailable(() => nodecg.log.info("Sample bundle for Slack WebAPI unset."));
 };

--- a/samples/streamdeck-rainbow/extension/index.ts
+++ b/samples/streamdeck-rainbow/extension/index.ts
@@ -1,59 +1,54 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { StreamdeckServiceClient } from "nodecg-io-streamdeck/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for streamdeck started");
 
-    // This explicit cast determines the client type in the requireService call
-    const streamdeck = (nodecg.extensions["nodecg-io-streamdeck"] as unknown) as
-        | ServiceProvider<StreamdeckServiceClient>
-        | undefined;
+    const streamdeck = requireService<StreamdeckServiceClient>(nodecg, "streamdeck");
 
-    streamdeck?.requireService(
-        "streamdeck-rainbow",
-        (client) => {
-            nodecg.log.info("Streamdeck client has been updated, painting the streamdeck.");
+    streamdeck?.onAvailable((client) => {
+        nodecg.log.info("Streamdeck client has been updated, painting the streamdeck.");
 
-            try {
-                const deck = client.getRawClient();
-                const colors: Array<[number, number, number]> = [
-                    [231, 60, 60],
-                    [231, 128, 60],
-                    [231, 197, 60],
-                    [197, 231, 60],
-                    [128, 231, 60],
-                    [60, 231, 60],
-                    [60, 231, 128],
-                    [60, 231, 179],
-                    [60, 197, 231],
-                    [60, 128, 231],
-                    [60, 60, 231],
-                    [128, 60, 231],
-                    [197, 60, 179],
-                    [231, 60, 128],
-                ];
-                let i = 0;
+        try {
+            const deck = client.getRawClient();
+            const colors: Array<[number, number, number]> = [
+                [231, 60, 60],
+                [231, 128, 60],
+                [231, 197, 60],
+                [197, 231, 60],
+                [128, 231, 60],
+                [60, 231, 60],
+                [60, 231, 128],
+                [60, 231, 179],
+                [60, 197, 231],
+                [60, 128, 231],
+                [60, 60, 231],
+                [128, 60, 231],
+                [197, 60, 179],
+                [231, 60, 128],
+            ];
+            let i = 0;
 
-                setInterval(() => {
-                    try {
-                        deck.fillColor(
-                            i % deck.NUM_KEYS,
-                            colors[i % colors.length][0],
-                            colors[i % colors.length][1],
-                            colors[i % colors.length][2],
-                        );
-                        i += 1;
-                    } catch (err) {
-                        nodecg.log.info("Streamdeck error: " + String(err));
-                        nodecg.log.info("You might need to replug your streamdeck. This is due to issue #21");
-                    }
-                }, 200);
-            } catch (err) {
-                nodecg.log.info("Streamdeck error: " + String(err));
-                nodecg.log.info("You might need to replug your streamdeck. This is due to issue #21");
-            }
-        },
-        () => nodecg.log.info("Streamdeck client has been unset."),
-    );
+            setInterval(() => {
+                try {
+                    deck.fillColor(
+                        i % deck.NUM_KEYS,
+                        colors[i % colors.length][0],
+                        colors[i % colors.length][1],
+                        colors[i % colors.length][2],
+                    );
+                    i += 1;
+                } catch (err) {
+                    nodecg.log.info("Streamdeck error: " + String(err));
+                    nodecg.log.info("You might need to replug your streamdeck. This is due to issue #21");
+                }
+            }, 200);
+        } catch (err) {
+            nodecg.log.info("Streamdeck error: " + String(err));
+            nodecg.log.info("You might need to replug your streamdeck. This is due to issue #21");
+        }
+    });
+
+    streamdeck?.onUnavailable(() => nodecg.log.info("Streamdeck client has been unset."));
 };

--- a/samples/streamelements/extension/index.ts
+++ b/samples/streamelements/extension/index.ts
@@ -1,71 +1,64 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { StreamElementsServiceClient } from "nodecg-io-streamelements/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for StreamElements started");
 
-    // This explicit cast determines the client type in the requireService call
-    const streamElements = (nodecg.extensions["nodecg-io-streamelements"] as unknown) as
-        | ServiceProvider<StreamElementsServiceClient>
-        | undefined;
+    const streamElements = requireService<StreamElementsServiceClient>(nodecg, "streamelements");
 
-    streamElements?.requireService(
-        "streamelements",
-        (client) => {
-            nodecg.log.info("SE client has been set, registering handlers now.");
+    streamElements?.onAvailable((client) => {
+        nodecg.log.info("SE client has been set, registering handlers now.");
 
-            client.onCheer((data) => {
+        client.onCheer((data) => {
+            nodecg.log.info(
+                `${data.data.displayName} just cheered ${data.data.amount} bit(s). Message: ${data.data.message}`,
+            );
+        });
+
+        client.onFollow((data) => {
+            nodecg.log.info(`${data.data.displayName} just followed.`);
+        });
+
+        client.onSubscriber((data) => {
+            if (data.data.tier) {
+                const tier =
+                    data.data.tier === "prime" ? "Twitch Prime" : "Tier " + Number.parseInt(data.data.tier) / 1000;
+                nodecg.log.info(`${data.data.displayName} just subscribed for ${data.data.amount} months (${tier}).`);
+            }
+        });
+
+        client.onGift((data) => {
+            if (data.data.tier) {
+                const tier = (Number.parseInt(data.data.tier) / 1000).toString();
+                if (data.data.sender) {
+                    nodecg.log.info(
+                        `${data.data.displayName} just got a tier ${tier} subscription from ${data.data.sender}! It's ${data.data.displayName}'s ${data.data.amount} month.`,
+                    );
+                } else {
+                    nodecg.log.info(
+                        `${data.data.displayName} just got a tier ${tier} subscription! It's ${data.data.displayName}'s ${data.data.amount} month.`,
+                    );
+                }
+            }
+        });
+
+        client.onHost((data) => {
+            nodecg.log.info(`${data.data.displayName} just hosted the stream for ${data.data.amount} viewer(s).`);
+        });
+
+        client.onRaid((data) => {
+            nodecg.log.info(`${data.data.displayName} just raided the stream with ${data.data.amount} viewers.`);
+        });
+
+        client.onTip((data) => {
+            if (data.data.currency) {
                 nodecg.log.info(
-                    `${data.data.displayName} just cheered ${data.data.amount} bit(s). Message: ${data.data.message}`,
+                    `${data.data.username} just donated ${data.data.amount} ${data.data.currency}. Message. ${data.data.message}`,
                 );
-            });
+            }
+        });
+    });
 
-            client.onFollow((data) => {
-                nodecg.log.info(`${data.data.displayName} just followed.`);
-            });
-
-            client.onSubscriber((data) => {
-                if (data.data.tier) {
-                    const tier =
-                        data.data.tier === "prime" ? "Twitch Prime" : "Tier " + Number.parseInt(data.data.tier) / 1000;
-                    nodecg.log.info(
-                        `${data.data.displayName} just subscribed for ${data.data.amount} months (${tier}).`,
-                    );
-                }
-            });
-
-            client.onGift((data) => {
-                if (data.data.tier) {
-                    const tier = (Number.parseInt(data.data.tier) / 1000).toString();
-                    if (data.data.sender) {
-                        nodecg.log.info(
-                            `${data.data.displayName} just got a tier ${tier} subscription from ${data.data.sender}! It's ${data.data.displayName}'s ${data.data.amount} month.`,
-                        );
-                    } else {
-                        nodecg.log.info(
-                            `${data.data.displayName} just got a tier ${tier} subscription! It's ${data.data.displayName}'s ${data.data.amount} month.`,
-                        );
-                    }
-                }
-            });
-
-            client.onHost((data) => {
-                nodecg.log.info(`${data.data.displayName} just hosted the stream for ${data.data.amount} viewer(s).`);
-            });
-
-            client.onRaid((data) => {
-                nodecg.log.info(`${data.data.displayName} just raided the stream with ${data.data.amount} viewers.`);
-            });
-
-            client.onTip((data) => {
-                if (data.data.currency) {
-                    nodecg.log.info(
-                        `${data.data.username} just donated ${data.data.amount} ${data.data.currency}. Message. ${data.data.message}`,
-                    );
-                }
-            });
-        },
-        () => nodecg.log.info("SE client has been unset."),
-    );
+    streamElements?.onUnavailable(() => nodecg.log.info("SE client has been unset."));
 };

--- a/samples/telegram/extension/index.ts
+++ b/samples/telegram/extension/index.ts
@@ -1,35 +1,30 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { TelegramServiceClient } from "nodecg-io-telegram/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for telegram started");
 
-    // This explicit cast determines the client type in the requireService call
-    const telegram = (nodecg.extensions["nodecg-io-telegram"] as unknown) as
-        | ServiceProvider<TelegramServiceClient>
-        | undefined;
+    const telegram = requireService<TelegramServiceClient>(nodecg, "telegram");
 
-    telegram?.requireService(
-        "telegram",
-        (client) => {
-            nodecg.log.info("Telegram client has been updated, adding handlers for messages.");
-            const testCommand = {
-                command: "test",
-                description: "This is a simple test command.",
-            };
+    telegram?.onAvailable((client) => {
+        nodecg.log.info("Telegram client has been updated, adding handlers for messages.");
+        const testCommand = {
+            command: "test",
+            description: "This is a simple test command.",
+        };
 
-            client.getRawClient().setMyCommands([testCommand]);
+        client.getRawClient().setMyCommands([testCommand]);
 
-            client.getRawClient().onText(/\/test/, (message) => {
-                const chatID = message.chat.id;
+        client.getRawClient().onText(/\/test/, (message) => {
+            const chatID = message.chat.id;
 
-                client.getRawClient().sendMessage(chatID, `Your ChatID is ${chatID}.`);
-                client
-                    .getRawClient()
-                    .sendVenue(chatID, 50.9438305556, 6.97453611111, "Koelnmesse", "Messeplatz 1 Mülheim, 50679 Köln");
-            });
-        },
-        () => nodecg.log.info("Telegram client has been unset."),
-    );
+            client.getRawClient().sendMessage(chatID, `Your ChatID is ${chatID}.`);
+            client
+                .getRawClient()
+                .sendVenue(chatID, 50.9438305556, 6.97453611111, "Koelnmesse", "Messeplatz 1 Mülheim, 50679 Köln");
+        });
+    });
+
+    telegram?.onUnavailable(() => nodecg.log.info("Telegram client has been unset."));
 };

--- a/samples/twitch-chat/extension/index.ts
+++ b/samples/twitch-chat/extension/index.ts
@@ -10,7 +10,7 @@ module.exports = function (nodecg: NodeCG) {
 
     // Hardcoded channels for testing purposes.
     // Note that this does need a # before the channel name and is case-insensitive.
-    const twitchChannels = ["#daniel0611"];
+    const twitchChannels = ["#skate702", "#daniel0611"];
 
     // Once the service instance has been set we add listeners for messages in the corresponding channels.
     twitch?.onAvailable((client) => {

--- a/samples/twitch-chat/extension/index.ts
+++ b/samples/twitch-chat/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { TwitchServiceClient } from "nodecg-io-twitch/extension";
-import { requireService } from "nodecg-io-core/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for twitch started");

--- a/samples/twitch-chat/extension/index.ts
+++ b/samples/twitch-chat/extension/index.ts
@@ -1,30 +1,27 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { TwitchServiceClient } from "nodecg-io-twitch/extension";
+import { requireService } from "nodecg-io-core/extension";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for twitch started");
 
-    // This explicit cast determines the client type in the requireService call
-    const twitch = (nodecg.extensions["nodecg-io-twitch"] as unknown) as
-        | ServiceProvider<TwitchServiceClient>
-        | undefined;
+    // Require the twitch service.
+    const twitch = requireService<TwitchServiceClient>(nodecg, "twitch");
 
     // Hardcoded channels for testing purposes.
     // Note that this does need a # before the channel name and is case-insensitive.
-    const twitchChannels = ["#skate702", "#daniel0611"];
+    const twitchChannels = ["#daniel0611"];
 
-    twitch?.requireService(
-        "twitch-chat",
-        (client) => {
-            nodecg.log.info("Twitch client has been updated, adding handlers for messages.");
+    // Once the service instance has been set we add listeners for messages in the corresponding channels.
+    twitch?.onAvailable((client) => {
+        nodecg.log.info("Twitch client has been updated, adding handlers for messages.");
 
-            twitchChannels.forEach((channel) => {
-                addListeners(nodecg, client, channel);
-            });
-        },
-        () => nodecg.log.info("Twitch client has been unset."),
-    );
+        twitchChannels.forEach((channel) => {
+            addListeners(nodecg, client, channel);
+        });
+    });
+
+    twitch?.onUnavailable(() => nodecg.log.info("Twitch client has been unset."));
 };
 
 function addListeners(nodecg: NodeCG, client: TwitchServiceClient, channel: string) {
@@ -42,7 +39,7 @@ function addListeners(nodecg: NodeCG, client: TwitchServiceClient, channel: stri
         })
         .catch((reason) => {
             nodecg.log.error(`Couldn't connect to twitch: ${reason}.`);
-            nodecg.log.info(`Retrying in 5 seconds.`);
+            nodecg.log.info("Retrying in 5 seconds.");
             setTimeout(() => addListeners(nodecg, client, channel), 5000);
         });
 }

--- a/samples/twitter-timeline/extension/index.ts
+++ b/samples/twitter-timeline/extension/index.ts
@@ -1,31 +1,26 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { TwitterServiceClient } from "nodecg-io-twitter/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for twitter started");
 
-    // This explicit cast determines the client type in the requireService call
-    const twitter = (nodecg.extensions["nodecg-io-twitter"] as unknown) as
-        | ServiceProvider<TwitterServiceClient>
-        | undefined;
+    const twitter = requireService<TwitterServiceClient>(nodecg, "twitter");
 
-    twitter?.requireService(
-        "twitter-timeline",
-        (client) => {
-            nodecg.log.info("Twitch client has been updated, adding handlers for messages.");
-            const twitterClient = client.getRawClient();
-            const params = {
-                screen_name: "skate702", // eslint-disable-line camelcase
-                exclude_replies: true, // eslint-disable-line camelcase
-                count: 50,
-            };
-            twitterClient
-                .get("statuses/user_timeline", params)
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                .then((tweets: any[]) => tweets.forEach((tweet) => nodecg.log.info(`Got tweet: ${tweet.text}`)))
-                .catch((err) => nodecg.log.error(err));
-        },
-        () => nodecg.log.info("Twitter client has been unset!"),
-    );
+    twitter?.onAvailable((client) => {
+        nodecg.log.info("Twitch client has been updated, adding handlers for messages.");
+        const twitterClient = client.getRawClient();
+        const params = {
+            screen_name: "skate702", // eslint-disable-line camelcase
+            exclude_replies: true, // eslint-disable-line camelcase
+            count: 50,
+        };
+        twitterClient
+            .get("statuses/user_timeline", params)
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            .then((tweets: any[]) => tweets.forEach((tweet) => nodecg.log.info(`Got tweet: ${tweet.text}`)))
+            .catch((err) => nodecg.log.error(err));
+    });
+
+    twitter?.onUnavailable(() => nodecg.log.info("Twitter client has been unset!"));
 };

--- a/samples/websocket-server/extension/index.ts
+++ b/samples/websocket-server/extension/index.ts
@@ -1,31 +1,26 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { WSServerServiceClient } from "nodecg-io-ws-server/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for WebSocket Server started");
 
-    // This explicit cast determines the client type in the requireService call
-    const webSocketServer = (nodecg.extensions["nodecg-io-ws-server"] as unknown) as
-        | ServiceProvider<WSServerServiceClient>
-        | undefined;
+    const webSocketServer = requireService<WSServerServiceClient>(nodecg, "websocket-server");
 
-    webSocketServer?.requireService(
-        "websocket-server",
-        (client) => {
-            nodecg.log.info("WebSocket Server has been set. Ready for connections.");
+    webSocketServer?.onAvailable((client) => {
+        nodecg.log.info("WebSocket Server has been set. Ready for connections.");
 
-            const server = client.getRawClient();
-            server.on("connection", (websocket) => {
-                websocket.on("message", (message) => {
-                    if (message.toString().toLowerCase() === "ping") {
-                        websocket.send("pong");
-                    } else {
-                        server.clients.forEach((client) => client.send(message));
-                    }
-                });
+        const server = client.getRawClient();
+        server.on("connection", (websocket) => {
+            websocket.on("message", (message) => {
+                if (message.toString().toLowerCase() === "ping") {
+                    websocket.send("pong");
+                } else {
+                    server.clients.forEach((client) => client.send(message));
+                }
             });
-        },
-        () => nodecg.log.info("WebSocket Server has been unset!"),
-    );
+        });
+    });
+
+    webSocketServer?.onUnavailable(() => nodecg.log.info("WebSocket Server has been unset!"));
 };

--- a/samples/xdotool/extension/index.ts
+++ b/samples/xdotool/extension/index.ts
@@ -1,22 +1,17 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { XdotoolServiceClient } from "nodecg-io-xdotool/extension";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for xdotool started");
 
-    // This explicit cast determines the client type in the requireService call
-    const xdotool = (nodecg.extensions["nodecg-io-xdotool"] as unknown) as
-        | ServiceProvider<XdotoolServiceClient>
-        | undefined;
+    const xdotool = requireService<XdotoolServiceClient>(nodecg, "xdotool");
 
-    xdotool?.requireService(
-        "xdotool",
-        (client) => {
-            nodecg.log.info("Xdotool client has been updated, minimising current window.");
+    xdotool?.onAvailable((client) => {
+        nodecg.log.info("Xdotool client has been updated, minimising current window.");
 
-            client.getRawClient().sendCommand("getactivewindow windowminimize");
-        },
-        () => nodecg.log.info("Xdotool client has been unset."),
-    );
+        client.getRawClient().sendCommand("getactivewindow windowminimize");
+    });
+
+    xdotool?.onUnavailable(() => nodecg.log.info("Xdotool client has been unset."));
 };

--- a/samples/youtube/extension/index.ts
+++ b/samples/youtube/extension/index.ts
@@ -1,33 +1,28 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceProvider } from "nodecg-io-core/extension/types";
 import { YoutubeServiceClient } from "nodecg-io-youtube/extension";
 import { youtube_v3 } from "googleapis";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for youtube started");
 
-    // This explicit cast determines the client type in the requireService call
-    const youtube = (nodecg.extensions["nodecg-io-youtube"] as unknown) as
-        | ServiceProvider<YoutubeServiceClient>
-        | undefined;
+    const youtube = requireService<YoutubeServiceClient>(nodecg, "youtube");
 
-    youtube?.requireService(
-        "youtube",
-        async (client) => {
-            const youtubeClient = client.getRawClient();
-            const resp = await youtubeClient.playlists.list({
-                part: ["id", "snippet"],
-                id: ["PL9oBXB6tQnlX013V1v20WkfzI9R2zamHi"],
-            });
-            const items = resp.data.items;
-            if (items) {
-                const { title, channelTitle, publishedAt, description } = items[0]
-                    .snippet as youtube_v3.Schema$PlaylistItemSnippet;
-                nodecg.log.info(
-                    `${title}${description ? " - " : ""}${description} by ${channelTitle} created at ${publishedAt}`,
-                );
-            }
-        },
-        () => nodecg.log.info("Youtube client has been unset."),
-    );
+    youtube?.onAvailable(async (client) => {
+        const youtubeClient = client.getRawClient();
+        const resp = await youtubeClient.playlists.list({
+            part: ["id", "snippet"],
+            id: ["PL9oBXB6tQnlX013V1v20WkfzI9R2zamHi"],
+        });
+        const items = resp.data.items;
+        if (items) {
+            const { title, channelTitle, publishedAt, description } = items[0]
+                .snippet as youtube_v3.Schema$PlaylistItemSnippet;
+            nodecg.log.info(
+                `${title}${description ? " - " : ""}${description} by ${channelTitle} created at ${publishedAt}`,
+            );
+        }
+    });
+
+    youtube?.onUnavailable(() => nodecg.log.info("Youtube client has been unset."));
 };


### PR DESCRIPTION
Closes #53 and closes #31

- [X] Add function to reduce bundle boilerplate as noted in #53 
- [x] Update all samples to use this easier way
- [x] Remove `ServiceProvider` (aka. the old way) because it isn't needed anymore and nobody should use this anymore
- [X] Update docs (https://github.com/codeoverflow-org/nodecg-io-docs/pull/19)