### PR TITLE
Decrypt configs in dashboard and don't expose sensitive data in replicants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ node_modules/
 # compiled js files
 *.js
 
+# Dashboard webpack
+nodecg-io-core/dashboard/dist
+!nodecg-io-core/dashboard/webpack.config.js
+
 # Editor configuration
 .idea/
 .vscode/

--- a/nodecg-io-core/dashboard/authentication.ts
+++ b/nodecg-io-core/dashboard/authentication.ts
@@ -1,7 +1,7 @@
 /// <reference types="nodecg/types/browser" />
 
 import { LoadFrameworkMessage } from "nodecg-io-core/extension/messageManager";
-import { updateMonacoLayout } from "./serviceInstance.js";
+import { updateMonacoLayout } from "./serviceInstance";
 
 // HTML elements
 const spanLoaded = document.getElementById("spanLoaded") as HTMLSpanElement;
@@ -9,6 +9,14 @@ const inputPassword = document.getElementById("inputPassword") as HTMLInputEleme
 const divAuth = document.getElementById("divAuth");
 const divMain = document.getElementById("divMain");
 const spanPasswordNotice = document.getElementById("spanPasswordNotice");
+
+// Add key listener to password input
+inputPassword?.addEventListener("keyup", function (event) {
+    if (event.keyCode === 13) {
+        event.preventDefault();
+        loadFramework();
+    }
+});
 
 // Handler for when the socket.io client re-connects which is usually a nodecg restart.
 nodecg.socket.on("connect", () => {

--- a/nodecg-io-core/dashboard/authentication.ts
+++ b/nodecg-io-core/dashboard/authentication.ts
@@ -2,6 +2,7 @@
 
 import { LoadFrameworkMessage } from "nodecg-io-core/extension/messageManager";
 import { updateMonacoLayout } from "./serviceInstance";
+import { setPassword, isPasswordSet, encryptedData as encryptedDataReplicant } from "./crypto";
 
 // HTML elements
 const spanLoaded = document.getElementById("spanLoaded") as HTMLSpanElement;
@@ -33,37 +34,70 @@ document.addEventListener("DOMContentLoaded", () => {
     updateLoadedStatus();
 });
 
-function updateLoadedStatus(): void {
-    nodecg.sendMessage("isLoaded", (_err, result) => {
-        if (result) {
-            spanLoaded.innerText = "Loaded";
-            divAuth?.classList.add("hidden");
-            divMain?.classList.remove("hidden");
-            updateMonacoLayout();
-        } else {
-            spanLoaded.innerText = "Not loaded";
-            divAuth?.classList.remove("hidden");
-            divMain?.classList.add("hidden");
-        }
+async function isLoaded(): Promise<boolean> {
+    return new Promise((resolve, _reject) => {
+        nodecg.sendMessage("isLoaded", (_err, res) => resolve(res));
+        setTimeout(() => resolve(false), 5000); // Fallback in case connection gets lost.
     });
 }
 
-export function loadFramework(): void {
+async function updateLoadedStatus(): Promise<void> {
+    const loaded = await isLoaded();
+    if (loaded) {
+        spanLoaded.innerText = "Loaded";
+    } else {
+        spanLoaded.innerText = "Not loaded";
+    }
+
+    const loggedIn = loaded && isPasswordSet();
+    if (loggedIn) {
+        divAuth?.classList.add("hidden");
+        divMain?.classList.remove("hidden");
+        updateMonacoLayout();
+    } else {
+        divAuth?.classList.remove("hidden");
+        divMain?.classList.add("hidden");
+    }
+}
+
+export async function loadFramework(): Promise<void> {
     const password = inputPassword.value;
     const msg: LoadFrameworkMessage = { password };
 
-    nodecg.sendMessage("load", msg, (error) => {
-        if (spanPasswordNotice !== null) {
-            spanPasswordNotice.innerText = "";
-        }
+    // We first load nodecg-io if needed because it may need to generate a config if
+    // this is the first start and that way we don't need to handle the case of an nonexistant config.
 
-        if (error) {
+    // If nodecg-io has been already loaded we don't need to do it again and it would return an error.
+    if (!(await isLoaded())) {
+        nodecg.sendMessage("load", msg, (error) => {
             if (spanPasswordNotice !== null) {
-                spanPasswordNotice.innerText = "The provided passwort isn't correct!";
+                spanPasswordNotice.innerText = "";
             }
-            inputPassword.value = "";
-        } else {
-            updateLoadedStatus();
-        }
-    });
+
+            if (error) {
+                wrongPassword();
+                return;
+            }
+        });
+    }
+
+    // Ensures that the encrypteDataReplicant has been declared because it is needed by setPassword()
+    // This is especially needed when handling a reconnect as the replicant takes time to declare
+    // and the password check is usually faster than that.
+    await NodeCG.waitForReplicants(encryptedDataReplicant);
+
+    // If the framework was already loaded then this check actually checks the password.
+    // If the above if was entered this just sets it because we assume that the password didn't change.
+    if (!setPassword(password)) {
+        wrongPassword();
+    }
+
+    updateLoadedStatus();
+}
+
+function wrongPassword() {
+    if (spanPasswordNotice !== null) {
+        spanPasswordNotice.innerText = "The provided passwort isn't correct!";
+    }
+    inputPassword.value = "";
 }

--- a/nodecg-io-core/dashboard/bundles.ts
+++ b/nodecg-io-core/dashboard/bundles.ts
@@ -1,7 +1,7 @@
 /// <reference types="nodecg/types/browser" />
 
 import { ObjectMap, ServiceDependency, ServiceInstance } from "nodecg-io-core/extension/types";
-import { updateOptionsArr, updateOptionsMap } from "./utils/selectUtils.js";
+import { updateOptionsArr, updateOptionsMap } from "./utils/selectUtils";
 import { SetServiceDependencyMessage } from "nodecg-io-core/extension/messageManager";
 
 // Replicants

--- a/nodecg-io-core/dashboard/bundles.ts
+++ b/nodecg-io-core/dashboard/bundles.ts
@@ -1,16 +1,12 @@
-/// <reference types="nodecg/types/browser" />
-
-import { ObjectMap, ServiceDependency, ServiceInstance } from "nodecg-io-core/extension/types";
 import { updateOptionsArr, updateOptionsMap } from "./utils/selectUtils";
 import { SetServiceDependencyMessage } from "nodecg-io-core/extension/messageManager";
-
-// Replicants
-const serviceInstances = nodecg.Replicant<ObjectMap<string, ServiceInstance<unknown, unknown>>>("serviceInstances");
-const bundles = nodecg.Replicant<ObjectMap<string, ServiceDependency<unknown>[]>>("bundles");
+import { config } from "./crypto";
 
 document.addEventListener("DOMContentLoaded", () => {
-    bundles.on("change", renderBundles);
-    serviceInstances.on("change", renderInstanceSelector);
+    config.onChange(() => {
+        renderBundles();
+        renderInstanceSelector();
+    });
 });
 
 // HTML Elements
@@ -19,22 +15,22 @@ const selectBundleDepTypes = document.getElementById("selectBundleDepType") as H
 const selectBundleInstance = document.getElementById("selectBundleInstance") as HTMLSelectElement;
 
 function renderBundles() {
-    if (bundles.value === undefined) {
+    if (!config.data) {
         return;
     }
 
-    updateOptionsMap(selectBundle, bundles.value);
+    updateOptionsMap(selectBundle, config.data.bundles);
 
     renderBundleDeps();
 }
 
 export function renderBundleDeps(): void {
-    if (bundles.value === undefined) {
+    if (!config.data) {
         return;
     }
 
     const bundle = selectBundle.options[selectBundle.selectedIndex].value;
-    const bundleDependencies = bundles.value[bundle];
+    const bundleDependencies = config.data.bundles[bundle];
     if (bundleDependencies === undefined) {
         return;
     }
@@ -48,7 +44,7 @@ export function renderBundleDeps(): void {
 }
 
 export function renderInstanceSelector(): void {
-    if (bundles.status !== "declared" || bundles.value === undefined) {
+    if (!config.data) {
         return;
     }
 
@@ -56,12 +52,12 @@ export function renderInstanceSelector(): void {
     const serviceType = selectBundleDepTypes.options[selectBundleDepTypes.selectedIndex].value;
     const instances = ["none"];
 
-    for (const instName in serviceInstances.value) {
-        if (!Object.prototype.hasOwnProperty.call(serviceInstances.value, instName)) {
+    for (const instName in config.data.instances) {
+        if (!Object.prototype.hasOwnProperty.call(config.data.instances, instName)) {
             continue;
         }
 
-        if (serviceInstances.value[instName]?.serviceType === serviceType) {
+        if (config.data.instances[instName]?.serviceType === serviceType) {
             instances.push(instName);
         }
     }
@@ -69,7 +65,8 @@ export function renderInstanceSelector(): void {
 
     // Selecting option of current set instance
     const bundle = selectBundle.options[selectBundle.selectedIndex].value;
-    const currentInstance = bundles.value[bundle]?.find((dep) => dep.serviceType === serviceType)?.serviceInstance;
+    const currentInstance = config.data.bundles[bundle]?.find((dep) => dep.serviceType === serviceType)
+        ?.serviceInstance;
     let index = 0;
     for (let i = 0; i < selectBundleInstance.options.length; i++) {
         if (selectBundleInstance.options.item(i)?.value === currentInstance) {

--- a/nodecg-io-core/dashboard/crypto.ts
+++ b/nodecg-io-core/dashboard/crypto.ts
@@ -1,0 +1,74 @@
+import { PersistentData, EncryptedData, decryptData } from "nodecg-io-core/extension/persistenceManager";
+import { EventEmitter } from "events";
+
+export const encryptedData = nodecg.Replicant<EncryptedData>("encryptedConfig");
+let password: string | undefined;
+
+/**
+ * ConfigData and the config variable give other components access to the decrypted data.
+ * It can be used to get the raw value or to register a handler.
+ */
+class ConfigData extends EventEmitter {
+    data: PersistentData | undefined;
+
+    constructor() {
+        super();
+        this.onChange((data) => (this.data = data));
+    }
+
+    onChange(handler: (data: PersistentData) => void): void {
+        super.on("change", handler);
+    }
+}
+export const config = new ConfigData();
+
+/**
+ * Sets the passed passwort to be used by the crypto module.
+ * Will try to decrypt decrypted data to tell whether the password is correct,
+ * if it is wrong the internal password will be set to undefined.
+ * Returns whether the password is correct.
+ * @param pw the password which should be set.
+ */
+export function setPassword(pw: string): boolean {
+    password = pw;
+
+    if (encryptedData.value) {
+        updateDecryptedData(encryptedData.value);
+        // Password is unset by updateDecryptedData if it is wrong.
+        if (!password) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Returns whether a password has been set in the crypto module aka. whether is is authenticated.
+ */
+export function isPasswordSet(): boolean {
+    return password !== undefined;
+}
+
+// Update the decrypted copy of the data once the encrypted version changes (if pw available).
+// This ensures that the decrypted data is kept uptodate.
+encryptedData.on("change", updateDecryptedData);
+
+/**
+ * Decryptes the passed data using the global password variable and saves it into ConfigData.
+ * Unsets the password if its wrong and also forwards `undefined` to ConfigData if the password is unset.
+ * @param data the data that should be decrypted.
+ */
+function updateDecryptedData(data: EncryptedData): void {
+    let result: PersistentData | undefined = undefined;
+    if (password && data.cipherText) {
+        const res = decryptData(data.cipherText, password);
+        if (!res.failed) {
+            result = res.result;
+        } else {
+            // Password is wrong
+            password = undefined;
+        }
+    }
+
+    config.emit("change", result);
+}

--- a/nodecg-io-core/dashboard/crypto.ts
+++ b/nodecg-io-core/dashboard/crypto.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from "events";
 import { ObjectMap, ServiceInstance, ServiceDependency, Service } from "nodecg-io-core/extension/types";
 
 export const encryptedData = nodecg.Replicant<EncryptedData>("encryptedConfig");
-const services = nodecg.Replicant<Service<unknown, any>[]>("services");
+const services = nodecg.Replicant<Service<unknown, never>[]>("services");
 let password: string | undefined;
 
 /**
@@ -15,8 +15,7 @@ let password: string | undefined;
 interface ConfigData {
     instances: ObjectMap<string, ServiceInstance<unknown, unknown>>;
     bundles: ObjectMap<string, ServiceDependency<unknown>[]>;
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    services: Service<unknown, any>[] | undefined;
+    services: Service<unknown, never>[] | undefined;
 }
 
 /**

--- a/nodecg-io-core/dashboard/main.ts
+++ b/nodecg-io-core/dashboard/main.ts
@@ -1,0 +1,10 @@
+// Re-exports functions that are used in panel.html
+export { loadFramework } from "./authentication";
+export {
+    onMonacoReady,
+    onInstanceSelectChange,
+    createInstance,
+    saveInstanceConfig,
+    deleteInstance,
+} from "./serviceInstance";
+export { renderBundleDeps, renderInstanceSelector, setServiceDependency } from "./bundles";

--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -3,8 +3,14 @@
     "version": "0.1.0",
     "description": "",
     "scripts": {
-        "build": "tsc",
-        "watch": "tsc -w"
+        "build": "webpack",
+        "watch": "webpack --watch"
+    },
+    "devDependencies": {
+        "webpack": "^4.44.1",
+        "webpack-cli": "^3.3.12",
+        "ts-loader": "^8.0.2",
+        "source-map-loader": "^1.0.1"
     },
     "dependencies": {
         "monaco-editor": "^0.20.0",

--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -10,7 +10,7 @@
         "webpack": "^4.44.1",
         "webpack-cli": "^3.3.12",
         "ts-loader": "^8.0.2",
-        "source-map-loader": "^1.0.1"
+        "clean-webpack-plugin": "^3.0.0"
     },
     "dependencies": {
         "monaco-editor": "^0.20.0",

--- a/nodecg-io-core/dashboard/panel.html
+++ b/nodecg-io-core/dashboard/panel.html
@@ -75,42 +75,13 @@
         </div>
 
         <!-- Scripts -->
-        <script src="node_modules/monaco-editor/min/vs/loader.js"></script>
-        <script type="module" src="utils/selectUtils.js"></script>
-        <script type="module" src="utils/deepCopy.js"></script>
-        <script type="module" src="serviceInstance.js"></script>
-        <script type="module" src="bundles.js"></script>
-        <script type="module">
-            import { loadFramework } from "./authentication.js";
-            import {
-                onMonacoReady,
-                onInstanceSelectChange,
-                createInstance,
-                saveInstanceConfig,
-                deleteInstance,
-            } from "./serviceInstance.js";
-            import { renderBundleDeps, renderInstanceSelector, setServiceDependency } from "./bundles.js";
+        <script src="./dist/main.bundle.js"></script>
 
+        <!-- monaco is manually included because when including it using webpack it created formatting issues. -->
+        <script src="node_modules/monaco-editor/min/vs/loader.js"></script>
+        <script>
             require.config({ paths: { vs: "node_modules/monaco-editor/min/vs" } });
             require(["vs/editor/editor.main"], onMonacoReady);
-
-            // Expose handlers from module to global window
-            window.loadFramework = loadFramework;
-            window.onInstanceSelectChange = onInstanceSelectChange;
-            window.createInstance = createInstance;
-            window.saveInstanceConfig = saveInstanceConfig;
-            window.deleteInstance = deleteInstance;
-            window.renderBundleDeps = renderBundleDeps;
-            window.renderInstanceSelector = renderInstanceSelector;
-            window.setServiceDependency = setServiceDependency;
-
-            // Add key listener to password input
-            document.getElementById("inputPassword").addEventListener("keyup", function (event) {
-                if (event.keyCode === 13) {
-                    event.preventDefault();
-                    window.loadFramework();
-                }
-            });
         </script>
     </body>
 </html>

--- a/nodecg-io-core/dashboard/serviceInstance.ts
+++ b/nodecg-io-core/dashboard/serviceInstance.ts
@@ -6,8 +6,8 @@ import {
     DeleteServiceInstanceMessage,
     UpdateInstanceConfigMessage,
 } from "nodecg-io-core/extension/messageManager";
-import { updateOptionsArr, updateOptionsMap } from "./utils/selectUtils.js";
-import { objectDeepCopy } from "./utils/deepCopy.js";
+import { updateOptionsArr, updateOptionsMap } from "./utils/selectUtils";
+import { objectDeepCopy } from "./utils/deepCopy";
 
 const editorDefaultText = "<---- Select a service instance to start editing it in here";
 const editorCreateText = "<---- Create a new service instance on the left and then you can edit it in here";
@@ -42,13 +42,11 @@ window.addEventListener("resize", () => {
     updateMonacoLayout();
 });
 export function updateMonacoLayout(): void {
-    if (instanceMonaco !== null) {
-        editor?.layout();
-    }
+    editor?.layout();
 }
 
 export function onMonacoReady(): void {
-    if (instanceMonaco !== null) {
+    if (instanceMonaco) {
         editor = monaco.editor.create(instanceMonaco, {
             theme: "vs-dark",
         });

--- a/nodecg-io-core/dashboard/tsconfig.json
+++ b/nodecg-io-core/dashboard/tsconfig.json
@@ -3,7 +3,8 @@
         "target": "ES2015",
 
         "lib": ["ES2015", "dom"],
-        "module": "ES2015"
+        "module": "ES2015",
+        "sourceMap": true
     },
     "extends": "../../tsconfig.common.json"
 }

--- a/nodecg-io-core/dashboard/webpack.config.js
+++ b/nodecg-io-core/dashboard/webpack.config.js
@@ -1,0 +1,53 @@
+const path = require('path');
+
+const ROOT = path.resolve( __dirname);
+const DESTINATION = path.resolve( __dirname, 'dist');
+
+module.exports = {
+    context: ROOT,
+
+    entry: {
+        'main': './main.ts'
+    },
+
+    output: {
+        filename: '[name].bundle.js',
+        path: DESTINATION,
+        libraryTarget: "global",
+        publicPath: "./dist/"
+    },
+
+    resolve: {
+        extensions: ['.ts', '.js'],
+        modules: [
+            ROOT,
+            'node_modules'
+        ]
+    },
+
+    module: {
+        rules: [
+            /****************
+             * PRE-LOADERS
+             *****************/
+            {
+                enforce: 'pre',
+                test: /\.js$/,
+                use: 'source-map-loader'
+            },
+
+
+            /****************
+             * LOADERS
+             *****************/
+            {
+                test: /\.ts$/,
+                exclude: [ /node_modules/ ],
+                use: 'ts-loader'
+            }
+        ]
+    },
+
+    devtool: 'cheap-module-source-map',
+    devServer: {}
+};

--- a/nodecg-io-core/dashboard/webpack.config.js
+++ b/nodecg-io-core/dashboard/webpack.config.js
@@ -1,4 +1,5 @@
 const path = require('path');
+const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 
 const ROOT = path.resolve( __dirname);
 const DESTINATION = path.resolve( __dirname, 'dist');
@@ -6,6 +7,7 @@ const DESTINATION = path.resolve( __dirname, 'dist');
 module.exports = {
     context: ROOT,
 
+    mode: "none",
     entry: {
         'main': './main.ts'
     },
@@ -28,16 +30,6 @@ module.exports = {
     module: {
         rules: [
             /****************
-             * PRE-LOADERS
-             *****************/
-            {
-                enforce: 'pre',
-                test: /\.js$/,
-                use: 'source-map-loader'
-            },
-
-
-            /****************
              * LOADERS
              *****************/
             {
@@ -47,6 +39,10 @@ module.exports = {
             }
         ]
     },
+
+    plugins: [
+        new CleanWebpackPlugin()
+    ],
 
     devtool: 'source-map',
     devServer: {}

--- a/nodecg-io-core/dashboard/webpack.config.js
+++ b/nodecg-io-core/dashboard/webpack.config.js
@@ -48,6 +48,6 @@ module.exports = {
         ]
     },
 
-    devtool: 'cheap-module-source-map',
+    devtool: 'source-map',
     devServer: {}
 };

--- a/nodecg-io-core/extension/instanceManager.ts
+++ b/nodecg-io-core/extension/instanceManager.ts
@@ -1,15 +1,16 @@
-import { NodeCG, ReplicantServer } from "nodecg/types/server";
+import { NodeCG } from "nodecg/types/server";
 import { ObjectMap, Service, ServiceClient, ServiceInstance } from "./types";
 import { emptySuccess, error, Result } from "./utils/result";
 import { ServiceManager } from "./serviceManager";
 import { BundleManager } from "./bundleManager";
 import * as Ajv from "ajv";
+import { EventEmitter } from "events";
 
 /**
  * Manages instances of services and their configs/clients.
  */
-export class InstanceManager {
-    private serviceInstances: ReplicantServer<ObjectMap<string, ServiceInstance<unknown, unknown>>>;
+export class InstanceManager extends EventEmitter {
+    private serviceInstances: ObjectMap<string, ServiceInstance<unknown, unknown>> = {};
     private ajv = new Ajv();
 
     constructor(
@@ -17,10 +18,7 @@ export class InstanceManager {
         private readonly services: ServiceManager,
         private readonly bundles: BundleManager,
     ) {
-        this.serviceInstances = this.nodecg.Replicant("serviceInstances", {
-            persistent: false,
-            defaultValue: {},
-        });
+        super();
     }
 
     /**
@@ -29,7 +27,7 @@ export class InstanceManager {
      * @return the wanted service instance if it has been found, undefined otherwise.
      */
     getServiceInstance(instanceName: string): ServiceInstance<unknown, unknown> | undefined {
-        return this.serviceInstances.value[instanceName];
+        return this.serviceInstances[instanceName];
     }
 
     /**
@@ -37,14 +35,7 @@ export class InstanceManager {
      * @return {ObjectMap<string, ServiceInstance<unknown, unknown>>} a map of the instance name to the instance.
      */
     getServiceInstances(): ObjectMap<string, ServiceInstance<unknown, unknown>> {
-        return this.serviceInstances.value;
-    }
-
-    /**
-     * Registers a handler that will get called whenever something about a service instance has been changed.
-     */
-    onInstanceUpdates(callback: () => void): void {
-        this.serviceInstances.on("change", callback);
+        return this.serviceInstances;
     }
 
     /**
@@ -55,7 +46,7 @@ export class InstanceManager {
      */
     createServiceInstance(serviceType: string, instanceName: string): Result<void> {
         // Check if a instance with the same name already exists.
-        if (this.serviceInstances.value[instanceName] !== undefined) {
+        if (this.serviceInstances[instanceName] !== undefined) {
             return error("A service instance with the same name already exists.");
         }
 
@@ -67,11 +58,12 @@ export class InstanceManager {
         const service = svcResult.result;
 
         // Create actual instance and save it
-        this.serviceInstances.value[instanceName] = {
+        this.serviceInstances[instanceName] = {
             serviceType: service.serviceType,
             config: service.defaultConfig,
             client: undefined,
         };
+        this.emit("change");
 
         this.nodecg.log.info(
             `Service instance "${instanceName}" of service "${service.serviceType}" has been successfully created.`,
@@ -87,7 +79,11 @@ export class InstanceManager {
     deleteServiceInstance(instanceName: string): boolean {
         // TODO: handle if a bundle is still connected to this instance, remove this instance from those bundle or don't allow deleting
         // Removing it from the list
-        return delete this.serviceInstances.value[instanceName];
+        const success = delete this.serviceInstances[instanceName];
+        if (success) {
+            this.emit("change");
+        }
+        return success;
     }
 
     /**
@@ -102,7 +98,7 @@ export class InstanceManager {
      */
     async updateInstanceConfig(instanceName: string, config: unknown, validation = true): Promise<Result<void>> {
         // Check existence and get service instance.
-        const inst = this.serviceInstances.value[instanceName];
+        const inst = this.serviceInstances[instanceName];
         if (inst === undefined) {
             return error("Service instance doesn't exist.");
         }
@@ -135,6 +131,7 @@ export class InstanceManager {
         // Update client of this instance using the new config.
         await this.updateInstanceClient(inst, instanceName, service.result);
 
+        this.emit("change");
         return emptySuccess();
     }
 

--- a/nodecg-io-core/extension/persistenceManager.ts
+++ b/nodecg-io-core/extension/persistenceManager.ts
@@ -62,7 +62,7 @@ export class PersistenceManager {
         private readonly bundles: BundleManager,
     ) {
         this.encryptedData = nodecg.Replicant("encryptedConfig", {
-            persistent: true, // Is ok since it is encrypted, all other replicants don't store data for this reason.
+            persistent: true, // Is ok since it is encrypted
             defaultValue: {},
         });
     }
@@ -127,8 +127,8 @@ export class PersistenceManager {
         this.password = password;
 
         // Register handlers to save when something changes
-        this.instances.onInstanceUpdates(() => this.save());
-        this.bundles.onBundleDependencyUpdates(() => this.save());
+        this.instances.on("change", () => this.save());
+        this.bundles.on("change", () => this.save());
 
         return emptySuccess();
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -280,9 +280,9 @@
                     }
                 },
                 "@types/node": {
-                    "version": "14.0.27",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-                    "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+                    "version": "14.6.0",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+                    "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
                 }
             }
         },
@@ -396,9 +396,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "14.0.27",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-                    "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+                    "version": "14.6.0",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+                    "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
                 }
             }
         },
@@ -2441,8 +2441,7 @@
         "@types/json-schema": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-            "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
-            "dev": true
+            "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
         },
         "@types/lru-cache": {
             "version": "4.1.2",
@@ -2807,6 +2806,163 @@
                 "@vaadin/vaadin-development-mode-detector": "^2.0.0"
             }
         },
+        "@webassemblyjs/ast": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.9.0.tgz",
+            "integrity": "sha512-C6wW5L+b7ogSDVqymbkkvuW9kruN//YisMED04xzeBBqjHa2FYnmvOlS6Xj68xWQRgWvI9cIglsjFowH/RJyEA==",
+            "requires": {
+                "@webassemblyjs/helper-module-context": "1.9.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                "@webassemblyjs/wast-parser": "1.9.0"
+            }
+        },
+        "@webassemblyjs/floating-point-hex-parser": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.9.0.tgz",
+            "integrity": "sha512-TG5qcFsS8QB4g4MhrxK5TqfdNe7Ey/7YL/xN+36rRjl/BlGE/NcBvJcqsRgCP6Z92mRE+7N50pRIi8SmKUbcQA=="
+        },
+        "@webassemblyjs/helper-api-error": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.9.0.tgz",
+            "integrity": "sha512-NcMLjoFMXpsASZFxJ5h2HZRcEhDkvnNFOAKneP5RbKRzaWJN36NC4jqQHKwStIhGXu5mUWlUUk7ygdtrO8lbmw=="
+        },
+        "@webassemblyjs/helper-buffer": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
+            "integrity": "sha512-qZol43oqhq6yBPx7YM3m9Bv7WMV9Eevj6kMi6InKOuZxhw+q9hOkvq5e/PpKSiLfyetpaBnogSbNCfBwyB00CA=="
+        },
+        "@webassemblyjs/helper-code-frame": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-code-frame/-/helper-code-frame-1.9.0.tgz",
+            "integrity": "sha512-ERCYdJBkD9Vu4vtjUYe8LZruWuNIToYq/ME22igL+2vj2dQ2OOujIZr3MEFvfEaqKoVqpsFKAGsRdBSBjrIvZA==",
+            "requires": {
+                "@webassemblyjs/wast-printer": "1.9.0"
+            }
+        },
+        "@webassemblyjs/helper-fsm": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-fsm/-/helper-fsm-1.9.0.tgz",
+            "integrity": "sha512-OPRowhGbshCb5PxJ8LocpdX9Kl0uB4XsAjl6jH/dWKlk/mzsANvhwbiULsaiqT5GZGT9qinTICdj6PLuM5gslw=="
+        },
+        "@webassemblyjs/helper-module-context": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-module-context/-/helper-module-context-1.9.0.tgz",
+            "integrity": "sha512-MJCW8iGC08tMk2enck1aPW+BE5Cw8/7ph/VGZxwyvGbJwjktKkDK7vy7gAmMDx88D7mhDTCNKAW5tED+gZ0W8g==",
+            "requires": {
+                "@webassemblyjs/ast": "1.9.0"
+            }
+        },
+        "@webassemblyjs/helper-wasm-bytecode": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.9.0.tgz",
+            "integrity": "sha512-R7FStIzyNcd7xKxCZH5lE0Bqy+hGTwS3LJjuv1ZVxd9O7eHCedSdrId/hMOd20I+v8wDXEn+bjfKDLzTepoaUw=="
+        },
+        "@webassemblyjs/helper-wasm-section": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.9.0.tgz",
+            "integrity": "sha512-XnMB8l3ek4tvrKUUku+IVaXNHz2YsJyOOmz+MMkZvh8h1uSJpSen6vYnw3IoQ7WwEuAhL8Efjms1ZWjqh2agvw==",
+            "requires": {
+                "@webassemblyjs/ast": "1.9.0",
+                "@webassemblyjs/helper-buffer": "1.9.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                "@webassemblyjs/wasm-gen": "1.9.0"
+            }
+        },
+        "@webassemblyjs/ieee754": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.9.0.tgz",
+            "integrity": "sha512-dcX8JuYU/gvymzIHc9DgxTzUUTLexWwt8uCTWP3otys596io0L5aW02Gb1RjYpx2+0Jus1h4ZFqjla7umFniTg==",
+            "requires": {
+                "@xtuc/ieee754": "^1.2.0"
+            }
+        },
+        "@webassemblyjs/leb128": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.9.0.tgz",
+            "integrity": "sha512-ENVzM5VwV1ojs9jam6vPys97B/S65YQtv/aanqnU7D8aSoHFX8GyhGg0CMfyKNIHBuAVjy3tlzd5QMMINa7wpw==",
+            "requires": {
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/utf8": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.9.0.tgz",
+            "integrity": "sha512-GZbQlWtopBTP0u7cHrEx+73yZKrQoBMpwkGEIqlacljhXCkVM1kMQge/Mf+csMJAjEdSwhOyLAS0AoR3AG5P8w=="
+        },
+        "@webassemblyjs/wasm-edit": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.9.0.tgz",
+            "integrity": "sha512-FgHzBm80uwz5M8WKnMTn6j/sVbqilPdQXTWraSjBwFXSYGirpkSWE2R9Qvz9tNiTKQvoKILpCuTjBKzOIm0nxw==",
+            "requires": {
+                "@webassemblyjs/ast": "1.9.0",
+                "@webassemblyjs/helper-buffer": "1.9.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                "@webassemblyjs/helper-wasm-section": "1.9.0",
+                "@webassemblyjs/wasm-gen": "1.9.0",
+                "@webassemblyjs/wasm-opt": "1.9.0",
+                "@webassemblyjs/wasm-parser": "1.9.0",
+                "@webassemblyjs/wast-printer": "1.9.0"
+            }
+        },
+        "@webassemblyjs/wasm-gen": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.9.0.tgz",
+            "integrity": "sha512-cPE3o44YzOOHvlsb4+E9qSqjc9Qf9Na1OO/BHFy4OI91XDE14MjFN4lTMezzaIWdPqHnsTodGGNP+iRSYfGkjA==",
+            "requires": {
+                "@webassemblyjs/ast": "1.9.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                "@webassemblyjs/ieee754": "1.9.0",
+                "@webassemblyjs/leb128": "1.9.0",
+                "@webassemblyjs/utf8": "1.9.0"
+            }
+        },
+        "@webassemblyjs/wasm-opt": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.9.0.tgz",
+            "integrity": "sha512-Qkjgm6Anhm+OMbIL0iokO7meajkzQD71ioelnfPEj6r4eOFuqm4YC3VBPqXjFyyNwowzbMD+hizmprP/Fwkl2A==",
+            "requires": {
+                "@webassemblyjs/ast": "1.9.0",
+                "@webassemblyjs/helper-buffer": "1.9.0",
+                "@webassemblyjs/wasm-gen": "1.9.0",
+                "@webassemblyjs/wasm-parser": "1.9.0"
+            }
+        },
+        "@webassemblyjs/wasm-parser": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.9.0.tgz",
+            "integrity": "sha512-9+wkMowR2AmdSWQzsPEjFU7njh8HTO5MqO8vjwEHuM+AMHioNqSBONRdr0NQQ3dVQrzp0s8lTcYqzUdb7YgELA==",
+            "requires": {
+                "@webassemblyjs/ast": "1.9.0",
+                "@webassemblyjs/helper-api-error": "1.9.0",
+                "@webassemblyjs/helper-wasm-bytecode": "1.9.0",
+                "@webassemblyjs/ieee754": "1.9.0",
+                "@webassemblyjs/leb128": "1.9.0",
+                "@webassemblyjs/utf8": "1.9.0"
+            }
+        },
+        "@webassemblyjs/wast-parser": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-parser/-/wast-parser-1.9.0.tgz",
+            "integrity": "sha512-qsqSAP3QQ3LyZjNC/0jBJ/ToSxfYJ8kYyuiGvtn/8MK89VrNEfwj7BPQzJVHi0jGTRK2dGdJ5PRqhtjzoww+bw==",
+            "requires": {
+                "@webassemblyjs/ast": "1.9.0",
+                "@webassemblyjs/floating-point-hex-parser": "1.9.0",
+                "@webassemblyjs/helper-api-error": "1.9.0",
+                "@webassemblyjs/helper-code-frame": "1.9.0",
+                "@webassemblyjs/helper-fsm": "1.9.0",
+                "@xtuc/long": "4.2.2"
+            }
+        },
+        "@webassemblyjs/wast-printer": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.9.0.tgz",
+            "integrity": "sha512-2J0nE95rHXHyQ24cWjMKJ1tqB/ds8z/cyeOZxJhcb+rW+SQASVjuznUSmdz5GpVJTzU8JkhYut0D3siFDD6wsA==",
+            "requires": {
+                "@webassemblyjs/ast": "1.9.0",
+                "@webassemblyjs/wast-parser": "1.9.0",
+                "@xtuc/long": "4.2.2"
+            }
+        },
         "@webcomponents/shadycss": {
             "version": "1.10.1",
             "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.1.tgz",
@@ -2816,6 +2972,16 @@
             "version": "2.4.4",
             "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.4.tgz",
             "integrity": "sha512-UWXZYbaDLLfhm+xONXTiDciyhOSwKRrZieGQHFMSMGSxY4mbjZ5uYzOKgnuX0luYFvjJw32G3r0sCwQZPJIR4Q=="
+        },
+        "@xtuc/ieee754": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
+            "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+        },
+        "@xtuc/long": {
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
+            "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
         },
         "@zkochan/cmd-shim": {
             "version": "3.1.0",
@@ -2837,6 +3003,11 @@
                 "jsonparse": "^1.2.0",
                 "through": ">=2.2.7 <3"
             }
+        },
+        "abab": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
+            "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ=="
         },
         "abbrev": {
             "version": "1.1.1",
@@ -2904,6 +3075,16 @@
                 "json-schema-traverse": "^0.4.1",
                 "uri-js": "^4.2.2"
             }
+        },
+        "ajv-errors": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
+            "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
+        },
+        "ajv-keywords": {
+            "version": "3.5.2",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
+            "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ=="
         },
         "ansi-align": {
             "version": "3.0.0",
@@ -2985,20 +3166,17 @@
         "arr-diff": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=",
-            "dev": true
+            "integrity": "sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA="
         },
         "arr-flatten": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-            "dev": true
