### PR TITLE
Reselect bundles and bundle services when rerendering the bundle section

### DIFF
--- a/nodecg-io-core/dashboard/utils/selectUtils.ts
+++ b/nodecg-io-core/dashboard/utils/selectUtils.ts
@@ -1,27 +1,24 @@
 import { ObjectMap } from "nodecg-io-core/extension/types";
 
 export function updateOptionsMap(node: HTMLSelectElement, options: ObjectMap<string, unknown>): void {
-    const keys = [];
-
-    for (const key in options) {
-        // eslint-disable-next-line no-prototype-builtins
-        if (!options.hasOwnProperty(key)) {
-            continue;
-        }
-        keys.push(key);
-    }
-
-    updateOptionsArr(node, keys);
+    updateOptionsArr(node, Object.keys(options));
 }
 
 export function updateOptionsArr(node: HTMLSelectElement, options: string[]): void {
+    const previouslySelected = node.options[node.selectedIndex]?.value;
+
     // Remove all children.
     node.innerHTML = "";
 
-    options.forEach((optStr) => {
+    options.forEach((optStr, i) => {
         const opt = document.createElement("option");
         opt.value = optStr;
         opt.innerText = optStr;
         node.options.add(opt);
+
+        // Try to reselect the previously selected item
+        if (optStr === previouslySelected) {
+            node.selectedIndex = i;
+        }
     });
 }


### PR DESCRIPTION
This fixes the jumping around while changing a bundle dependency where it always goes to the ahk bundle (because it is the first).
Now it will re-select the previously used bundle/service, e.g. when assigning a instance to twitch-chat it will stay there and not go to the ahk sample bundle.