### PR TITLE
Don't save services in replicants

### DIFF
--- a/nodecg-io-core/dashboard/authentication.ts
+++ b/nodecg-io-core/dashboard/authentication.ts
@@ -2,7 +2,7 @@
 
 import { LoadFrameworkMessage } from "nodecg-io-core/extension/messageManager";
 import { updateMonacoLayout } from "./serviceInstance";
-import { setPassword, isPasswordSet, encryptedData as encryptedDataReplicant } from "./crypto";
+import { setPassword, isPasswordSet } from "./crypto";
 
 // HTML elements
 const spanLoaded = document.getElementById("spanLoaded") as HTMLSpanElement;
@@ -81,14 +81,9 @@ export async function loadFramework(): Promise<void> {
         });
     }
 
-    // Ensures that the encrypteDataReplicant has been declared because it is needed by setPassword()
-    // This is especially needed when handling a reconnect as the replicant takes time to declare
-    // and the password check is usually faster than that.
-    await NodeCG.waitForReplicants(encryptedDataReplicant);
-
     // If the framework was already loaded then this check actually checks the password.
     // If the above if was entered this just sets it because we assume that the password didn't change.
-    if (!setPassword(password)) {
+    if (!(await setPassword(password))) {
         wrongPassword();
     }
 

--- a/nodecg-io-core/dashboard/serviceInstance.ts
+++ b/nodecg-io-core/dashboard/serviceInstance.ts
@@ -80,7 +80,7 @@ export function onInstanceSelectChange(value: string): void {
 
 function showConfig(value: string) {
     const inst = config.data?.instances[value];
-    const service = config.data?.services?.find((svc) => svc.serviceType === inst?.serviceType);
+    const service = config.data?.services.find((svc) => svc.serviceType === inst?.serviceType);
 
     editor?.updateOptions({
         readOnly: false,
@@ -179,7 +179,7 @@ export function createInstance(): void {
 // Render functions of Replicants
 
 function renderServices() {
-    if (config.data?.services === undefined) {
+    if (!config.data) {
         return;
     }
     updateOptionsArr(

--- a/nodecg-io-core/extension/index.ts
+++ b/nodecg-io-core/extension/index.ts
@@ -27,7 +27,7 @@ module.exports = (nodecg: NodeCG): NodeCGIOCore => {
     const instanceManager = new InstanceManager(nodecg, serviceManager, bundleManager);
     const persistenceManager = new PersistenceManager(nodecg, instanceManager, bundleManager);
 
-    MessageManager.registerMessageHandlers(nodecg, instanceManager, bundleManager, persistenceManager);
+    MessageManager.registerMessageHandlers(nodecg, serviceManager, instanceManager, bundleManager, persistenceManager);
 
     registerExitHandlers(nodecg, bundleManager, instanceManager, serviceManager);
 

--- a/nodecg-io-core/extension/serviceBundle.ts
+++ b/nodecg-io-core/extension/serviceBundle.ts
@@ -40,6 +40,8 @@ export abstract class ServiceBundle<R, C extends ServiceClient<unknown>> impleme
         // The service is saved in a Replicant and nodecg tries to serialize everything in there, including
         // nodecg instances, which throw errors when serialized.
         Object.defineProperty(this, "nodecg", { enumerable: false });
+        // Core is not needed but avoids confusion because a service shouldn't have it.
+        Object.defineProperty(this, "core", { enumerable: false, writable: true });
 
         this.nodecg.log.info(this.serviceType + " bundle started.");
         this.core = (this.nodecg.extensions["nodecg-io-core"] as unknown) as NodeCGIOCore | undefined;

--- a/nodecg-io-core/extension/serviceManager.ts
+++ b/nodecg-io-core/extension/serviceManager.ts
@@ -1,5 +1,5 @@
 import { Service, ServiceClient } from "./types";
-import { NodeCG, ReplicantServer } from "nodecg/types/server";
+import { NodeCG } from "nodecg/types/server";
 import { error, Result, success } from "./utils/result";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -8,21 +8,16 @@ import { error, Result, success } from "./utils/result";
  * Manages services by allowing services to register them and allowing access of other components to the registered services.
  */
 export class ServiceManager {
-    private services: ReplicantServer<Service<unknown, any>[]>;
+    private services: Service<unknown, any>[] = [];
 
-    constructor(private readonly nodecg: NodeCG) {
-        this.services = this.nodecg.Replicant("services", {
-            persistent: false,
-            defaultValue: [],
-        });
-    }
+    constructor(private readonly nodecg: NodeCG) {}
 
     /**
      * Registers the passed service which show it in the GUI and allows it to be instanced using {@link createServiceInstance}.
      * @param service the service you want to register.
      */
     registerService<R, C extends ServiceClient<unknown>>(service: Service<R, C>): void {
-        this.services.value.push(service);
+        this.services.push(service);
         this.nodecg.log.info(`Service ${service.serviceType} has been registered.`);
     }
 
@@ -30,7 +25,7 @@ export class ServiceManager {
      * Returns all registered services.
      */
     getServices(): Service<unknown, any>[] {
-        return this.services.value;
+        return this.services;
     }
 
     /**
@@ -39,7 +34,7 @@ export class ServiceManager {
      * @return the service or undefined if no service with this name has been registered.
      */
     getService(serviceName: string): Result<Service<unknown, any>> {
-        const svc = this.services.value.find((svc) => svc.serviceType === serviceName);
+        const svc = this.services.find((svc) => svc.serviceType === serviceName);
         if (svc === undefined) {
             return error("Service hasn't been registered.");
         } else {


### PR DESCRIPTION
Follow-up on #90

When saving services in Replicants other bundles have read and write access. I've assumed in #90 that thats fine based on my understanding that replicants always share data through serialization thus functions of the service objects aren't available to other bundles.
Turns out that this is not the case for server-side executed extensions, those get full access. Therefore a bundle could overwrite the createClient or validateConfig function to gain access to the passed config/credentials.
Because of that this PR also removes the services from Replicants and moves them into a array and gives out copies without the functions via nodecg messages.