+            "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
         },
         "arr-union": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
-            "dev": true
+            "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ="
         },
         "array-differ": {
             "version": "2.1.0",
@@ -3041,8 +3219,7 @@
         "array-unique": {
             "version": "0.3.2",
             "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
-            "dev": true
+            "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg="
         },
         "array.prototype.findindex": {
             "version": "2.1.0",
@@ -3089,6 +3266,48 @@
                 "safer-buffer": "~2.1.0"
             }
         },
+        "asn1.js": {
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
+            "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
+            "requires": {
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "safer-buffer": "^2.1.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+                }
+            }
+        },
+        "assert": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+            "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
+            "requires": {
+                "object-assign": "^4.1.1",
+                "util": "0.10.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE="
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "requires": {
+                        "inherits": "2.0.1"
+                    }
+                }
+            }
+        },
         "assert-plus": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
@@ -3097,8 +3316,7 @@
         "assign-symbols": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=",
-            "dev": true
+            "integrity": "sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c="
         },
         "astral-regex": {
             "version": "1.0.0",
@@ -3110,6 +3328,12 @@
             "version": "0.2.10",
             "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
             "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        },
+        "async-each": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
+            "integrity": "sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==",
+            "optional": true
         },
         "async-limiter": {
             "version": "1.0.1",
@@ -3124,8 +3348,7 @@
         "atob": {
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
-            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
-            "dev": true
+            "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
         "atob-lite": {
             "version": "2.0.0",
@@ -3185,7 +3408,6 @@
             "version": "0.11.2",
             "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-            "dev": true,
             "requires": {
                 "cache-base": "^1.0.1",
                 "class-utils": "^0.3.5",
@@ -3200,7 +3422,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -3209,7 +3430,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -3218,7 +3438,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -3227,7 +3446,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -3277,6 +3495,11 @@
             "requires": {
                 "callsite": "1.0.0"
             }
+        },
+        "big.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
         },
         "bignumber.js": {
             "version": "9.0.0",
@@ -3335,6 +3558,11 @@
             "version": "3.7.2",
             "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
             "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+        },
+        "bn.js": {
+            "version": "5.1.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.3.tgz",
+            "integrity": "sha512-GkTiFpjFtUzU9CbMeJ5iazkCzGL3jrhzerzZIuqLABjbwRaFt33I9tUdSNryIptM+RxDet6OKm2WnLXzW51KsQ=="
         },
         "body-parser": {
             "version": "1.19.0",
@@ -3495,7 +3723,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-            "dev": true,
             "requires": {
                 "arr-flatten": "^1.1.0",
                 "array-unique": "^0.3.2",
@@ -3513,11 +3740,101 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
                 }
+            }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
+        },
+        "browserify-aes": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
+            "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
+            "requires": {
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
+        "browserify-cipher": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.1.tgz",
+            "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
+            "requires": {
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
+            }
+        },
+        "browserify-des": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.2.tgz",
+            "integrity": "sha512-BioO1xf3hFwz4kc6iBhI3ieDFompMhrMlnDFC4/0/vd5MokpuAc3R+LYbwTA9A5Yc9pq9UYPqffKpW2ObuwX5A==",
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
+        "browserify-rsa": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
+            "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
+            "requires": {
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+                }
+            }
+        },
+        "browserify-sign": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.2.1.tgz",
+            "integrity": "sha512-/vrA5fguVAKKAVTNJjgSm1tRQDHUU6DbwO9IROu/0WAzC8PKhucDSh18J0RMvVeHAn5puMd+QHC2erPRNf8lmg==",
+            "requires": {
+                "bn.js": "^5.1.1",
+                "browserify-rsa": "^4.0.1",
+                "create-hash": "^1.2.0",
+                "create-hmac": "^1.1.7",
+                "elliptic": "^6.5.3",
+                "inherits": "^2.0.4",
+                "parse-asn1": "^5.1.5",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "browserify-zlib": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
+            "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
+            "requires": {
+                "pako": "~1.0.5"
             }
         },
         "btoa-lite": {
@@ -3544,6 +3861,16 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+        },
+        "buffer-xor": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
+            "integrity": "sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk="
+        },
+        "builtin-status-codes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
+            "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
         },
         "builtins": {
             "version": "1.0.3",
@@ -3604,7 +3931,6 @@
             "version": "12.0.4",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
             "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
-            "dev": true,
             "requires": {
                 "bluebird": "^3.5.5",
                 "chownr": "^1.1.1",
@@ -3627,7 +3953,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-            "dev": true,
             "requires": {
                 "collection-visit": "^1.0.0",
                 "component-emitter": "^1.2.1",
@@ -3875,17 +4200,40 @@
             "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
             "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
+        "chrome-trace-event": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+            "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
+            "requires": {
+                "tslib": "^1.9.0"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "1.13.0",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+                }
+            }
+        },
         "ci-info": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
             "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
             "dev": true
         },
