### PR TITLE
Automatic re-login in dashboard

### DIFF
--- a/nodecg-io-core/dashboard/authentication.ts
+++ b/nodecg-io-core/dashboard/authentication.ts
@@ -10,10 +10,9 @@ const divAuth = document.getElementById("divAuth");
 const divMain = document.getElementById("divMain");
 const spanPasswordNotice = document.getElementById("spanPasswordNotice");
 
-// A hacky way to have a callback whenever nodecg restarts.
-// On start the replicant will be declared, resulting in a call to the passed callback.
-// Needed to show the framework as unloaded when nodecg gets restarted with the dashboard still running.
-nodecg.Replicant("restart", { persistent: false }).on("declared", () => {
+// Handler for when the socket.io client re-connects which is usually a nodecg restart.
+nodecg.socket.on("connect", () => {
+    // If a password has been entered previously try to directly login using it.
     if (inputPassword.value !== "") {
         loadFramework();
     } else {
@@ -22,6 +21,7 @@ nodecg.Replicant("restart", { persistent: false }).on("declared", () => {
 });
 
 document.addEventListener("DOMContentLoaded", () => {
+    // Render loaded status for initial load
     updateLoadedStatus();
 });
 

--- a/nodecg-io-core/dashboard/authentication.ts
+++ b/nodecg-io-core/dashboard/authentication.ts
@@ -13,7 +13,13 @@ const spanPasswordNotice = document.getElementById("spanPasswordNotice");
 // A hacky way to have a callback whenever nodecg restarts.
 // On start the replicant will be declared, resulting in a call to the passed callback.
 // Needed to show the framework as unloaded when nodecg gets restarted with the dashboard still running.
-nodecg.Replicant("restart", { persistent: false }).on("declared", () => updateLoadedStatus());
+nodecg.Replicant("restart", { persistent: false }).on("declared", () => {
+    if (inputPassword.value !== "") {
+        loadFramework();
+    } else {
+        updateLoadedStatus();
+    }
+});
 
 document.addEventListener("DOMContentLoaded", () => {
     updateLoadedStatus();
@@ -38,7 +44,6 @@ export function loadFramework(): void {
     const password = inputPassword.value;
     const msg: LoadFrameworkMessage = { password };
 
-    // TODO: Password (and configs) shouldn't be sent over plaintext.
     nodecg.sendMessage("load", msg, (error) => {
         if (spanPasswordNotice !== null) {
             spanPasswordNotice.innerText = "";
@@ -48,9 +53,8 @@ export function loadFramework(): void {
             if (spanPasswordNotice !== null) {
                 spanPasswordNotice.innerText = "The provided passwort isn't correct!";
             }
-        } else {
-            // Clear password input for security reasons.
             inputPassword.value = "";
+        } else {
             updateLoadedStatus();
         }
     });


### PR DESCRIPTION
Closes #12 

My hack mentioned in https://github.com/codeoverflow-org/nodecg-io/issues/12#issuecomment-643625054 didn't work and I didn't find any other way to find out whether nodecg has already loaded all bundles.
The last thing nodecg does after loading all the bundles is to start the webserver and therefore the dashboard so I thought why not just do it in the dashboard and relog using the password that was previously used to login.

Therefore after this PR the dashboard will try to login with the password that has been used to login once the dashboard reconnects to the nodecg webserver.
I think this solution is actually a bit cleaner than the one #12 because a bundle could read the environment variables or the cli flags but here it uses the normal login procedure so this solution is also safe to use in "production"-environments.