### PR TITLE
Check whether bundles replicant is declared in instance selector renderer

### DIFF
--- a/nodecg-io-core/dashboard/bundles.ts
+++ b/nodecg-io-core/dashboard/bundles.ts
@@ -48,7 +48,7 @@ export function renderBundleDeps(): void {
 }
 
 export function renderInstanceSelector(): void {
-    if (bundles.value === undefined) {
+    if (bundles.status !== "declared" || bundles.value === undefined) {
         return;
     }
 


### PR DESCRIPTION
This fixes all these "Attempted to get value before Replicant had finished declaring." browser warnings that always made the browser console messy.