+        "cipher-base": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
+            "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "class-utils": {
             "version": "0.3.6",
             "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "define-property": "^0.2.5",
@@ -3897,7 +4245,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -3939,7 +4286,6 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
             "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
-            "dev": true,
             "requires": {
                 "string-width": "^3.1.0",
                 "strip-ansi": "^5.2.0",
@@ -3949,14 +4295,12 @@
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^4.1.0"
                     }
@@ -3998,7 +4342,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-            "dev": true,
             "requires": {
                 "map-visit": "^1.0.0",
                 "object-visit": "^1.0.0"
@@ -4056,6 +4399,16 @@
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
+        },
+        "commander": {
+            "version": "2.20.3",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+            "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+        },
+        "commondir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+            "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
         },
         "compare-func": {
             "version": "1.3.4",
@@ -4230,10 +4583,20 @@
                 }
             }
         },
+        "console-browserify": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
+            "integrity": "sha512-ZMkYO/LkF17QvCPqM0gxw8yUzigAOZOSWSHg91FH6orS7vcEj5dVZTidN2fQ14yBSdg97RqhSNwLUXInd52OTA=="
+        },
         "console-control-strings": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
             "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+        },
+        "constants-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/constants-browserify/-/constants-browserify-1.0.0.tgz",
+            "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U="
         },
         "content-disposition": {
             "version": "0.5.3",
@@ -4594,8 +4957,7 @@
         "copy-descriptor": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
-            "dev": true
+            "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
         "core-util-is": {
             "version": "1.0.2",
@@ -4615,6 +4977,47 @@
                 "yaml": "^1.7.2"
             }
         },
+        "create-ecdh": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.4.tgz",
+            "integrity": "sha512-mf+TCx8wWc9VpuxfP2ht0iSISLZnt0JgWlrOKZiNqyUZWnjIaCIVNQArMHnCZKfEYRg6IM7A+NeJoN8gf/Ws0A==",
+            "requires": {
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.5.3"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+                }
+            }
+        },
+        "create-hash": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+            "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+            "requires": {
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
+            }
+        },
+        "create-hmac": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+            "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+            "requires": {
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
         "cross-spawn": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -4630,6 +5033,24 @@
             "version": "0.0.2",
             "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
             "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+        },
+        "crypto-browserify": {
+            "version": "3.12.0",
+            "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
+            "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
+            "requires": {
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
+            }
         },
         "crypto-js": {
             "version": "4.0.0",
@@ -4694,6 +5115,41 @@
                 "assert-plus": "^1.0.0"
             }
         },
+        "data-urls": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
+            "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
+            "requires": {
+                "abab": "^2.0.3",
+                "whatwg-mimetype": "^2.3.0",
+                "whatwg-url": "^8.0.0"
+            },
+            "dependencies": {
+                "tr46": {
+                    "version": "2.0.2",
+                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
+                    "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
+                    "requires": {
+                        "punycode": "^2.1.1"
+                    }
+                },
+                "webidl-conversions": {
+                    "version": "5.0.0",
+                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
+                    "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
+                },
+                "whatwg-url": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
+                    "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
+                    "requires": {
+                        "lodash.sortby": "^4.7.0",
+                        "tr46": "^2.0.2",
+                        "webidl-conversions": "^5.0.0"
+                    }
+                }
+            }
+        },
         "dateformat": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -4740,8 +5196,7 @@
         "decode-uri-component": {
             "version": "0.2.0",
             "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
-            "dev": true
+            "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "decompress-response": {
             "version": "3.3.0",
@@ -4809,7 +5264,6 @@
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-            "dev": true,
             "requires": {
                 "is-descriptor": "^1.0.2",
                 "isobject": "^3.0.1"
@@ -4819,7 +5273,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -4828,7 +5281,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -4837,7 +5289,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -4872,6 +5323,15 @@
             "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
             "dev": true
         },
+        "des.js": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.1.tgz",
+            "integrity": "sha512-Q0I4pfFrv2VPd34/vfLrFOoRmlYj3OV50i7fskps1jZWK1kApMWWT9G6RRUeYedLcBDIhnSDaUvJMb3AhUlaEA==",
+            "requires": {
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
+            }
+        },
         "desandro-matches-selector": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/desandro-matches-selector/-/desandro-matches-selector-2.0.2.tgz",
@@ -4881,6 +5341,11 @@
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
             "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
+        },
+        "detect-file": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+            "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc="
         },
         "detect-indent": {
             "version": "5.0.0",
@@ -4937,6 +5402,23 @@
                     "version": "0.10.31",
                     "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                     "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+                }
+            }
+        },
+        "diffie-hellman": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.3.tgz",
+            "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
+            "requires": {
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
                 }
             }
         },
@@ -5005,6 +5487,11 @@
                 "domelementtype": "^1.3.0",
                 "entities": "^1.1.1"
             }
+        },
+        "domain-browser": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.2.0.tgz",
+            "integrity": "sha512-jnjyiM6eRyZl2H+W8Q/zLMA481hzi0eszAaBUzIVnmYVDBbnLxVNnfu1HgEBvCbL+71FrxMl3E6lpKH7Ge3OXA=="
         },
         "domelementtype": {
             "version": "1.3.1",
@@ -5109,11 +5596,36 @@
                 "node-hid": "^1.2.0"
             }
         },
+        "elliptic": {
+            "version": "6.5.3",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+            "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+            "requires": {
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+                }
+            }
+        },
         "emoji-regex": {
             "version": "7.0.3",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
-            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
-            "dev": true
+            "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
+        },
+        "emojis-list": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q=="
         },
         "encodeurl": {
             "version": "1.0.2",
@@ -5196,6 +5708,16 @@
                 "has-binary2": "~1.0.2"
             }
         },
+        "enhanced-resolve": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.3.0.tgz",
+            "integrity": "sha512-3e87LvavsdxyoCfGusJnrZ5G8SLPOFeHSNpZI/ATL9a5leXo2k0w6MKnbqhdBad9qTobSfB20Ld7UmgoNbAZkQ==",
+            "requires": {
+                "graceful-fs": "^4.1.2",
+                "memory-fs": "^0.5.0",
+                "tapable": "^1.0.0"
+            }
+        },
         "enquirer": {
             "version": "2.3.6",
             "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.3.6.tgz",
@@ -5226,6 +5748,14 @@
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/err-code/-/err-code-1.1.2.tgz",
             "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
+        },
+        "errno": {
+            "version": "0.1.7",
+            "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
+            "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+            "requires": {
+                "prr": "~1.0.1"
+            }
         },
         "error-ex": {
             "version": "1.3.2",
@@ -5444,7 +5974,6 @@
             "version": "4.2.1",
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
             "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
-            "dev": true,
             "requires": {
                 "estraverse": "^4.1.0"
             }
@@ -5452,8 +5981,7 @@
         "estraverse": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-            "dev": true
+            "integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
         },
         "esutils": {
             "version": "2.0.3",
@@ -5480,6 +6008,20 @@
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
             "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        },
+        "events": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/events/-/events-3.2.0.tgz",
+            "integrity": "sha512-/46HWwbfCX2xTawVfkKLGxMifJYQBWMwY1mjywRtb4c9x8l5NP3KoJtnIOiL1hfdRkIuYhETxQlo62IF8tcnlg=="
+        },
+        "evp_bytestokey": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
+            "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
+            "requires": {
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
+            }
         },
         "execa": {
             "version": "1.0.0",
@@ -5556,7 +6098,6 @@
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
-            "dev": true,
             "requires": {
                 "debug": "^2.3.3",
                 "define-property": "^0.2.5",
@@ -5571,7 +6112,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -5580,7 +6120,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -5589,7 +6128,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -5597,8 +6135,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -5606,6 +6143,14 @@
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
             "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+        },
+        "expand-tilde": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+            "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+            "requires": {
+                "homedir-polyfill": "^1.0.1"
+            }
         },
         "express": {
             "version": "4.17.1",
@@ -5754,7 +6299,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-            "dev": true,
             "requires": {
                 "assign-symbols": "^1.0.0",
                 "is-extendable": "^1.0.1"
@@ -5764,7 +6308,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -5797,7 +6340,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-            "dev": true,
             "requires": {
                 "array-unique": "^0.3.2",
                 "define-property": "^1.0.0",
@@ -5813,7 +6355,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -5822,7 +6363,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -5831,7 +6371,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5840,7 +6379,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -5849,7 +6387,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -5974,7 +6511,6 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-number": "^3.0.0",
@@ -5986,7 +6522,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -6022,6 +6557,70 @@
                 }
             }
         },
+        "find-cache-dir": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
+            "integrity": "sha512-Tq6PixE0w/VMFfCgbONnkiQIVol/JJL7nRMi20fqzA4NRs9AfeqMGeRdPi3wIhYkxjeBaWh2rxwapn5Tu3IqOQ==",
+            "requires": {
+                "commondir": "^1.0.1",
+                "make-dir": "^2.0.0",
+                "pkg-dir": "^3.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "make-dir": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
+                    "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+                    "requires": {
+                        "pify": "^4.0.1",
+                        "semver": "^5.6.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                },
+                "pkg-dir": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
+                    "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
+                    "requires": {
+                        "find-up": "^3.0.0"
+                    }
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                }
+            }
+        },
         "find-up": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
@@ -6039,6 +6638,17 @@
             "dev": true,
             "requires": {
                 "semver-regex": "^2.0.0"
+            }
+        },
+        "findup-sync": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-3.0.0.tgz",
+            "integrity": "sha512-YbffarhcicEhOrm4CtrwdKBdCuz576RLdhJDsIfvNtxUuhdRet1qZcsMjqbePtAseKdAnDyM/IyXbu7PRPRLYg==",
+            "requires": {
+                "detect-file": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "micromatch": "^3.0.4",
+                "resolve-dir": "^1.0.1"
             }
         },
         "fizzy-ui-utils": {
@@ -6101,8 +6711,7 @@
         "for-in": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=",
-            "dev": true
+            "integrity": "sha1-gQaNKVqBQuwKxybG4iAMMPttXoA="
         },
         "foreachasync": {
             "version": "3.0.0",
@@ -6143,7 +6752,6 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-            "dev": true,
             "requires": {
                 "map-cache": "^0.2.2"
             }
@@ -6381,8 +6989,7 @@
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-            "dev": true
+            "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-pkg-repo": {
             "version": "1.4.0",
@@ -6601,8 +7208,7 @@
         "get-value": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=",
-            "dev": true
+            "integrity": "sha1-3BXKHGcjh8p2vTesCjlbogQqLCg="
         },
         "getpass": {
             "version": "0.1.7",
@@ -6917,6 +7523,56 @@
                 "ini": "^1.3.5"
             }
         },
+        "global-modules": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+            "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+            "requires": {
+                "global-prefix": "^3.0.0"
+            },
+            "dependencies": {
+                "global-prefix": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+                    "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+                    "requires": {
+                        "ini": "^1.3.5",
+                        "kind-of": "^6.0.2",
+                        "which": "^1.3.1"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
+        "global-prefix": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+            "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+            "requires": {
+                "expand-tilde": "^2.0.2",
+                "homedir-polyfill": "^1.0.1",
+                "ini": "^1.3.4",
+                "is-windows": "^1.0.1",
+                "which": "^1.2.14"
+            },
+            "dependencies": {
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                }
+            }
+        },
         "globals": {
             "version": "12.4.0",
             "resolved": "https://registry.npmjs.org/globals/-/globals-12.4.0.tgz",
@@ -7166,7 +7822,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
-            "dev": true,
             "requires": {
                 "get-value": "^2.0.6",
                 "has-values": "^1.0.0",
@@ -7177,7 +7832,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "kind-of": "^4.0.0"
@@ -7187,7 +7841,6 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -7199,6 +7852,55 @@
             "resolved": "https://registry.npmjs.org/has-yarn/-/has-yarn-2.1.0.tgz",
             "integrity": "sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==",
             "dev": true
+        },
+        "hash-base": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+            "integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
+            "requires": {
+                "inherits": "^2.0.4",
+                "readable-stream": "^3.6.0",
+                "safe-buffer": "^5.2.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+                    "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                }
+            }
+        },
+        "hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "requires": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
+        "homedir-polyfill": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+            "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+            "requires": {
+                "parse-passwd": "^1.0.0"
+            }
         },
         "hosted-git-info": {
             "version": "2.8.8",
@@ -7293,6 +7995,11 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/httpolyglot/-/httpolyglot-0.1.2.tgz",
             "integrity": "sha1-5NNH/omEpi9GfUBg31J/GFH2mXs="
+        },
+        "https-browserify": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/https-browserify/-/https-browserify-1.0.0.tgz",
+            "integrity": "sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM="
         },
         "https-proxy-agent": {
             "version": "2.2.4",
@@ -7417,7 +8124,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/import-local/-/import-local-2.0.0.tgz",
             "integrity": "sha512-b6s04m3O+s3CGSbqDIyP4R6aAwAeYlVq9+WUWep6iHa8ETRf9yei1U48C5MmfJmV9AiLYYBKPMq/W+/WRpQmCQ==",
-            "dev": true,
             "requires": {
                 "pkg-dir": "^3.0.0",
                 "resolve-cwd": "^2.0.0"
@@ -7427,7 +8133,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-                    "dev": true,
                     "requires": {
                         "locate-path": "^3.0.0"
                     }
@@ -7436,7 +8141,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
                     "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-                    "dev": true,
                     "requires": {
                         "p-locate": "^3.0.0",
                         "path-exists": "^3.0.0"
@@ -7446,7 +8150,6 @@
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
                     "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-                    "dev": true,
                     "requires": {
                         "p-limit": "^2.0.0"
                     }
@@ -7454,14 +8157,12 @@
                 "path-exists": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-                    "dev": true
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
                 },
                 "pkg-dir": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-3.0.0.tgz",
                     "integrity": "sha512-/E57AYkoeQ25qkxMj5PBOVgF8Kiu/h7cYS30Z5+R7WaiCCBfLq58ZI/dSeaEKb9WVJV5n/03QwrN3IeWIFllvw==",
-                    "dev": true,
                     "requires": {
                         "find-up": "^3.0.0"
                     }
@@ -7487,8 +8188,7 @@
         "infer-owner": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/infer-owner/-/infer-owner-1.0.4.tgz",
-            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==",
-            "dev": true
+            "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
         },
         "inflight": {
             "version": "1.0.6",
@@ -7663,9 +8363,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "14.0.27",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.0.27.tgz",
-                    "integrity": "sha512-kVrqXhbclHNHGu9ztnAwSncIgJv/FaxmzXJvGXNdcCpV1b8u1/Mi6z6m0vwy0LzKeXFTPLH0NzwmoJ3fNCIq0g=="
+                    "version": "14.6.0",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
+                    "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
                 },
                 "clone": {
                     "version": "2.1.2",
@@ -7678,7 +8378,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -7687,7 +8386,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -7736,7 +8434,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -7745,7 +8442,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -7761,7 +8457,6 @@
             "version": "0.1.6",
             "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-            "dev": true,
             "requires": {
                 "is-accessor-descriptor": "^0.1.6",
                 "is-data-descriptor": "^0.1.4",
@@ -7771,8 +8466,7 @@
                 "kind-of": {
                     "version": "5.1.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
-                    "dev": true
+                    "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
                 }
             }
         },
@@ -7783,9 +8477,9 @@
             "dev": true
         },
         "is-docker": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.0.0.tgz",
-            "integrity": "sha512-pJEdRugimx4fBMra5z2/5iRdZ63OhYV0vr0Dwm5+xtW4D1FvRkB8hamMIhnWfyJeDdyr/aa7BDyNbtG38VxgoQ=="
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.1.1.tgz",
+            "integrity": "sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw=="
         },
         "is-error": {
             "version": "2.2.2",
@@ -7795,8 +8489,7 @@
         "is-extendable": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
-            "dev": true
+            "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
         },
         "is-extglob": {
             "version": "2.1.1",
@@ -7872,7 +8565,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -7881,7 +8573,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -7910,7 +8601,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -7983,8 +8673,7 @@
         "is-windows": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-            "dev": true
+            "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
         },
         "is-wsl": {
             "version": "2.2.0",
@@ -8008,14 +8697,12 @@
         "isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-            "dev": true
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isobject": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-            "dev": true
+            "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
         },
         "isstream": {
             "version": "0.1.2",
@@ -8202,8 +8889,7 @@
         "kind-of": {
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-            "dev": true
+            "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
         },
         "latest-version": {
             "version": "5.1.0",
@@ -8306,6 +8992,21 @@
                     "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ==",
                     "dev": true
                 }
+            }
+        },
+        "loader-runner": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-2.4.0.tgz",
+            "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
+        },
+        "loader-utils": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
+            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+            "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
             }
         },
         "localforage": {
@@ -8465,8 +9166,7 @@
         "map-cache": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=",
-            "dev": true
+            "integrity": "sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8="
         },
         "map-obj": {
             "version": "4.1.0",
@@ -8478,7 +9178,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-            "dev": true,
             "requires": {
                 "object-visit": "^1.0.0"
             }
@@ -8493,10 +9192,29 @@
                 "is-buffer": "~1.1.6"
             }
         },
+        "md5.js": {
+            "version": "1.3.5",
+            "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+            "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            }
+        },
         "media-typer": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
+        },
+        "memory-fs": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
+            "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+            "requires": {
+                "errno": "^0.1.3",
+                "readable-stream": "^2.0.1"
+            }
         },
         "meow": {
             "version": "7.0.1",
@@ -8622,7 +9340,6 @@
             "version": "3.1.10",
             "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -8646,6 +9363,22 @@
             "requires": {
                 "bindings": "~1.5.0",
                 "nan": "^2.3.3"
+            }
+        },
+        "miller-rabin": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
+            "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
+            "requires": {
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+                }
             }
         },
         "mime": {
@@ -8683,6 +9416,16 @@
             "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
             "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
             "dev": true
+        },
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "minimatch": {
             "version": "3.0.4",
@@ -8748,7 +9491,6 @@
             "version": "1.3.2",
             "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
             "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-            "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
                 "is-extendable": "^1.0.1"
@@ -8758,7 +9500,6 @@
                     "version": "1.0.1",
                     "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-                    "dev": true,
                     "requires": {
                         "is-plain-object": "^2.0.4"
                     }
@@ -8875,7 +9616,6 @@
             "version": "1.2.13",
             "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
             "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-            "dev": true,
             "requires": {
                 "arr-diff": "^4.0.0",
                 "array-unique": "^0.3.2",
@@ -8926,14 +9666,12 @@
         "neo-async": {
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
-            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
-            "dev": true
+            "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw=="
         },
         "nice-try": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
-            "dev": true
+            "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node-abi": {
             "version": "2.18.0",
@@ -9018,9 +9756,9 @@
             }
         },
         "node-hue-api": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/node-hue-api/-/node-hue-api-4.0.8.tgz",
-            "integrity": "sha512-9/MfN0Qot5KSysS7C4yDjmDoR/TLSeX4PDkSH85zpC36jdQBW1db9HVhznG0C/6v4K51u+4h+gEa/pNSueHVXQ==",
+            "version": "4.0.9",
+            "resolved": "https://registry.npmjs.org/node-hue-api/-/node-hue-api-4.0.9.tgz",
+            "integrity": "sha512-xsMUGKDSeMtYsKHSKNCn5XFq4eEArbEaFRAAccGBIlQ+ysrVKjlg1So44wY32gMgYfm3S6sJQOw2jLyPxu3Dkw==",
             "requires": {
                 "axios": "^0.19.0",
                 "bottleneck": "^2.19.5",
@@ -9034,6 +9772,53 @@
             "optional": true,
             "requires": {
                 "nan": "^2.3.3"
+            }
+        },
+        "node-libs-browser": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+            "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
+            "requires": {
+                "assert": "^1.1.1",
+                "browserify-zlib": "^0.2.0",
+                "buffer": "^4.3.0",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "^1.0.0",
+                "crypto-browserify": "^3.11.0",
+                "domain-browser": "^1.1.1",
+                "events": "^3.0.0",
+                "https-browserify": "^1.0.0",
+                "os-browserify": "^0.3.0",
+                "path-browserify": "0.0.1",
+                "process": "^0.11.10",
+                "punycode": "^1.2.4",
+                "querystring-es3": "^0.2.0",
+                "readable-stream": "^2.3.3",
+                "stream-browserify": "^2.0.1",
+                "stream-http": "^2.7.2",
+                "string_decoder": "^1.0.0",
+                "timers-browserify": "^2.0.4",
+                "tty-browserify": "0.0.0",
+                "url": "^0.11.0",
+                "util": "^0.11.0",
+                "vm-browserify": "^1.0.1"
+            },
+            "dependencies": {
+                "buffer": {
+                    "version": "4.9.2",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz",
+                    "integrity": "sha512-xq+q3SRMOxGivLhBNaUdC64hDTQwejJ+H0T/NB1XMtTVEwNTrfFF3gAxiyW0Bu/xWEGhjVKgUcMhCrUy2+uCWg==",
+                    "requires": {
+                        "base64-js": "^1.0.2",
+                        "ieee754": "^1.1.4",
+                        "isarray": "^1.0.0"
+                    }
+                },
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                }
             }
         },
         "node-localstorage": {
@@ -9489,7 +10274,6 @@
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
-            "dev": true,
             "requires": {
                 "copy-descriptor": "^0.1.0",
                 "define-property": "^0.2.5",
@@ -9500,7 +10284,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -9509,7 +10292,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -9544,7 +10326,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.0"
             }
@@ -9574,7 +10355,6 @@
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
-            "dev": true,
             "requires": {
                 "isobject": "^3.0.1"
             }
@@ -9660,6 +10440,11 @@
                 "word-wrap": "^1.2.3"
             }
         },
+        "os-browserify": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/os-browserify/-/os-browserify-0.3.0.tgz",
+            "integrity": "sha1-hUNzx/XCMVkU/Jv8a9gjj92h7Cc="
+        },
         "os-homedir": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
@@ -9718,7 +10503,6 @@
             "version": "2.3.0",
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
             "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "dev": true,
             "requires": {
                 "p-try": "^2.0.0"
             }
@@ -9787,8 +10571,7 @@
         "p-try": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "dev": true
+            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
         },
         "p-waterfall": {
             "version": "1.0.0",
@@ -9828,6 +10611,11 @@
                 "outlayer": "^2.0.0"
             }
         },
+        "pako": {
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+            "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+        },
         "parallel-transform": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/parallel-transform/-/parallel-transform-1.2.0.tgz",
@@ -9847,6 +10635,18 @@
                 "callsites": "^3.0.0"
             }
         },
+        "parse-asn1": {
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.6.tgz",
+            "integrity": "sha512-RnZRo1EPU6JBnra2vGHj0yhp6ebyjBZpmUCLHWiFhxlzvBCCpAuZ7elsBp1PVAbQN0/04VD/19rfzlBSwLstMw==",
+            "requires": {
+                "asn1.js": "^5.2.0",
+                "browserify-aes": "^1.0.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3",
+                "safe-buffer": "^5.1.1"
+            }
+        },
         "parse-github-repo-url": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
@@ -9864,6 +10664,11 @@
                 "json-parse-better-errors": "^1.0.1",
                 "lines-and-columns": "^1.1.6"
             }
+        },
+        "parse-passwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+            "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
         },
         "parse-path": {
             "version": "4.0.1",
@@ -9919,8 +10724,7 @@
         "pascalcase": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=",
-            "dev": true
+            "integrity": "sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ="
         },
         "passport": {
             "version": "0.4.1",
@@ -9974,11 +10778,15 @@
                 "pkginfo": "0.2.x"
             }
         },
+        "path-browserify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+            "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ=="
+        },
         "path-dirname": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/path-dirname/-/path-dirname-1.0.2.tgz",
-            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=",
-            "dev": true
+            "integrity": "sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA="
         },
         "path-exists": {
             "version": "4.0.0",
@@ -10023,6 +10831,18 @@
             "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
             "integrity": "sha1-HUCLP9t2kjuVQ9lvtMnf1TXZy10="
         },
+        "pbkdf2": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.1.tgz",
+            "integrity": "sha512-4Ejy1OPxi9f2tt1rRV7Go7zmfDQ+ZectEQz3VGUQhgq62HtIRPDyG/JtnwIxs6x3uNMwo2V7q1fMvKjb+Tnpqg==",
+            "requires": {
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
+            }
+        },
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
@@ -10036,8 +10856,7 @@
         "pify": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-            "dev": true
+            "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
         },
         "pinkie": {
             "version": "2.0.4",
@@ -10080,8 +10899,7 @@
         "posix-character-classes": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
-            "dev": true
+            "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "prebuild-install": {
             "version": "5.3.5",
@@ -10263,6 +11081,11 @@
             "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.2.2.tgz",
             "integrity": "sha512-I+nkWY212lJ500jLe4tN9tWO7nRiBAVdMv76P9kffZjYhw20raMlW1HSSvS+MLXC9MmbNZCazMrAr+5jEEgTuw=="
         },
+        "process": {
+            "version": "0.11.10",
+            "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+            "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI="
+        },
         "process-nextick-args": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -10327,6 +11150,11 @@
                 "ipaddr.js": "1.9.1"
             }
         },
+        "prr": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
+            "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+        },
         "pseudomap": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -10342,6 +11170,26 @@
             "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
             "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
             "dev": true
+        },
+        "public-encrypt": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.3.tgz",
+            "integrity": "sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==",
+            "requires": {
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1",
+                "safe-buffer": "^5.1.2"
+            },
+            "dependencies": {
+                "bn.js": {
+                    "version": "4.11.9",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+                    "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
+                }
+            }
         },
         "pump": {
             "version": "3.0.0",
@@ -10398,6 +11246,16 @@
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
             "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+        },
+        "querystring-es3": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/querystring-es3/-/querystring-es3-0.2.1.tgz",
+            "integrity": "sha1-nsYfeQSYdXB9aUFFlv2Qek1xHnM="
+        },
         "quick-lru": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
@@ -10408,6 +11266,23 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
             "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs="
+        },
+        "randombytes": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+            "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+            "requires": {
+                "safe-buffer": "^5.1.0"
+            }
+        },
+        "randomfill": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
+            "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
+            "requires": {
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
+            }
         },
         "range-parser": {
             "version": "1.2.1",
@@ -10706,7 +11581,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.2",
                 "safe-regex": "^1.1.0"
@@ -10745,17 +11619,21 @@
                 "rc": "^1.2.8"
             }
         },
+        "remove-trailing-separator": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+            "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
+            "optional": true
+        },
         "repeat-element": {
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.3.tgz",
-            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==",
-            "dev": true
+            "integrity": "sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g=="
         },
         "repeat-string": {
             "version": "1.6.1",
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
-            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-            "dev": true
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
         },
         "repeating": {
             "version": "2.0.1",
@@ -10815,14 +11693,12 @@
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
-            "dev": true
+            "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "require-main-filename": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
-            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
-            "dev": true
+            "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
         },
         "resolve": {
             "version": "1.17.0",
@@ -10836,7 +11712,6 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-2.0.0.tgz",
             "integrity": "sha1-AKn3OHVW4nA46uIyyqNypqWbZlo=",
-            "dev": true,
             "requires": {
                 "resolve-from": "^3.0.0"
             },
@@ -10844,8 +11719,28 @@
                 "resolve-from": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-3.0.0.tgz",
-                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g=",
-                    "dev": true
+                    "integrity": "sha1-six699nWiBvItuZTM17rywoYh0g="
+                }
+            }
+        },
+        "resolve-dir": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+            "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+            "requires": {
+                "expand-tilde": "^2.0.0",
+                "global-modules": "^1.0.0"
+            },
+            "dependencies": {
+                "global-modules": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+                    "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+                    "requires": {
+                        "global-prefix": "^1.0.1",
+                        "is-windows": "^1.0.1",
+                        "resolve-dir": "^1.0.0"
+                    }
                 }
             }
         },
@@ -10858,8 +11753,7 @@
         "resolve-url": {
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
-            "dev": true
+            "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo="
         },
         "responselike": {
             "version": "1.0.2",
@@ -10883,8 +11777,7 @@
         "ret": {
             "version": "0.1.15",
             "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-            "dev": true
+            "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
         },
         "retry": {
             "version": "0.10.1",
@@ -10897,6 +11790,15 @@
             "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
             "requires": {
                 "glob": "^7.1.3"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "run-async": {
@@ -10944,7 +11846,6 @@
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
-            "dev": true,
             "requires": {
                 "ret": "~0.1.10"
             }
@@ -10953,6 +11854,16 @@
             "version": "2.1.2",
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+        },
+        "schema-utils": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
+            "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+            "requires": {
+                "@types/json-schema": "^7.0.4",
+                "ajv": "^6.12.2",
+                "ajv-keywords": "^3.4.1"
+            }
         },
         "select": {
             "version": "1.1.2",
@@ -11051,6 +11962,14 @@
                 }
             }
         },
+        "serialize-javascript": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+            "integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+            "requires": {
+                "randombytes": "^2.1.0"
+            }
+        },
         "serve-static": {
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.14.1.tgz",
@@ -11071,7 +11990,6 @@
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
             "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
                 "is-extendable": "^0.1.1",
@@ -11083,7 +12001,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -11099,6 +12016,15 @@
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
             "integrity": "sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw=="
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
         },
         "sha1": {
             "version": "1.1.1",
@@ -11214,7 +12140,6 @@
             "version": "0.8.2",
             "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-            "dev": true,
             "requires": {
                 "base": "^0.11.1",
                 "debug": "^2.2.0",
@@ -11230,7 +12155,6 @@
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
                     "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-                    "dev": true,
                     "requires": {
                         "ms": "2.0.0"
                     }
@@ -11239,7 +12163,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -11248,7 +12171,6 @@
                     "version": "2.0.1",
                     "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
                     "requires": {
                         "is-extendable": "^0.1.0"
                     }
@@ -11256,8 +12178,7 @@
                 "ms": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-                    "dev": true
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 }
             }
         },
@@ -11265,7 +12186,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-            "dev": true,
             "requires": {
                 "define-property": "^1.0.0",
                 "isobject": "^3.0.0",
@@ -11276,7 +12196,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^1.0.0"
                     }
@@ -11285,7 +12204,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -11294,7 +12212,6 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
-                    "dev": true,
                     "requires": {
                         "kind-of": "^6.0.0"
                     }
@@ -11303,7 +12220,6 @@
                     "version": "1.0.2",
                     "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
-                    "dev": true,
                     "requires": {
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
@@ -11316,7 +12232,6 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.2.0"
             },
@@ -11325,7 +12240,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -11472,16 +12386,47 @@
             "resolved": "https://registry.npmjs.org/soundjs/-/soundjs-1.0.1.tgz",
             "integrity": "sha512-MgFPvmKYfpcNiE3X5XybNvScie3DMQlZgmNzUn4puBcpw64f4LqjH/fhM8Sb/eTJ8hK57Crr7mWy0bfJOqPj6Q=="
         },
+        "source-list-map": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/source-list-map/-/source-list-map-2.0.1.tgz",
+            "integrity": "sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw=="
+        },
         "source-map": {
             "version": "0.5.7",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
+        "source-map-loader": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-1.0.1.tgz",
+            "integrity": "sha512-DE4CJyfCVoxFLsHyuVE9Sjcib8cs5qdmOq3wcev1Un/r6F2AfQJDhag4rzpPPA48A2QZyV3CTbc+NGoFMfKIOQ==",
+            "requires": {
+                "data-urls": "^2.0.0",
+                "iconv-lite": "^0.5.1",
+                "loader-utils": "^2.0.0",
+                "schema-utils": "^2.6.6",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "iconv-lite": {
+                    "version": "0.5.2",
+                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
+                    "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
+                    "requires": {
+                        "safer-buffer": ">= 2.1.2 < 3"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
+        },
         "source-map-resolve": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
             "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
-            "dev": true,
             "requires": {
                 "atob": "^2.1.2",
                 "decode-uri-component": "^0.2.0",
@@ -11490,11 +12435,26 @@
                 "urix": "^0.1.0"
             }
         },
+        "source-map-support": {
+            "version": "0.5.19",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+            "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
+            "requires": {
+                "buffer-from": "^1.0.0",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
+        },
         "source-map-url": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
-            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
-            "dev": true
+            "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM="
         },
         "spdx-correct": {
             "version": "3.1.1",
@@ -11541,7 +12501,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-            "dev": true,
             "requires": {
                 "extend-shallow": "^3.0.0"
             }
@@ -11601,7 +12560,6 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
-            "dev": true,
             "requires": {
                 "define-property": "^0.2.5",
                 "object-copy": "^0.1.0"
@@ -11611,7 +12569,6 @@
                     "version": "0.2.5",
                     "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-                    "dev": true,
                     "requires": {
                         "is-descriptor": "^0.1.0"
                     }
@@ -11636,6 +12593,15 @@
                 "qs": "^6.1.0"
             }
         },
+        "stream-browserify": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.2.tgz",
+            "integrity": "sha512-nX6hmklHs/gr2FuxYDltq8fJA1GDlxKQCz8O/IM4atRqBH8OORmBNgfvW5gG10GT/qQ9u0CzIvr2X5Pkt6ntqg==",
+            "requires": {
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
+            }
+        },
         "stream-each": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.3.tgz",
@@ -11643,6 +12609,18 @@
             "requires": {
                 "end-of-stream": "^1.1.0",
                 "stream-shift": "^1.0.0"
+            }
+        },
+        "stream-http": {
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+            "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
+            "requires": {
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "stream-shift": {
@@ -11659,7 +12637,6 @@
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
             "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-            "dev": true,
             "requires": {
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
@@ -11669,14 +12646,12 @@
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^4.1.0"
                     }
@@ -11816,6 +12791,11 @@
                 "string-width": "^3.0.0"
             }
         },
+        "tapable": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
+            "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+        },
         "tar": {
             "version": "4.4.13",
             "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
@@ -11900,6 +12880,61 @@
             "integrity": "sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==",
             "dev": true
         },
+        "terser": {
+            "version": "4.8.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.0.tgz",
+            "integrity": "sha512-EAPipTNeWsb/3wLPeup1tVPaXfIaU68xMnVdPafIL1TV05OhASArYyIfFvnvJCNrR2NIOvDVNNTFRa+Re2MWyw==",
+            "requires": {
+                "commander": "^2.20.0",
+                "source-map": "~0.6.1",
+                "source-map-support": "~0.5.12"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
+        },
+        "terser-webpack-plugin": {
+            "version": "1.4.5",
+            "resolved": "https://registry.npmjs.org/terser-webpack-plugin/-/terser-webpack-plugin-1.4.5.tgz",
+            "integrity": "sha512-04Rfe496lN8EYruwi6oPQkG0vo8C+HT49X687FZnpPF0qMAIHONI6HEXYPKDOE8e5HjXTyKfqRd/agHtH0kOtw==",
+            "requires": {
+                "cacache": "^12.0.2",
+                "find-cache-dir": "^2.1.0",
+                "is-wsl": "^1.1.0",
+                "schema-utils": "^1.0.0",
+                "serialize-javascript": "^4.0.0",
+                "source-map": "^0.6.1",
+                "terser": "^4.1.2",
+                "webpack-sources": "^1.4.0",
+                "worker-farm": "^1.7.0"
+            },
+            "dependencies": {
+                "is-wsl": {
+                    "version": "1.1.0",
+                    "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
+                    "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
+                },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                },
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
+        },
         "text-extensions": {
             "version": "1.9.0",
             "resolved": "https://registry.npmjs.org/text-extensions/-/text-extensions-1.9.0.tgz",
@@ -11950,6 +12985,14 @@
             "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
+        "timers-browserify": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
+            "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+            "requires": {
+                "setimmediate": "^1.0.4"
+            }
+        },
         "tiny-emitter": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
@@ -11969,6 +13012,11 @@
             "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
             "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
         },
+        "to-arraybuffer": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/to-arraybuffer/-/to-arraybuffer-1.0.1.tgz",
+            "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M="
+        },
         "to-fast-properties": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
@@ -11978,7 +13026,6 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-            "dev": true,
             "requires": {
                 "kind-of": "^3.0.2"
             },
@@ -11987,7 +13034,6 @@
                     "version": "3.2.2",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "dev": true,
                     "requires": {
                         "is-buffer": "^1.1.5"
                     }
@@ -12004,7 +13050,6 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-            "dev": true,
             "requires": {
                 "define-property": "^2.0.2",
                 "extend-shallow": "^3.0.2",
@@ -12016,7 +13061,6 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
-            "dev": true,
             "requires": {
                 "is-number": "^3.0.0",
                 "repeat-string": "^1.6.1"
@@ -12081,6 +13125,91 @@
             "integrity": "sha1-n5up2e+odkw4dpi8v+sshI8RrbM=",
             "dev": true
         },
+        "ts-loader": {
+            "version": "8.0.2",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.2.tgz",
+            "integrity": "sha512-oYT7wOTUawYXQ8XIDsRhziyW0KUEV38jISYlE+9adP6tDtG+O5GkRe4QKQXrHVH4mJJ88DysvEtvGP65wMLlhg==",
+            "requires": {
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^4.0.0",
+                "semver": "^6.0.0"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+                },
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "loader-utils": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "micromatch": {
+                    "version": "4.0.2",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "requires": {
+                        "braces": "^3.0.1",
+                        "picomatch": "^2.0.5"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
         "tslib": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
@@ -12102,6 +13231,11 @@
                     "dev": true
                 }
             }
+        },
+        "tty-browserify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/tty-browserify/-/tty-browserify-0.0.0.tgz",
+            "integrity": "sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY="
         },
         "tunnel-agent": {
             "version": "0.6.0",
@@ -12290,7 +13424,6 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
             "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-            "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
@@ -12355,7 +13488,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
-            "dev": true,
             "requires": {
                 "has-value": "^0.3.1",
                 "isobject": "^3.0.0"
@@ -12365,7 +13497,6 @@
                     "version": "0.3.1",
                     "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
-                    "dev": true,
                     "requires": {
                         "get-value": "^2.0.3",
                         "has-values": "^0.1.4",
@@ -12376,7 +13507,6 @@
                             "version": "2.1.0",
                             "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
                             "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-                            "dev": true,
                             "requires": {
                                 "isarray": "1.0.0"
                             }
@@ -12386,16 +13516,14 @@
                 "has-values": {
                     "version": "0.1.4",
                     "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E=",
-                    "dev": true
+                    "integrity": "sha1-bWHeldkd/Km5oCCJrThL/49it3E="
                 }
             }
         },
         "upath": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/upath/-/upath-1.2.0.tgz",
-            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==",
-            "dev": true
+            "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
         },
         "update-notifier": {
             "version": "4.1.0",
@@ -12481,8 +13609,23 @@
         "urix": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
-            "dev": true
+            "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
+        },
+        "url": {
+            "version": "0.11.0",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
+            "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+                }
+            }
         },
         "url-parse-lax": {
             "version": "3.0.0",
@@ -12501,8 +13644,22 @@
         "use": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-            "dev": true
+            "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+        },
+        "util": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.11.1.tgz",
+            "integrity": "sha512-HShAsny+zS2TZfaXxD9tYj4HQGlBezXZMZuM/S5PKLLoZkShZiGk9o5CzukI1LVHZvjdvZ2Sj1aW/Ndn2NB/HQ==",
+            "requires": {
+                "inherits": "2.0.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.3",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                    "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+                }
+            }
         },
         "util-deprecate": {
             "version": "1.0.2",
@@ -12531,8 +13688,7 @@
         "v8-compile-cache": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.1.tgz",
-            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ==",
-            "dev": true
+            "integrity": "sha512-8OQ9CL+VWyt3JStj7HX7/ciTL2V3Rl1Wf5OL+SNTm0yK1KvtReVulksyeRnCANHHuUxHlQig+JJDlUhBt1NQDQ=="
         },
         "validate-npm-package-license": {
             "version": "3.0.4",
@@ -12573,12 +13729,188 @@
                 "extsprintf": "^1.2.0"
             }
         },
+        "vm-browserify": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
+            "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
+        },
         "walk": {
             "version": "2.3.14",
             "resolved": "https://registry.npmjs.org/walk/-/walk-2.3.14.tgz",
             "integrity": "sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==",
             "requires": {
                 "foreachasync": "^3.0.0"
+            }
+        },
+        "watchpack": {
+            "version": "1.7.4",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.7.4.tgz",
+            "integrity": "sha512-aWAgTW4MoSJzZPAicljkO1hsi1oKj/RRq/OJQh2PKI2UKL04c2Bs+MBOB+BBABHTXJpf9mCwHN7ANCvYsvY2sg==",
+            "requires": {
+                "chokidar": "^3.4.1",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0",
+                "watchpack-chokidar2": "^2.0.0"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "3.0.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "optional": true,
+                    "requires": {
+                        "fill-range": "^7.0.1"
+                    }
+                },
+                "chokidar": {
+                    "version": "3.4.2",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+                    "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
+                    "optional": true,
+                    "requires": {
+                        "anymatch": "~3.1.1",
+                        "braces": "~3.0.2",
+                        "fsevents": "~2.1.2",
+                        "glob-parent": "~5.1.0",
+                        "is-binary-path": "~2.1.0",
+                        "is-glob": "~4.0.1",
+                        "normalize-path": "~3.0.0",
+                        "readdirp": "~3.4.0"
+                    }
+                },
+                "fill-range": {
+                    "version": "7.0.1",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "optional": true,
+                    "requires": {
+                        "to-regex-range": "^5.0.1"
+                    }
+                },
+                "is-number": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "optional": true
+                },
+                "to-regex-range": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "optional": true,
+                    "requires": {
+                        "is-number": "^7.0.0"
+                    }
+                }
+            }
+        },
+        "watchpack-chokidar2": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/watchpack-chokidar2/-/watchpack-chokidar2-2.0.0.tgz",
+            "integrity": "sha512-9TyfOyN/zLUbA288wZ8IsMZ+6cbzvsNyEzSBp6e/zkifi6xxbl8SmQ/CxQq32k8NNqrdVEVUVSEf56L4rQ/ZxA==",
+            "optional": true,
+            "requires": {
+                "chokidar": "^2.1.8"
+            },
+            "dependencies": {
+                "anymatch": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-2.0.0.tgz",
+                    "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
+                    "optional": true,
+                    "requires": {
+                        "micromatch": "^3.1.4",
+                        "normalize-path": "^2.1.1"
+                    },
+                    "dependencies": {
+                        "normalize-path": {
+                            "version": "2.1.1",
+                            "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+                            "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+                            "optional": true,
+                            "requires": {
+                                "remove-trailing-separator": "^1.0.1"
+                            }
+                        }
+                    }
+                },
+                "binary-extensions": {
+                    "version": "1.13.1",
+                    "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.13.1.tgz",
+                    "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
+                    "optional": true
+                },
+                "chokidar": {
+                    "version": "2.1.8",
+                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
+                    "integrity": "sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==",
+                    "optional": true,
+                    "requires": {
+                        "anymatch": "^2.0.0",
+                        "async-each": "^1.0.1",
+                        "braces": "^2.3.2",
+                        "fsevents": "^1.2.7",
+                        "glob-parent": "^3.1.0",
+                        "inherits": "^2.0.3",
+                        "is-binary-path": "^1.0.0",
+                        "is-glob": "^4.0.0",
+                        "normalize-path": "^3.0.0",
+                        "path-is-absolute": "^1.0.0",
+                        "readdirp": "^2.2.1",
+                        "upath": "^1.1.1"
+                    }
+                },
+                "fsevents": {
+                    "version": "1.2.13",
+                    "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
+                    "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
+                    "optional": true,
+                    "requires": {
+                        "bindings": "^1.5.0",
+                        "nan": "^2.12.1"
+                    }
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "optional": true,
+                    "requires": {
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "optional": true,
+                            "requires": {
+                                "is-extglob": "^2.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-binary-path": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
+                    "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
+                    "optional": true,
+                    "requires": {
+                        "binary-extensions": "^1.0.0"
+                    }
+                },
+                "readdirp": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
+                    "integrity": "sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==",
+                    "optional": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "micromatch": "^3.1.10",
+                        "readable-stream": "^2.0.2"
+                    }
+                }
             }
         },
         "wcwidth": {
@@ -12595,10 +13927,279 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
             "integrity": "sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg=="
         },
+        "webpack": {
+            "version": "4.44.1",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.44.1.tgz",
+            "integrity": "sha512-4UOGAohv/VGUNQJstzEywwNxqX417FnjZgZJpJQegddzPmTvph37eBIRbRTfdySXzVtJXLJfbMN3mMYhM6GdmQ==",
+            "requires": {
+                "@webassemblyjs/ast": "1.9.0",
+                "@webassemblyjs/helper-module-context": "1.9.0",
+                "@webassemblyjs/wasm-edit": "1.9.0",
+                "@webassemblyjs/wasm-parser": "1.9.0",
+                "acorn": "^6.4.1",
+                "ajv": "^6.10.2",
+                "ajv-keywords": "^3.4.1",
+                "chrome-trace-event": "^1.0.2",
+                "enhanced-resolve": "^4.3.0",
+                "eslint-scope": "^4.0.3",
+                "json-parse-better-errors": "^1.0.2",
+                "loader-runner": "^2.4.0",
+                "loader-utils": "^1.2.3",
+                "memory-fs": "^0.4.1",
+                "micromatch": "^3.1.10",
+                "mkdirp": "^0.5.3",
+                "neo-async": "^2.6.1",
+                "node-libs-browser": "^2.2.1",
+                "schema-utils": "^1.0.0",
+                "tapable": "^1.1.3",
+                "terser-webpack-plugin": "^1.4.3",
+                "watchpack": "^1.7.4",
+                "webpack-sources": "^1.4.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "6.4.1",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+                },
+                "eslint-scope": {
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+                    "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+                    "requires": {
+                        "esrecurse": "^4.1.0",
+                        "estraverse": "^4.1.1"
+                    }
+                },
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "loader-utils": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "memory-fs": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
+                    "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
+                    "requires": {
+                        "errno": "^0.1.3",
+                        "readable-stream": "^2.0.1"
+                    }
+                },
+                "schema-utils": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
+                    "requires": {
+                        "ajv": "^6.1.0",
+                        "ajv-errors": "^1.0.0",
+                        "ajv-keywords": "^3.1.0"
+                    }
+                }
+            }
+        },
+        "webpack-cli": {
+            "version": "3.3.12",
+            "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-3.3.12.tgz",
+            "integrity": "sha512-NVWBaz9k839ZH/sinurM+HcDvJOTXwSjYp1ku+5XKeOC03z8v5QitnK/x+lAxGXFyhdayoIf/GOpv85z3/xPag==",
+            "requires": {
+                "chalk": "^2.4.2",
+                "cross-spawn": "^6.0.5",
+                "enhanced-resolve": "^4.1.1",
+                "findup-sync": "^3.0.0",
+                "global-modules": "^2.0.0",
+                "import-local": "^2.0.0",
+                "interpret": "^1.4.0",
+                "loader-utils": "^1.4.0",
+                "supports-color": "^6.1.0",
+                "v8-compile-cache": "^2.1.1",
+                "yargs": "^13.3.2"
+            },
+            "dependencies": {
+                "chalk": {
+                    "version": "2.4.2",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "requires": {
+                        "ansi-styles": "^3.2.1",
+                        "escape-string-regexp": "^1.0.5",
+                        "supports-color": "^5.3.0"
+                    },
+                    "dependencies": {
+                        "supports-color": {
+                            "version": "5.5.0",
+                            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                            "requires": {
+                                "has-flag": "^3.0.0"
+                            }
+                        }
+                    }
+                },
+                "cross-spawn": {
+                    "version": "6.0.5",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+                    "requires": {
+                        "nice-try": "^1.0.4",
+                        "path-key": "^2.0.1",
+                        "semver": "^5.5.0",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "find-up": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+                    "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+                    "requires": {
+                        "locate-path": "^3.0.0"
+                    }
+                },
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                },
+                "loader-utils": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
+                    "requires": {
+                        "big.js": "^5.2.2",
+                        "emojis-list": "^3.0.0",
+                        "json5": "^1.0.1"
+                    }
+                },
+                "locate-path": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+                    "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+                    "requires": {
+                        "p-locate": "^3.0.0",
+                        "path-exists": "^3.0.0"
+                    }
+                },
+                "p-locate": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+                    "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+                    "requires": {
+                        "p-limit": "^2.0.0"
+                    }
+                },
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+                },
+                "path-key": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+                    "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+                },
+                "semver": {
+                    "version": "5.7.1",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+                },
+                "shebang-command": {
+                    "version": "1.2.0",
+                    "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+                    "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+                    "requires": {
+                        "shebang-regex": "^1.0.0"
+                    }
+                },
+                "shebang-regex": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+                    "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+                },
+                "supports-color": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                    "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                    "requires": {
+                        "has-flag": "^3.0.0"
+                    }
+                },
+                "which": {
+                    "version": "1.3.1",
+                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+                    "requires": {
+                        "isexe": "^2.0.0"
+                    }
+                },
+                "yargs": {
+                    "version": "13.3.2",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
+                    "integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+                    "requires": {
+                        "cliui": "^5.0.0",
+                        "find-up": "^3.0.0",
+                        "get-caller-file": "^2.0.1",
+                        "require-directory": "^2.1.1",
+                        "require-main-filename": "^2.0.0",
+                        "set-blocking": "^2.0.0",
+                        "string-width": "^3.0.0",
+                        "which-module": "^2.0.0",
+                        "y18n": "^4.0.0",
+                        "yargs-parser": "^13.1.2"
+                    }
+                },
+                "yargs-parser": {
+                    "version": "13.1.2",
+                    "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
+                    "integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+                    "requires": {
+                        "camelcase": "^5.0.0",
+                        "decamelize": "^1.2.0"
+                    }
+                }
+            }
+        },
+        "webpack-sources": {
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
+            "integrity": "sha512-lgTS3Xhv1lCOKo7SA5TjKXMjpSM4sBjNV5+q2bqesbSPs5FjGmU6jjtBSkX9b4qW87vDIsCIlUPOEhbZrMdjeQ==",
+            "requires": {
+                "source-list-map": "^2.0.0",
+                "source-map": "~0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
+        },
         "whatwg-fetch": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
             "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
+        },
+        "whatwg-mimetype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
+            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
         },
         "whatwg-url": {
             "version": "7.1.0",
@@ -12622,8 +14223,7 @@
         "which-module": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
-            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
-            "dev": true
+            "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "which-pm-runs": {
             "version": "1.0.0",
@@ -12737,11 +14337,18 @@
             "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
             "dev": true
         },
+        "worker-farm": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/worker-farm/-/worker-farm-1.7.0.tgz",
+            "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
+            "requires": {
+                "errno": "~0.1.7"
+            }
+        },
         "wrap-ansi": {
             "version": "5.1.0",
             "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
             "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-            "dev": true,
             "requires": {
                 "ansi-styles": "^3.2.0",
                 "string-width": "^3.0.0",
@@ -12751,14 +14358,12 @@
                 "ansi-regex": {
                     "version": "4.1.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-                    "dev": true
+                    "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
                 },
                 "strip-ansi": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
                     "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-                    "dev": true,
                     "requires": {
                         "ansi-regex": "^4.1.0"
                     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2321,6 +2321,11 @@
                 "defer-to-connect": "^1.0.1"
             }
         },
+        "@types/anymatch": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
+            "integrity": "sha512-/+CRPXpBDpo2RK9C68N3b2cOvO0Cf5B9aPijHsoDQTHivnGSObdOF2BRQOYjojWTDy6nQvMjmqRXIxH55VjxxA=="
+        },
         "@types/body-parser": {
             "version": "1.19.0",
             "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.0.tgz",
@@ -2408,7 +2413,6 @@
             "version": "7.1.3",
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
             "integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
-            "dev": true,
             "requires": {
                 "@types/minimatch": "*",
                 "@types/node": "*"
@@ -2441,7 +2445,8 @@
         "@types/json-schema": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-            "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ=="
+            "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+            "dev": true
         },
         "@types/lru-cache": {
             "version": "4.1.2",
@@ -2456,8 +2461,7 @@
         "@types/minimatch": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
-            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
-            "dev": true
+            "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
         },
         "@types/minimist": {
             "version": "1.2.0",
@@ -2603,6 +2607,11 @@
                 "@types/preloadjs": "*"
             }
         },
+        "@types/source-list-map": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+            "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA=="
+        },
         "@types/spotify-api": {
             "version": "0.0.4",
             "resolved": "https://registry.npmjs.org/@types/spotify-api/-/spotify-api-0.0.4.tgz",
@@ -2616,6 +2625,11 @@
                 "@types/spotify-api": "*"
             }
         },
+        "@types/tapable": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.6.tgz",
+            "integrity": "sha512-W+bw9ds02rAQaMvaLYxAbJ6cvguW/iJXNT6lTssS1ps6QdrMKttqEAMEG/b5CR8TZl3/L7/lH0ZV5nNR1LXikA=="
+        },
         "@types/tough-cookie": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.0.tgz",
@@ -2628,6 +2642,58 @@
             "requires": {
                 "@types/node": "*",
                 "@types/request": "*"
+            }
+        },
+        "@types/uglify-js": {
+            "version": "3.9.3",
+            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
+            "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+            "requires": {
+                "source-map": "^0.6.1"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
+        },
+        "@types/webpack": {
+            "version": "4.41.21",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
+            "integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+            "requires": {
+                "@types/anymatch": "*",
+                "@types/node": "*",
+                "@types/tapable": "*",
+                "@types/uglify-js": "*",
+                "@types/webpack-sources": "*",
+                "source-map": "^0.6.0"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.6.1",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+                }
+            }
+        },
+        "@types/webpack-sources": {
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
+            "integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
+            "requires": {
+                "@types/node": "*",
+                "@types/source-list-map": "*",
+                "source-map": "^0.7.3"
+            },
+            "dependencies": {
+                "source-map": {
+                    "version": "0.7.3",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
+                    "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
+                }
             }
         },
         "@types/ws": {
@@ -3004,11 +3070,6 @@
                 "through": ">=2.2.7 <3"
             }
         },
-        "abab": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.4.tgz",
-            "integrity": "sha512-Eu9ELJWCz/c1e9gTiCY+FceWxcqzjYEbqMgtndnuSqZSUCOL73TWNK2mHfIj4Cw2E/ongOp+JISVNCmovt2KYQ=="
-        },
         "abbrev": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -3205,7 +3266,6 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
             "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "dev": true,
             "requires": {
                 "array-uniq": "^1.0.1"
             }
@@ -3213,8 +3273,7 @@
         "array-uniq": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
-            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
-            "dev": true
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY="
         },
         "array-unique": {
             "version": "0.3.2",
@@ -4251,6 +4310,15 @@
                 }
             }
         },
+        "clean-webpack-plugin": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/clean-webpack-plugin/-/clean-webpack-plugin-3.0.0.tgz",
+            "integrity": "sha512-MciirUH5r+cYLGCOL5JX/ZLzOZbVr1ot3Fw+KcvbhUb6PM+yycqd9ZhIlcigQ5gl+XhppNmw3bEFuaaMNyLj3A==",
+            "requires": {
+                "@types/webpack": "^4.4.31",
+                "del": "^4.1.1"
+            }
+        },
         "cli-boxes": {
             "version": "2.2.0",
             "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
@@ -5115,41 +5183,6 @@
                 "assert-plus": "^1.0.0"
             }
         },
-        "data-urls": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
-            "integrity": "sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==",
-            "requires": {
-                "abab": "^2.0.3",
-                "whatwg-mimetype": "^2.3.0",
-                "whatwg-url": "^8.0.0"
-            },
-            "dependencies": {
-                "tr46": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
-                    "integrity": "sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==",
-                    "requires": {
-                        "punycode": "^2.1.1"
-                    }
-                },
-                "webidl-conversions": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-5.0.0.tgz",
-                    "integrity": "sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA=="
-                },
-                "whatwg-url": {
-                    "version": "8.1.0",
-                    "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-8.1.0.tgz",
-                    "integrity": "sha512-vEIkwNi9Hqt4TV9RdnaBPNt+E2Sgmo3gePebCRgZ1R7g6d23+53zCTnuB0amKI4AXq6VM8jj2DUAa0S1vjJxkw==",
-                    "requires": {
-                        "lodash.sortby": "^4.7.0",
-                        "tr46": "^2.0.2",
-                        "webidl-conversions": "^5.0.0"
-                    }
-                }
-            }
-        },
         "dateformat": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
@@ -5293,6 +5326,41 @@
                         "is-accessor-descriptor": "^1.0.0",
                         "is-data-descriptor": "^1.0.0",
                         "kind-of": "^6.0.2"
+                    }
+                }
+            }
+        },
+        "del": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+            "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+            "requires": {
+                "@types/glob": "^7.1.1",
+                "globby": "^6.1.0",
+                "is-path-cwd": "^2.0.0",
+                "is-path-in-cwd": "^2.0.0",
+                "p-map": "^2.0.0",
+                "pify": "^4.0.1",
+                "rimraf": "^2.6.3"
+            },
+            "dependencies": {
+                "globby": {
+                    "version": "6.1.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+                    "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
+                    "requires": {
+                        "array-union": "^1.0.1",
+                        "glob": "^7.0.3",
+                        "object-assign": "^4.0.1",
+                        "pify": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "2.3.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
+                        }
                     }
                 }
             }
@@ -8585,6 +8653,29 @@
             "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
             "dev": true
         },
+        "is-path-cwd": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+            "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ=="
+        },
+        "is-path-in-cwd": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+            "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+            "requires": {
+                "is-path-inside": "^2.1.0"
+            },
+            "dependencies": {
+                "is-path-inside": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+                    "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+                    "requires": {
+                        "path-is-inside": "^1.0.2"
+                    }
+                }
+            }
+        },
         "is-path-inside": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.2.tgz",
@@ -9000,13 +9091,23 @@
             "integrity": "sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw=="
         },
         "loader-utils": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.0.tgz",
-            "integrity": "sha512-rP4F0h2RaWSvPEkD7BLDFQnvSf+nK+wr3ESUjNTyAGobqrijmW92zc+SO6d4p4B1wh7+B/Jg1mkQe5NYUEHtHQ==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
+            "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
             "requires": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
-                "json5": "^2.1.2"
+                "json5": "^1.0.1"
+            },
+            "dependencies": {
+                "json5": {
+                    "version": "1.0.1",
+                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+                    "requires": {
+                        "minimist": "^1.2.0"
+                    }
+                }
             }
         },
         "localforage": {
@@ -10519,8 +10620,7 @@
         "p-map": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-            "dev": true
+            "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw=="
         },
         "p-map-series": {
             "version": "1.0.0",
@@ -10861,14 +10961,12 @@
         "pinkie": {
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
-            "dev": true
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
         },
         "pinkie-promise": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
             "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-            "dev": true,
             "requires": {
                 "pinkie": "^2.0.0"
             }
@@ -11856,13 +11954,13 @@
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "schema-utils": {
-            "version": "2.7.0",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.7.0.tgz",
-            "integrity": "sha512-0ilKFI6QQF5nxDZLFn2dMjvc4hjg/Wkg7rHd3jK6/A4a1Hl9VFdQWvgB1UMGoU94pad1P/8N7fMcEnLnSiju8A==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
+            "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
             "requires": {
-                "@types/json-schema": "^7.0.4",
-                "ajv": "^6.12.2",
-                "ajv-keywords": "^3.4.1"
+                "ajv": "^6.1.0",
+                "ajv-errors": "^1.0.0",
+                "ajv-keywords": "^3.1.0"
             }
         },
         "select": {
@@ -12396,33 +12494,6 @@
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
             "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         },
-        "source-map-loader": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/source-map-loader/-/source-map-loader-1.0.1.tgz",
-            "integrity": "sha512-DE4CJyfCVoxFLsHyuVE9Sjcib8cs5qdmOq3wcev1Un/r6F2AfQJDhag4rzpPPA48A2QZyV3CTbc+NGoFMfKIOQ==",
-            "requires": {
-                "data-urls": "^2.0.0",
-                "iconv-lite": "^0.5.1",
-                "loader-utils": "^2.0.0",
-                "schema-utils": "^2.6.6",
-                "source-map": "^0.6.0"
-            },
-            "dependencies": {
-                "iconv-lite": {
-                    "version": "0.5.2",
-                    "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.5.2.tgz",
-                    "integrity": "sha512-kERHXvpSaB4aU3eANwidg79K8FlrN77m8G9V+0vOR3HYaRifrlwMEpT7ZBJqLSEIHnEgJTHcWK82wwLwwKwtag==",
-                    "requires": {
-                        "safer-buffer": ">= 2.1.2 < 3"
-                    }
-                },
-                "source-map": {
-                    "version": "0.6.1",
-                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-                    "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-                }
-            }
-        },
         "source-map-resolve": {
             "version": "0.5.3",
             "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
@@ -12918,16 +12989,6 @@
                     "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
                     "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
                 },
-                "schema-utils": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-                    "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-errors": "^1.0.0",
-                        "ajv-keywords": "^3.1.0"
-                    }
-                },
                 "source-map": {
                     "version": "0.6.1",
                     "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13167,24 +13228,6 @@
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
                     "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-                },
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
                 },
                 "micromatch": {
                     "version": "4.0.2",
@@ -13971,24 +14014,6 @@
                         "estraverse": "^4.1.1"
                     }
                 },
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
-                    }
-                },
                 "memory-fs": {
                     "version": "0.4.1",
                     "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -13996,16 +14021,6 @@
                     "requires": {
                         "errno": "^0.1.3",
                         "readable-stream": "^2.0.1"
-                    }
-                },
-                "schema-utils": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-1.0.0.tgz",
-                    "integrity": "sha512-i27Mic4KovM/lnGsy8whRCHhc7VicJajAjTrYg11K9zfZXnYIt4k5F+kZkwjnrhKzLic/HLU4j11mjsz2G/75g==",
-                    "requires": {
-                        "ajv": "^6.1.0",
-                        "ajv-errors": "^1.0.0",
-                        "ajv-keywords": "^3.1.0"
                     }
                 }
             }
@@ -14066,24 +14081,6 @@
                     "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
                     "requires": {
                         "locate-path": "^3.0.0"
-                    }
-                },
-                "json5": {
-                    "version": "1.0.1",
-                    "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-                    "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-                    "requires": {
-                        "minimist": "^1.2.0"
-                    }
-                },
-                "loader-utils": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-                    "integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-                    "requires": {
-                        "big.js": "^5.2.2",
-                        "emojis-list": "^3.0.0",
-                        "json5": "^1.0.1"
                     }
                 },
                 "locate-path": {
@@ -14195,11 +14192,6 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
             "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
-        },
-        "whatwg-mimetype": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",
-            "integrity": "sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g=="
         },
         "whatwg-url": {
             "version": "7.1.0",


### PR DESCRIPTION
Fixes #30.

Adds webpack to build the dashboard because importing crypto-js using plain html and getting it to work in TS is not a beautiful experience and this way I can import the decryption logic from the main core.

- [X] Implement logic to decrypt the config in the dashboard, get update handlers and so on
- [x] Use data from the crypto module of the dashboard instead of the replicants
- [x] Remove the unencrypted replicants (the service replicant will stay because it doesn't contain sensitive data)