### PR TITLE
Bump dependencies

### DIFF
--- a/nodecg-io-ahk/package.json
+++ b/nodecg-io-ahk/package.json
@@ -23,13 +23,13 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "@types/node-fetch": "^2.5.7",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",
-        "node-fetch": "^2.5.7"
+        "node-fetch": "^2.6.0"
     }
 }

--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -9,14 +9,15 @@
     "devDependencies": {
         "webpack": "^4.44.1",
         "webpack-cli": "^3.3.12",
-        "ts-loader": "^8.0.2",
+        "ts-loader": "^8.0.3",
         "clean-webpack-plugin": "^3.0.0"
     },
     "dependencies": {
         "monaco-editor": "^0.20.0",
         "nodecg": "^1.6.1",
         "nodecg-io-core": "0.1.0",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2",
+        "crypto-js": "^4.0.0"
     },
     "license": "MIT"
 }

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -30,13 +30,13 @@
     "license": "MIT",
     "devDependencies": {
         "@types/crypto-js": "^3.1.47",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1"
     },
     "dependencies": {
-        "ajv": "^6.12.2",
+        "ajv": "^6.12.4",
         "crypto-js": "^4.0.0",
-        "tslib": "^2.0.0",
-        "typescript": "^3.9.6"
+        "tslib": "^2.0.1",
+        "typescript": "^4.0.2"
     }
 }

--- a/nodecg-io-discord/package.json
+++ b/nodecg-io-discord/package.json
@@ -23,12 +23,12 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",
-        "discord.js": "12.2.0"
+        "discord.js": "^12.3.1"
     }
 }

--- a/nodecg-io-intellij/package.json
+++ b/nodecg-io-intellij/package.json
@@ -23,13 +23,13 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6",
+        "typescript": "^4.0.2",
         "@types/node-fetch": "^2.5.7"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",
-        "node-fetch": "^2.5.7"
+        "node-fetch": "^2.6.0"
     }
 }

--- a/nodecg-io-irc/package.json
+++ b/nodecg-io-irc/package.json
@@ -23,10 +23,10 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "@types/irc": "0.3.33",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",

--- a/nodecg-io-midi-input/package.json
+++ b/nodecg-io-midi-input/package.json
@@ -23,9 +23,9 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",

--- a/nodecg-io-midi-output/package.json
+++ b/nodecg-io-midi-output/package.json
@@ -23,9 +23,9 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",

--- a/nodecg-io-obs/package.json
+++ b/nodecg-io-obs/package.json
@@ -26,9 +26,9 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",

--- a/nodecg-io-philipshue/package.json
+++ b/nodecg-io-philipshue/package.json
@@ -22,14 +22,13 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6",
-        "@types/is-ip": "^3.0.0"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "is-ip": "^3.1.0",
-        "node-hue-api": "^4.0.7",
+        "node-hue-api": "^4.0.9",
         "nodecg-io-core": "0.1.0"
     }
 }

--- a/nodecg-io-rcon/package.json
+++ b/nodecg-io-rcon/package.json
@@ -23,9 +23,9 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",

--- a/nodecg-io-sacn-receiver/package.json
+++ b/nodecg-io-sacn-receiver/package.json
@@ -23,9 +23,9 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",

--- a/nodecg-io-sacn-sender/package.json
+++ b/nodecg-io-sacn-sender/package.json
@@ -23,9 +23,9 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",

--- a/nodecg-io-slack/package.json
+++ b/nodecg-io-slack/package.json
@@ -23,12 +23,12 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",
-        "@slack/web-api": "^5.10.0"
+        "@slack/web-api": "^5.11.0"
     }
 }

--- a/nodecg-io-spotify/package.json
+++ b/nodecg-io-spotify/package.json
@@ -23,14 +23,15 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
-        "@types/spotify-web-api-node": "^4.0.1",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
+        "@types/spotify-web-api-node": "^4.0.1",
         "nodecg-io-core": "0.1.0",
-        "open": "^7.0.4",
+        "express": "^4.17.1",
+        "open": "^7.2.1",
         "spotify-web-api-node": "^4.0.0"
     }
 }

--- a/nodecg-io-streamdeck/package.json
+++ b/nodecg-io-streamdeck/package.json
@@ -29,6 +29,6 @@
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",
-        "elgato-stream-deck": "^3.3.0"
+        "elgato-stream-deck": "^3.3.2"
     }
 }

--- a/nodecg-io-streamdeck/package.json
+++ b/nodecg-io-streamdeck/package.json
@@ -23,9 +23,9 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",

--- a/nodecg-io-streamelements/package.json
+++ b/nodecg-io-streamelements/package.json
@@ -30,9 +30,9 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "@types/socket.io-client": "^1.4.33",

--- a/nodecg-io-telegram/package.json
+++ b/nodecg-io-telegram/package.json
@@ -23,10 +23,10 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "@types/node-telegram-bot-api": "^0.50.2",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",

--- a/nodecg-io-twitch/extension/index.ts
+++ b/nodecg-io-twitch/extension/index.ts
@@ -2,8 +2,8 @@ import { NodeCG } from "nodecg/types/server";
 import { ServiceClient } from "nodecg-io-core/extension/types";
 import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
 import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
-import TwitchClient from "twitch";
-import ChatClient from "twitch-chat-client";
+import { getTokenInfo, StaticAuthProvider } from "twitch-auth";
+import { ChatClient } from "twitch-chat-client";
 
 interface TwitchServiceConfig {
     oauthKey: string;
@@ -18,25 +18,28 @@ module.exports = (nodecg: NodeCG) => {
 class TwitchService extends ServiceBundle<TwitchServiceConfig, TwitchServiceClient> {
     async validateConfig(config: TwitchServiceConfig): Promise<Result<void>> {
         const authKey = config.oauthKey.replace("oauth:", "");
-        await TwitchClient.getTokenInfo(authKey); // This will throw a error if the token is invalid
+        await getTokenInfo(authKey); // This will throw a error if the token is invalid
         return emptySuccess();
     }
 
     async createClient(config: TwitchServiceConfig): Promise<Result<TwitchServiceClient>> {
         // This twitch client needs the token without the "oauth:" before the actual token, strip it away
         const authKey = config.oauthKey.replace("oauth:", "");
-        // Create a twitch authentication client
-        const tokenInfo = await TwitchClient.getTokenInfo(authKey);
-        const authClient = TwitchClient.withCredentials(tokenInfo.clientId, authKey, tokenInfo.scopes);
+
+        // Create a twitch authentication provider
+        const tokenInfo = await getTokenInfo(authKey);
+        const authProvider = new StaticAuthProvider(tokenInfo.clientId, authKey, tokenInfo.scopes);
 
         // Create the actual chat client and connect
-        const chatClient = ChatClient.forTwitchClient(authClient);
+        const chatClient = new ChatClient(authProvider);
         this.nodecg.log.info("Connecting to twitch chat...");
         await chatClient.connect(); // Connects to twitch IRC
+
         // This also waits till it has registered itself at the IRC server, which is needed to do anything.
         await new Promise((resolve, _reject) => {
             chatClient.onRegister(resolve);
         });
+
         this.nodecg.log.info("Successfully connected to twitch.");
 
         return success({

--- a/nodecg-io-twitch/package.json
+++ b/nodecg-io-twitch/package.json
@@ -30,6 +30,7 @@
     "dependencies": {
         "nodecg-io-core": "0.1.0",
         "twitch": "^4.2.1",
+        "twitch-auth": "^4.2.1",
         "twitch-chat-client": "^4.2.1"
     }
 }

--- a/nodecg-io-twitch/package.json
+++ b/nodecg-io-twitch/package.json
@@ -23,13 +23,13 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",
-        "twitch": "^4.1.3",
-        "twitch-chat-client": "^4.1.3"
+        "twitch": "^4.2.1",
+        "twitch-chat-client": "^4.2.1"
     }
 }

--- a/nodecg-io-twitter/package.json
+++ b/nodecg-io-twitter/package.json
@@ -23,9 +23,9 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "@types/twitter": "^1.7.0",

--- a/nodecg-io-websocket-client/package.json
+++ b/nodecg-io-websocket-client/package.json
@@ -23,13 +23,13 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",
-        "@types/ws": "^7.2.5",
-        "ws": "^7.3.0"
+        "@types/ws": "^7.2.6",
+        "ws": "^7.3.1"
     }
 }

--- a/nodecg-io-websocket-server/package.json
+++ b/nodecg-io-websocket-server/package.json
@@ -23,13 +23,13 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",
-        "@types/ws": "^7.2.5",
-        "ws": "^7.3.0"
+        "@types/ws": "^7.2.6",
+        "ws": "^7.3.1"
     }
 }

--- a/nodecg-io-xdotool/package.json
+++ b/nodecg-io-xdotool/package.json
@@ -23,14 +23,14 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "@types/node-fetch": "^2.5.7",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
         "nodecg-io-core": "0.1.0",
-        "node-fetch": "^2.5.7",
+        "node-fetch": "^2.6.0",
         "@rauschma/stringio": "^1.4.0"
     }
 }

--- a/nodecg-io-youtube/package.json
+++ b/nodecg-io-youtube/package.json
@@ -23,17 +23,15 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     },
     "dependencies": {
-        "@types/express": "^4.17.6",
         "@types/gapi": "0.0.39",
-        "@types/open": "^6.2.1",
         "express": "^4.17.1",
-        "googleapis": "^52.1.0",
+        "googleapis": "^59.0.0",
         "nodecg-io-core": "0.1.0",
-        "open": "^7.0.4"
+        "open": "^7.2.1"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -7985,9 +7985,9 @@
             }
         },
         "git-url-parse": {
-            "version": "11.1.3",
-            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.3.tgz",
-            "integrity": "sha512-GPsfwticcu52WQ+eHp0IYkAyaOASgYdtsQDIt4rUp6GbiNt1P9ddrh3O0kQB0eD4UJZszVqNT3+9Zwcg40fywA==",
+            "version": "11.2.0",
+            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.2.0.tgz",
+            "integrity": "sha512-KPoHZg8v+plarZvto4ruIzzJLFQoRx+sUs5DQSr07By9IBKguVd+e6jwrFR6/TP6xrCJlNV1tPqLO1aREc7O2g==",
             "dev": true,
             "requires": {
                 "git-up": "^4.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,18 +12,18 @@
             }
         },
         "@babel/core": {
-            "version": "7.11.1",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.1.tgz",
-            "integrity": "sha512-XqF7F6FWQdKGGWAzGELL+aCO1p+lRY5Tj5/tbT3St1G8NaH70jhhDIKknIZaDans0OQBG5wRAldROLHSt44BgQ==",
+            "version": "7.11.6",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
+            "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.0",
+                "@babel/generator": "^7.11.6",
                 "@babel/helper-module-transforms": "^7.11.0",
                 "@babel/helpers": "^7.10.4",
-                "@babel/parser": "^7.11.1",
+                "@babel/parser": "^7.11.5",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.11.0",
-                "@babel/types": "^7.11.0",
+                "@babel/traverse": "^7.11.5",
+                "@babel/types": "^7.11.5",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
@@ -42,11 +42,11 @@
             }
         },
         "@babel/generator": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.0.tgz",
-            "integrity": "sha512-fEm3Uzw7Mc9Xi//qU20cBKatTfs2aOtKqmvy/Vm7RkJEGFQ4xc9myCfbXxqK//ZS8MR/ciOHw6meGASJuKmDfQ==",
+            "version": "7.11.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
+            "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
             "requires": {
-                "@babel/types": "^7.11.0",
+                "@babel/types": "^7.11.5",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -178,9 +178,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.11.3",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.3.tgz",
-            "integrity": "sha512-REo8xv7+sDxkKvoxEywIdsNFiZLybwdI7hcT5uEPyQrSMB4YQ973BfC9OOrD/81MaIjh6UxdulIQXkjmiH3PcA=="
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
+            "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
         },
         "@babel/plugin-syntax-dynamic-import": {
             "version": "7.8.3",
@@ -201,16 +201,16 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.0.tgz",
-            "integrity": "sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
+            "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.0",
+                "@babel/generator": "^7.11.5",
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/helper-split-export-declaration": "^7.11.0",
-                "@babel/parser": "^7.11.0",
-                "@babel/types": "^7.11.0",
+                "@babel/parser": "^7.11.5",
+                "@babel/types": "^7.11.5",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.19"
@@ -224,9 +224,9 @@
             }
         },
         "@babel/types": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.0.tgz",
-            "integrity": "sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==",
+            "version": "7.11.5",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
+            "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
             "requires": {
                 "@babel/helper-validator-identifier": "^7.10.4",
                 "lodash": "^4.17.19",
@@ -244,9 +244,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.54",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-                    "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w=="
+                    "version": "12.12.55",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.55.tgz",
+                    "integrity": "sha512-Vd6xQUVvPCTm7Nx1N7XHcpX6t047ltm7TgcsOr4gFHjeYgwZevo+V7I1lfzHnj5BT5frztZ42+RTG4MwYw63dw=="
                 },
                 "tslib": {
                     "version": "1.13.0",
@@ -268,22 +268,6 @@
                 "@types/ws": "^7.2.5",
                 "tslib": "^2.0.0",
                 "ws": "^7.3.0"
-            },
-            "dependencies": {
-                "@d-fischer/logger": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-2.0.0.tgz",
-                    "integrity": "sha512-KIVO0U8sqoulnepMEvXP/FjJAavfmKHLoFIn+D0iqzmFgaY8eaZ464y8nuMVgZGYUGAFxY953XVAeijBf07vcw==",
-                    "requires": {
-                        "detect-node": "^2.0.4",
-                        "tslib": "^2.0.0"
-                    }
-                },
-                "@types/node": {
-                    "version": "14.6.0",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-                    "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
-                }
             }
         },
         "@d-fischer/cross-fetch": {
@@ -316,19 +300,12 @@
             "integrity": "sha512-fdXM0iXtYcGbIxpWpUYsUi7cAMw8jXbJ75OJDFuScL/TXrrtMlZ9JOLpsZFVMzgeBOTpHLefG5KydsZEAzj95Q=="
         },
         "@d-fischer/logger": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-1.1.1.tgz",
-            "integrity": "sha512-JpK3Pl+8mW5LvsNfeCOJwOKOHX88KI1X4NFWSxSVgfY0KFV9nE478Y0/3ZjlTLJuiaxBEmOLsvhPGtQeDfi4EQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-2.0.0.tgz",
+            "integrity": "sha512-KIVO0U8sqoulnepMEvXP/FjJAavfmKHLoFIn+D0iqzmFgaY8eaZ464y8nuMVgZGYUGAFxY953XVAeijBf07vcw==",
             "requires": {
                 "detect-node": "^2.0.4",
-                "tslib": "^1.10.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-                }
+                "tslib": "^2.0.0"
             }
         },
         "@d-fischer/promise.allsettled": {
@@ -358,26 +335,10 @@
                 "tslib": "^1.9.3"
             },
             "dependencies": {
-                "@d-fischer/logger": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-2.0.0.tgz",
-                    "integrity": "sha512-KIVO0U8sqoulnepMEvXP/FjJAavfmKHLoFIn+D0iqzmFgaY8eaZ464y8nuMVgZGYUGAFxY953XVAeijBf07vcw==",
-                    "requires": {
-                        "detect-node": "^2.0.4",
-                        "tslib": "^2.0.0"
-                    },
-                    "dependencies": {
-                        "tslib": {
-                            "version": "2.0.1",
-                            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-                            "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
-                        }
-                    }
-                },
                 "@types/node": {
-                    "version": "12.12.54",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.54.tgz",
-                    "integrity": "sha512-ge4xZ3vSBornVYlDnk7yZ0gK6ChHf/CHB7Gl1I0Jhah8DDnEQqBzgohYG4FX4p81TNirSETOiSyn+y1r9/IR6w=="
+                    "version": "12.12.55",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.55.tgz",
+                    "integrity": "sha512-Vd6xQUVvPCTm7Nx1N7XHcpX6t047ltm7TgcsOr4gFHjeYgwZevo+V7I1lfzHnj5BT5frztZ42+RTG4MwYw63dw=="
                 },
                 "tslib": {
                     "version": "1.13.0",
@@ -393,13 +354,6 @@
             "requires": {
                 "@types/node": "^14.0.5",
                 "tslib": "^2.0.0"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "14.6.0",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-                    "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
-                }
             }
         },
         "@d-fischer/typed-event-emitter": {
@@ -411,6 +365,11 @@
                 "tslib": "^1.11.1"
             },
             "dependencies": {
+                "@types/node": {
+                    "version": "13.13.16",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.16.tgz",
+                    "integrity": "sha512-dJ9vXxJ8MEwzNn4GkoAGauejhXoKuJyYKegsA6Af25ZpEDXomeVXt5HUWUNVHk5UN7+U0f6ghC6otwt+7PdSDg=="
+                },
                 "tslib": {
                     "version": "1.13.0",
                     "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
@@ -431,6 +390,32 @@
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "mime-types": "^2.1.12"
+            }
+        },
+        "@eslint/eslintrc": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.1.3.tgz",
+            "integrity": "sha512-4YVwPkANLeNtRjMekzux1ci8hIaH5eGKktGqR0d3LWsKNn5B2X/1Z6Trxy7jQXl9EBGE6Yj02O+t09FMeRllaA==",
+            "dev": true,
+            "requires": {
+                "ajv": "^6.12.4",
+                "debug": "^4.1.1",
+                "espree": "^7.3.0",
+                "globals": "^12.1.0",
+                "ignore": "^4.0.6",
+                "import-fresh": "^3.2.1",
+                "js-yaml": "^3.13.1",
+                "lodash": "^4.17.19",
+                "minimatch": "^3.0.4",
+                "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                    "dev": true
+                }
             }
         },
         "@evocateur/libnpmaccess": {
@@ -811,6 +796,197 @@
                 "whatwg-url": "^7.0.0"
             },
             "dependencies": {
+                "@nodelib/fs.stat": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+                    "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+                    "dev": true
+                },
+                "array-union": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                    "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                    "dev": true,
+                    "requires": {
+                        "array-uniq": "^1.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "dir-glob": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+                    "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+                    "dev": true,
+                    "requires": {
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "fast-glob": {
+                    "version": "2.2.7",
+                    "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+                    "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+                    "dev": true,
+                    "requires": {
+                        "@mrmlnc/readdir-enhanced": "^2.2.1",
+                        "@nodelib/fs.stat": "^1.1.2",
+                        "glob-parent": "^3.1.0",
+                        "is-glob": "^4.0.0",
+                        "merge2": "^1.2.3",
+                        "micromatch": "^3.1.10"
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "glob-parent": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^3.1.0",
+                        "path-dirname": "^1.0.0"
+                    },
+                    "dependencies": {
+                        "is-glob": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                            "dev": true,
+                            "requires": {
+                                "is-extglob": "^2.1.0"
+                            }
+                        }
+                    }
+                },
+                "globby": {
+                    "version": "9.2.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+                    "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/glob": "^7.1.1",
+                        "array-union": "^1.0.2",
+                        "dir-glob": "^2.2.2",
+                        "fast-glob": "^2.2.6",
+                        "glob": "^7.1.3",
+                        "ignore": "^4.0.3",
+                        "pify": "^4.0.1",
+                        "slash": "^2.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                    "dev": true
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
+                    }
+                },
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -822,6 +998,16 @@
                     "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
                     "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
                     "dev": true
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
                 }
             }
         },
@@ -1256,6 +1442,50 @@
                 "write-json-file": "^3.2.0"
             },
             "dependencies": {
+                "@nodelib/fs.stat": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
+                    "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+                    "dev": true
+                },
+                "array-union": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                    "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                    "dev": true,
+                    "requires": {
+                        "array-uniq": "^1.0.1"
+                    }
+                },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "dev": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
                 "cosmiconfig": {
                     "version": "5.2.1",
                     "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
@@ -1267,6 +1497,97 @@
                         "js-yaml": "^3.13.1",
                         "parse-json": "^4.0.0"
                     }
+                },
+                "dir-glob": {
+                    "version": "2.2.2",
+                    "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+                    "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+                    "dev": true,
+                    "requires": {
+                        "path-type": "^3.0.0"
+                    }
+                },
+                "fast-glob": {
+                    "version": "2.2.7",
+                    "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
+                    "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+                    "dev": true,
+                    "requires": {
+                        "@mrmlnc/readdir-enhanced": "^2.2.1",
+                        "@nodelib/fs.stat": "^1.1.2",
+                        "glob-parent": "^3.1.0",
+                        "is-glob": "^4.0.0",
+                        "merge2": "^1.2.3",
+                        "micromatch": "^3.1.10"
+                    },
+                    "dependencies": {
+                        "glob-parent": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
+                            "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
+                            "dev": true,
+                            "requires": {
+                                "is-glob": "^3.1.0",
+                                "path-dirname": "^1.0.0"
+                            },
+                            "dependencies": {
+                                "is-glob": {
+                                    "version": "3.1.0",
+                                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
+                                    "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
+                                    "dev": true,
+                                    "requires": {
+                                        "is-extglob": "^2.1.0"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "dev": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "dev": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "globby": {
+                    "version": "9.2.0",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
+                    "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/glob": "^7.1.1",
+                        "array-union": "^1.0.2",
+                        "dir-glob": "^2.2.2",
+                        "fast-glob": "^2.2.6",
+                        "glob": "^7.1.3",
+                        "ignore": "^4.0.3",
+                        "pify": "^4.0.1",
+                        "slash": "^2.0.0"
+                    }
+                },
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                    "dev": true
                 },
                 "import-fresh": {
                     "version": "2.0.0",
@@ -1286,6 +1607,47 @@
                         }
                     }
                 },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "dev": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "dev": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "dev": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
                 "parse-json": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -1294,6 +1656,39 @@
                     "requires": {
                         "error-ex": "^1.3.1",
                         "json-parse-better-errors": "^1.0.1"
+                    }
+                },
+                "path-type": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+                    "dev": true,
+                    "requires": {
+                        "pify": "^3.0.0"
+                    },
+                    "dependencies": {
+                        "pify": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+                            "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+                            "dev": true
+                        }
+                    }
+                },
+                "slash": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
+                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
+                    "dev": true
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "dev": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
                     }
                 }
             }
@@ -1565,11 +1960,31 @@
                 "glob-to-regexp": "^0.3.0"
             }
         },
+        "@nodelib/fs.scandir": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+            "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.stat": "2.0.3",
+                "run-parallel": "^1.1.9"
+            }
+        },
         "@nodelib/fs.stat": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-1.1.3.tgz",
-            "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+            "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
             "dev": true
+        },
+        "@nodelib/fs.walk": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+            "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+            "dev": true,
+            "requires": {
+                "@nodelib/fs.scandir": "2.1.3",
+                "fastq": "^1.6.0"
+            }
         },
         "@octokit/auth-token": {
             "version": "2.4.2",
@@ -1581,30 +1996,27 @@
             }
         },
         "@octokit/endpoint": {
-            "version": "6.0.3",
-            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.3.tgz",
-            "integrity": "sha512-Y900+r0gIz+cWp6ytnkibbD95ucEzDSKzlEnaWS52hbCDNcCJYO5mRmWW7HRAnDc7am+N/5Lnd8MppSaTYx1Yg==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.5.tgz",
+            "integrity": "sha512-70K5u6zd45ItOny6aHQAsea8HHQjlQq85yqOMe+Aj8dkhN2qSJ9T+Q3YjUjEYfPRBcuUWNgMn62DQnP/4LAIiQ==",
             "dev": true,
             "requires": {
                 "@octokit/types": "^5.0.0",
-                "is-plain-object": "^3.0.0",
-                "universal-user-agent": "^5.0.0"
+                "is-plain-object": "^4.0.0",
+                "universal-user-agent": "^6.0.0"
             },
             "dependencies": {
                 "is-plain-object": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-                    "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+                    "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
                     "dev": true
                 },
                 "universal-user-agent": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-                    "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-                    "dev": true,
-                    "requires": {
-                        "os-name": "^3.1.0"
-                    }
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+                    "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+                    "dev": true
                 }
             }
         },
@@ -1662,19 +2074,19 @@
             }
         },
         "@octokit/request": {
-            "version": "5.4.5",
-            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.5.tgz",
-            "integrity": "sha512-atAs5GAGbZedvJXXdjtKljin+e2SltEs48B3naJjqWupYl2IUBbB/CJisyjbNHcKpHzb3E+OYEZ46G8eakXgQg==",
+            "version": "5.4.7",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.4.7.tgz",
+            "integrity": "sha512-FN22xUDP0i0uF38YMbOfx6TotpcENP5W8yJM1e/LieGXn6IoRxDMnBf7tx5RKSW4xuUZ/1P04NFZy5iY3Rax1A==",
             "dev": true,
             "requires": {
                 "@octokit/endpoint": "^6.0.1",
                 "@octokit/request-error": "^2.0.0",
                 "@octokit/types": "^5.0.0",
                 "deprecation": "^2.0.0",
-                "is-plain-object": "^3.0.0",
+                "is-plain-object": "^4.0.0",
                 "node-fetch": "^2.3.0",
                 "once": "^1.4.0",
-                "universal-user-agent": "^5.0.0"
+                "universal-user-agent": "^6.0.0"
             },
             "dependencies": {
                 "@octokit/request-error": {
@@ -1689,19 +2101,16 @@
                     }
                 },
                 "is-plain-object": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.1.tgz",
-                    "integrity": "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g==",
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-4.1.1.tgz",
+                    "integrity": "sha512-5Aw8LLVsDlZsETVMhoMXzqsXwQqr/0vlnBYzIXJbYo2F4yYlhLHs+Ez7Bod7IIQKWkJbJfxrWD7pA1Dw1TKrwA==",
                     "dev": true
                 },
                 "universal-user-agent": {
-                    "version": "5.0.0",
-                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-5.0.0.tgz",
-                    "integrity": "sha512-B5TPtzZleXyPrUMKCpEHFmVhMN6EhmJYjG5PQna9s7mXeSqGTLap4OpqLl5FCEFUI3UBmllkETwKf/db66Y54Q==",
-                    "dev": true,
-                    "requires": {
-                        "os-name": "^3.1.0"
-                    }
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+                    "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w==",
+                    "dev": true
                 }
             }
         },
@@ -1752,9 +2161,9 @@
             }
         },
         "@octokit/types": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.0.1.tgz",
-            "integrity": "sha512-GorvORVwp244fGKEt3cgt/P+M0MGy4xEDbckw+K5ojEezxyMDgCaYPKVct+/eWQfZXOT7uq0xRpmrl/+hliabA==",
+            "version": "5.4.1",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-5.4.1.tgz",
+            "integrity": "sha512-OlMlSySBJoJ6uozkr/i03nO5dlYQyE05vmQNZhAh9MyO4DPBP88QlwsDVLmVjIMFssvIZB6WO0ctIGMRG+xsJQ==",
             "dev": true,
             "requires": {
                 "@types/node": ">= 8"
@@ -2252,9 +2661,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.28",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-                    "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+                    "version": "10.17.29",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
+                    "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA=="
                 }
             }
         },
@@ -2377,16 +2786,10 @@
                 "@types/node": "*"
             }
         },
-        "@types/eslint-visitor-keys": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
-            "integrity": "sha512-OCutwjDZ4aFS6PB1UZ988C4YgwlBHJd6wCeQqaLdmadZ/7e+w79+hbMUFC1QXDNCmdyoRfAFdm0RypzwR+Qpag==",
-            "dev": true
-        },
         "@types/express": {
-            "version": "4.17.7",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.7.tgz",
-            "integrity": "sha512-dCOT5lcmV/uC2J9k0rPafATeeyz+99xTt54ReX11/LObZgfzJqZNcW27zGhYyX+9iSEGXGt5qLPwRSvBZcLvtQ==",
+            "version": "4.17.8",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.8.tgz",
+            "integrity": "sha512-wLhcKh3PMlyA2cNAB9sjM1BntnhPMiM0JOBwPBqttjHev2428MLEB4AYVN+d8s2iyCVZac+o41Pflm/ZH5vLXQ==",
             "requires": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "*",
@@ -2395,9 +2798,9 @@
             }
         },
         "@types/express-serve-static-core": {
-            "version": "4.17.9",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.9.tgz",
-            "integrity": "sha512-DG0BYg6yO+ePW+XoDENYz8zhNGC3jDDEpComMYn7WJc4mY1Us8Rw9ax2YhJXxpyk2SF47PQAoQ0YyVT1a0bEkA==",
+            "version": "4.17.12",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.12.tgz",
+            "integrity": "sha512-EaEdY+Dty1jEU7U6J4CUWwxL+hyEGMkO5jan5gplfegUgCUsIUWqXxqw47uGjimeT4Qgkz/XUfwoau08+fgvKA==",
             "requires": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -2426,14 +2829,6 @@
                 "@types/node": "*"
             }
         },
-        "@types/is-ip": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@types/is-ip/-/is-ip-3.0.0.tgz",
-            "integrity": "sha512-4bsr3mi//fAtvM6IgxkAxTjHwuUUl89/3emBkmqUvTQ4+rf3XsGsP9eS9N+4EXLdfYS3aJhHyaNwo/zTlRd0ag==",
-            "requires": {
-                "is-ip": "*"
-            }
-        },
         "@types/is-stream": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",
@@ -2443,9 +2838,9 @@
             }
         },
         "@types/json-schema": {
-            "version": "7.0.5",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.5.tgz",
-            "integrity": "sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.6.tgz",
+            "integrity": "sha512-3c+yGKvVP5Y9TYBEibGNR+kLtijnj7mYrXRg+WpFb2X9xm04g/DXYkfg4hmzJQosc9snFNUPkbYIhu+KAm6jJw==",
             "dev": true
         },
         "@types/lru-cache": {
@@ -2470,9 +2865,9 @@
             "dev": true
         },
         "@types/node": {
-            "version": "13.13.14",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.14.tgz",
-            "integrity": "sha512-Az3QsOt1U/K1pbCQ0TXGELTuTkPLOiFIQf3ILzbOyo0FqgV9SxRnxbxM5QlAveERZMHpZY+7u3Jz2tKyl+yg6g=="
+            "version": "14.6.4",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.4.tgz",
+            "integrity": "sha512-Wk7nG1JSaMfMpoMJDKUsWYugliB2Vy55pdjLpmLixeyMi7HizW2I/9QoxsPCkXl3dO+ZOVqPumKaDUv5zJu2uQ=="
         },
         "@types/node-fetch": {
             "version": "2.5.7",
@@ -2509,14 +2904,6 @@
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
             "dev": true
-        },
-        "@types/open": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/@types/open/-/open-6.2.1.tgz",
-            "integrity": "sha512-CzV16LToFaKwm1FfplVTF08E3pznw4fQNCQ87N+A1RU00zu/se7npvb6IC9db3/emnSThQ6R8qFKgrei2M4EYQ==",
-            "requires": {
-                "open": "*"
-            }
         },
         "@types/p-queue": {
             "version": "2.3.2",
@@ -2660,9 +3047,9 @@
             }
         },
         "@types/webpack": {
-            "version": "4.41.21",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.21.tgz",
-            "integrity": "sha512-2j9WVnNrr/8PLAB5csW44xzQSJwS26aOnICsP3pSGCEdsu6KYtfQ6QJsVUKHWRnm1bL7HziJsfh5fHqth87yKA==",
+            "version": "4.41.22",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
+            "integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
             "requires": {
                 "@types/anymatch": "*",
                 "@types/node": "*",
@@ -2705,12 +3092,13 @@
             }
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-3.6.1.tgz",
-            "integrity": "sha512-06lfjo76naNeOMDl+mWG9Fh/a0UHKLGhin+mGaIw72FUMbMGBkdi/FEJmgEDzh4eE73KIYzHWvOCYJ0ak7nrJQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.0.1.tgz",
+            "integrity": "sha512-pQZtXupCn11O4AwpYVUX4PDFfmIJl90ZgrEBg0CEcqlwvPiG0uY81fimr1oMFblZnpKAq6prrT9a59pj1x58rw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "3.6.1",
+                "@typescript-eslint/experimental-utils": "4.0.1",
+                "@typescript-eslint/scope-manager": "4.0.1",
                 "debug": "^4.1.1",
                 "functional-red-black-tree": "^1.0.1",
                 "regexpp": "^3.0.0",
@@ -2719,47 +3107,57 @@
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-3.6.1.tgz",
-            "integrity": "sha512-oS+hihzQE5M84ewXrTlVx7eTgc52eu+sVmG7ayLfOhyZmJ8Unvf3osyFQNADHP26yoThFfbxcibbO0d2FjnYhg==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.0.1.tgz",
+            "integrity": "sha512-gAqOjLiHoED79iYTt3F4uSHrYmg/GPz/zGezdB0jAdr6S6gwNiR/j7cTZ8nREKVzMVKLd9G3xbg1sV9GClW3sw==",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.3",
-                "@typescript-eslint/types": "3.6.1",
-                "@typescript-eslint/typescript-estree": "3.6.1",
+                "@typescript-eslint/scope-manager": "4.0.1",
+                "@typescript-eslint/types": "4.0.1",
+                "@typescript-eslint/typescript-estree": "4.0.1",
                 "eslint-scope": "^5.0.0",
                 "eslint-utils": "^2.0.0"
             }
         },
         "@typescript-eslint/parser": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-3.6.1.tgz",
-            "integrity": "sha512-SLihQU8RMe77YJ/jGTqOt0lMq7k3hlPVfp7v/cxMnXA9T0bQYoMDfTsNgHXpwSJM1Iq2aAJ8WqekxUwGv5F67Q==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.0.1.tgz",
+            "integrity": "sha512-1+qLmXHNAWSQ7RB6fdSQszAiA7JTwzakj5cNYjBTUmpH2cqilxMZEIV+DRKjVZs8NzP3ALmKexB0w/ExjcK9Iw==",
             "dev": true,
             "requires": {
-                "@types/eslint-visitor-keys": "^1.0.0",
-                "@typescript-eslint/experimental-utils": "3.6.1",
-                "@typescript-eslint/types": "3.6.1",
-                "@typescript-eslint/typescript-estree": "3.6.1",
-                "eslint-visitor-keys": "^1.1.0"
+                "@typescript-eslint/scope-manager": "4.0.1",
+                "@typescript-eslint/types": "4.0.1",
+                "@typescript-eslint/typescript-estree": "4.0.1",
+                "debug": "^4.1.1"
+            }
+        },
+        "@typescript-eslint/scope-manager": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.0.1.tgz",
+            "integrity": "sha512-u3YEXVJ8jsj7QCJk3om0Y457fy2euEOkkzxIB/LKU3MdyI+FJ2gI0M4aKEaXzwCSfNDiZ13a3lDo5DVozc+XLQ==",
+            "dev": true,
+            "requires": {
+                "@typescript-eslint/types": "4.0.1",
+                "@typescript-eslint/visitor-keys": "4.0.1"
             }
         },
         "@typescript-eslint/types": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-3.6.1.tgz",
-            "integrity": "sha512-NPxd5yXG63gx57WDTW1rp0cF3XlNuuFFB5G+Kc48zZ+51ZnQn9yjDEsjTPQ+aWM+V+Z0I4kuTFKjKvgcT1F7xQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.0.1.tgz",
+            "integrity": "sha512-S+gD3fgbkZYW2rnbjugNMqibm9HpEjqZBZkTiI3PwbbNGWmAcxolWIUwZ0SKeG4Dy2ktpKKaI/6+HGYVH8Qrlg==",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-3.6.1.tgz",
-            "integrity": "sha512-G4XRe/ZbCZkL1fy09DPN3U0mR6SayIv1zSeBNquRFRk7CnVLgkC2ZPj8llEMJg5Y8dJ3T76SvTGtceytniaztQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.0.1.tgz",
+            "integrity": "sha512-zGzleORFXrRWRJAMLTB2iJD1IZbCPkg4hsI8mGdpYlKaqzvKYSEWVAYh14eauaR+qIoZVWrXgYSXqLtTlxotiw==",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "3.6.1",
-                "@typescript-eslint/visitor-keys": "3.6.1",
+                "@typescript-eslint/types": "4.0.1",
+                "@typescript-eslint/visitor-keys": "4.0.1",
                 "debug": "^4.1.1",
-                "glob": "^7.1.6",
+                "globby": "^11.0.1",
                 "is-glob": "^4.0.1",
                 "lodash": "^4.17.15",
                 "semver": "^7.3.2",
@@ -2767,25 +3165,26 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "3.6.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-3.6.1.tgz",
-            "integrity": "sha512-qC8Olwz5ZyMTZrh4Wl3K4U6tfms0R/mzU4/5W3XeUZptVraGVmbptJbn6h2Ey6Rb3hOs3zWoAUebZk8t47KGiQ==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.0.1.tgz",
+            "integrity": "sha512-yBSqd6FjnTzbg5RUy9J+9kJEyQjTI34JdGMJz+9ttlJzLCnGkBikxw+N5n2VDcc3CesbIEJ0MnZc5uRYnrEnCw==",
             "dev": true,
             "requires": {
-                "eslint-visitor-keys": "^1.1.0"
+                "@typescript-eslint/types": "4.0.1",
+                "eslint-visitor-keys": "^2.0.0"
             }
         },
         "@vaadin/vaadin-button": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-button/-/vaadin-button-2.3.0.tgz",
-            "integrity": "sha512-FnKvsxwBQhXWV/kW+PNY+vFF+V6cQE6IiSH32LZ6rlZ+aqsvpRLEF4yNr3sg39yBsdWfeU1J+44Ne4chPbcizA==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-button/-/vaadin-button-2.4.0.tgz",
+            "integrity": "sha512-C94F07OOb5Ciq2BY4CklIQG+WJFA6QoTFDQl8JJloJgPI12b9kmyP8uRgfq4VAHHusqKqIvA8AB6VZuGg5lagg==",
             "requires": {
                 "@polymer/polymer": "^3.0.0",
-                "@vaadin/vaadin-control-state-mixin": "^2.1.1",
-                "@vaadin/vaadin-element-mixin": "^2.0.0",
+                "@vaadin/vaadin-control-state-mixin": "^2.2.1",
+                "@vaadin/vaadin-element-mixin": "^2.4.1",
                 "@vaadin/vaadin-lumo-styles": "^1.3.3",
                 "@vaadin/vaadin-material-styles": "^1.2.0",
-                "@vaadin/vaadin-themable-mixin": "^1.2.1"
+                "@vaadin/vaadin-themable-mixin": "^1.6.1"
             }
         },
         "@vaadin/vaadin-control-state-mixin": {
@@ -2830,15 +3229,15 @@
             }
         },
         "@vaadin/vaadin-progress-bar": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-progress-bar/-/vaadin-progress-bar-1.2.0.tgz",
-            "integrity": "sha512-Yx7thw2KcPQtiFK7eA2pPmWn7xMaeb/yKGOPEMT4Jo7TMQtzl78wx1uy45+Ki/oX2lwZMNu3PuCa3rQNZzu1+Q==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-progress-bar/-/vaadin-progress-bar-1.3.0.tgz",
+            "integrity": "sha512-kPkG2M99UHHJVMX8TNN++KdU/rLTsDuDTNLUypcNVWDGDo0oHOY2P29yqwu8x6rGM3bIzgyQIgNSukKmIAjYcQ==",
             "requires": {
                 "@polymer/polymer": "^3.0.0",
-                "@vaadin/vaadin-element-mixin": "^2.3.0",
+                "@vaadin/vaadin-element-mixin": "^2.4.1",
                 "@vaadin/vaadin-lumo-styles": "^1.1.0",
                 "@vaadin/vaadin-material-styles": "^1.1.0",
-                "@vaadin/vaadin-themable-mixin": "^1.2.1"
+                "@vaadin/vaadin-themable-mixin": "^1.6.1"
             }
         },
         "@vaadin/vaadin-themable-mixin": {
@@ -2851,17 +3250,17 @@
             }
         },
         "@vaadin/vaadin-upload": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-upload/-/vaadin-upload-4.3.0.tgz",
-            "integrity": "sha512-7ZD+mfAFzULs9Qc6qbPf5BuAEktxjP1Dq2bwzQuUxCw/p7q7u/m73cAV2R+Zph8NNOsgP6i2QY/zt12B14VESw==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-upload/-/vaadin-upload-4.4.0.tgz",
+            "integrity": "sha512-HLXotsPxJxQtjpUPBjY/lwM1n4GfzWo75vxKKZkdlh0NjYSmk7G6dq9iHyVp22zN4T03YwuTHwal6zvNoukXXg==",
             "requires": {
                 "@polymer/polymer": "^3.0.0",
-                "@vaadin/vaadin-button": "^2.3.0",
-                "@vaadin/vaadin-element-mixin": "^2.3.0",
+                "@vaadin/vaadin-button": "^2.4.0",
+                "@vaadin/vaadin-element-mixin": "^2.4.1",
                 "@vaadin/vaadin-lumo-styles": "^1.1.0",
                 "@vaadin/vaadin-material-styles": "^1.1.0",
-                "@vaadin/vaadin-progress-bar": "^1.2.0",
-                "@vaadin/vaadin-themable-mixin": "^1.2.1"
+                "@vaadin/vaadin-progress-bar": "^1.3.0",
+                "@vaadin/vaadin-themable-mixin": "^1.6.1"
             }
         },
         "@vaadin/vaadin-usage-statistics": {
@@ -3094,9 +3493,9 @@
             }
         },
         "acorn": {
-            "version": "7.3.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
-            "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
+            "version": "7.4.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.0.tgz",
+            "integrity": "sha512-+G7P8jJmCHr+S+cLfQxygbWhXy+8YTVGzAkpEbcLo2mLoL7tij/VG41QSHACSf5QgYRhMZYHuNc6drJaO0Da+w==",
             "dev": true
         },
         "acorn-jsx": {
@@ -3127,9 +3526,9 @@
             }
         },
         "ajv": {
-            "version": "6.12.3",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.3.tgz",
-            "integrity": "sha512-4K0cK3L1hsqk9xIb2z9vs/XU+PGJZ9PNpJRDS9YLzmNdX6jmVPfamLvTJr0aDAusnHyCHO6MjzlkAsgtqp9teA==",
+            "version": "6.12.4",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.4.tgz",
+            "integrity": "sha512-eienB2c9qVQs2KWexhkrdMLVDoIQCz5KSeLxwg9Lzk4DOfBtIK9PQwwufcsn1jjGuf9WZmqPMbGxOzfcuphJCQ==",
             "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -3263,12 +3662,10 @@
             "dev": true
         },
         "array-union": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-            "requires": {
-                "array-uniq": "^1.0.1"
-            }
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true
         },
         "array-uniq": {
             "version": "1.0.3",
@@ -3421,9 +3818,9 @@
             "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.0.tgz",
-            "integrity": "sha512-3YDiu347mtVtjpyV3u5kVqQLP242c06zwDOgpeRnybmXlYYsLbtTrUBUm8i8srONt+FWobl5aibnU1030PeeuA=="
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.10.1.tgz",
+            "integrity": "sha512-zg7Hz2k5lI8kb7U32998pRRFin7zJlkfezGJjUc2heaD4Pw2wObakCDVzkKztTm/Ln7eiVvYsjqak0Ed4LkMDA=="
         },
         "axios": {
             "version": "0.19.2",
@@ -3587,9 +3984,9 @@
             }
         },
         "bl": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
-            "integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.3.tgz",
+            "integrity": "sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==",
             "requires": {
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
@@ -3759,9 +4156,9 @@
                     }
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
@@ -3779,30 +4176,11 @@
             }
         },
         "braces": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-            "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
             "requires": {
-                "arr-flatten": "^1.1.0",
-                "array-unique": "^0.3.2",
-                "extend-shallow": "^2.0.1",
-                "fill-range": "^4.0.0",
-                "isobject": "^3.0.1",
-                "repeat-element": "^1.1.2",
-                "snapdragon": "^0.8.1",
-                "snapdragon-node": "^2.0.1",
-                "split-string": "^3.0.2",
-                "to-regex": "^3.0.1"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                }
+                "fill-range": "^7.0.1"
             }
         },
         "brorand": {
@@ -4040,9 +4418,9 @@
             },
             "dependencies": {
                 "get-stream": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
                     "dev": true,
                     "requires": {
                         "pump": "^3.0.0"
@@ -4174,9 +4552,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
@@ -4209,9 +4587,9 @@
             }
         },
         "chokidar": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.0.tgz",
-            "integrity": "sha512-aXAaho2VJtisB/1fg1+3nlLJqGOuewTzQpd/Tz0yTg2R0e4IGtshYvtjowyEumcBv2z+y4+kc75Mz7j5xJskcQ==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+            "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
             "requires": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
@@ -4221,37 +4599,6 @@
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
                 "readdirp": "~3.4.0"
-            },
-            "dependencies": {
-                "braces": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-                    "requires": {
-                        "fill-range": "^7.0.1"
-                    }
-                },
-                "fill-range": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-                    "requires": {
-                        "to-regex-range": "^5.0.1"
-                    }
-                },
-                "is-number": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-                },
-                "to-regex-range": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-                    "requires": {
-                        "is-number": "^7.0.0"
-                    }
-                }
             }
         },
         "chownr": {
@@ -4320,9 +4667,9 @@
             }
         },
         "cli-boxes": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.0.tgz",
-            "integrity": "sha512-gpaBrMAizVEANOpfZp/EEUixTXDyGt7DFzdK5hU+UbWt/J0lB0w20ncZj59Z9a93xHb9u12zF5BS6i9RKbtg4w==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-2.2.1.tgz",
+            "integrity": "sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==",
             "dev": true
         },
         "cli-cursor": {
@@ -4479,23 +4826,29 @@
             "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
         },
         "compare-func": {
-            "version": "1.3.4",
-            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-1.3.4.tgz",
-            "integrity": "sha512-sq2sWtrqKPkEXAC8tEJA1+BqAH9GbFkGBtUOqrUX57VSfwp8xyktctk+uLoRy5eccTdxzDcVIztlYDpKs3Jv1Q==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/compare-func/-/compare-func-2.0.0.tgz",
+            "integrity": "sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==",
             "dev": true,
             "requires": {
                 "array-ify": "^1.0.0",
-                "dot-prop": "^3.0.0"
+                "dot-prop": "^5.1.0"
             },
             "dependencies": {
                 "dot-prop": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-3.0.0.tgz",
-                    "integrity": "sha1-G3CK8JSknJoOfbyteQq6U52sEXc=",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-5.2.0.tgz",
+                    "integrity": "sha512-uEUyaDKoSQ1M4Oq8l45hSE26SnTxL6snNnqvK/VWx5wJhmff5z0FUVJDKDanor/6w3kzE3i7XZOk+7wC0EXr1A==",
                     "dev": true,
                     "requires": {
-                        "is-obj": "^1.0.0"
+                        "is-obj": "^2.0.0"
                     }
+                },
+                "is-obj": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-2.0.0.tgz",
+                    "integrity": "sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==",
+                    "dev": true
                 }
             }
         },
@@ -4687,12 +5040,12 @@
             "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
         },
         "conventional-changelog-angular": {
-            "version": "5.0.10",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.10.tgz",
-            "integrity": "sha512-k7RPPRs0vp8+BtPsM9uDxRl6KcgqtCJmzRD1wRtgqmhQ96g8ifBGo9O/TZBG23jqlXS/rg8BKRDELxfnQQGiaA==",
+            "version": "5.0.11",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-angular/-/conventional-changelog-angular-5.0.11.tgz",
+            "integrity": "sha512-nSLypht/1yEflhuTogC03i7DX7sOrXGsRn14g131Potqi6cbGbGEE9PSDEHKldabB6N76HiSyw9Ph+kLmC04Qw==",
             "dev": true,
             "requires": {
-                "compare-func": "^1.3.1",
+                "compare-func": "^2.0.0",
                 "q": "^1.5.1"
             }
         },
@@ -4736,12 +5089,12 @@
             "dev": true
         },
         "conventional-changelog-writer": {
-            "version": "4.0.16",
-            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.16.tgz",
-            "integrity": "sha512-jmU1sDJDZpm/dkuFxBeRXvyNcJQeKhGtVcFFkwTphUAzyYWcwz2j36Wcv+Mv2hU3tpvLMkysOPXJTLO55AUrYQ==",
+            "version": "4.0.17",
+            "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.0.17.tgz",
+            "integrity": "sha512-IKQuK3bib/n032KWaSb8YlBFds+aLmzENtnKtxJy3+HqDq5kohu3g/UdNbIHeJWygfnEbZjnCKFxAW0y7ArZAw==",
             "dev": true,
             "requires": {
-                "compare-func": "^1.3.1",
+                "compare-func": "^2.0.0",
                 "conventional-commits-filter": "^2.0.6",
                 "dateformat": "^3.0.0",
                 "handlebars": "^4.7.6",
@@ -5344,6 +5697,14 @@
                 "rimraf": "^2.6.3"
             },
             "dependencies": {
+                "array-union": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                    "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                    "requires": {
+                        "array-uniq": "^1.0.1"
+                    }
+                },
                 "globby": {
                     "version": "6.1.0",
                     "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
@@ -5491,44 +5852,27 @@
             }
         },
         "dir-glob": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-            "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
             "requires": {
-                "path-type": "^3.0.0"
-            },
-            "dependencies": {
-                "path-type": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-                    "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
-                    "dev": true,
-                    "requires": {
-                        "pify": "^3.0.0"
-                    }
-                },
-                "pify": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-                    "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-                    "dev": true
-                }
+                "path-type": "^4.0.0"
             }
         },
         "discord.js": {
-            "version": "12.2.0",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.2.0.tgz",
-            "integrity": "sha512-Ueb/0SOsxXyqwvwFYFe0msMrGqH1OMqpp2Dpbplnlr4MzcRrFWwsBM9gKNZXPVBHWUKiQkwU8AihXBXIvTTSvg==",
+            "version": "12.3.1",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.3.1.tgz",
+            "integrity": "sha512-mSFyV/mbvzH12UXdS4zadmeUf8IMQOo/YdunubG1wWt1xjWvtaJz/s9CGsFD2B5pTw1W/LXxxUbrQjIZ/xlUdw==",
             "requires": {
-                "@discordjs/collection": "^0.1.5",
+                "@discordjs/collection": "^0.1.6",
                 "@discordjs/form-data": "^3.0.1",
                 "abort-controller": "^3.0.0",
                 "node-fetch": "^2.6.0",
-                "prism-media": "^1.2.0",
+                "prism-media": "^1.2.2",
                 "setimmediate": "^1.0.5",
                 "tweetnacl": "^1.0.3",
-                "ws": "^7.2.1"
+                "ws": "^7.3.1"
             },
             "dependencies": {
                 "tweetnacl": {
@@ -5584,9 +5928,9 @@
             }
         },
         "dot-prop": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
-            "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.1.tgz",
+            "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
             "dev": true,
             "requires": {
                 "is-obj": "^1.0.0"
@@ -5602,9 +5946,9 @@
             }
         },
         "duplexer": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
-            "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+            "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
         },
         "duplexer3": {
@@ -5655,12 +5999,12 @@
             "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "elgato-stream-deck": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/elgato-stream-deck/-/elgato-stream-deck-3.3.1.tgz",
-            "integrity": "sha512-0WR8Ge3O1uHMxkZnB/q7/lcGmN8NJtSuWACEOwF5zz36JROdM79/iX4MKoErIq5XPQhV4CtKrPL0Wea/YOsEmA==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/elgato-stream-deck/-/elgato-stream-deck-3.3.2.tgz",
+            "integrity": "sha512-NIrL2wFSXGsi/5ZNmBGNO/5fJGP64IhzeY1rc9e06CGoTw57+Hi6XFB4vjyUbnbnxGwbKl+aZMmO43eRAIPgRQ==",
             "requires": {
                 "exit-hook": "^2.2.0",
-                "jpeg-js": "^0.3.5",
+                "jpeg-js": "^0.4.2",
                 "node-hid": "^1.2.0"
             }
         },
@@ -5807,9 +6151,9 @@
             "dev": true
         },
         "envinfo": {
-            "version": "7.5.1",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.5.1.tgz",
-            "integrity": "sha512-hQBkDf2iO4Nv0CNHpCuSBeaSrveU6nThVxFGTrq/eDlV716UQk09zChaJae4mZRsos1x4YLY2TaH3LHUae3ZmQ==",
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.7.3.tgz",
+            "integrity": "sha512-46+j5QxbPWza0PB1i15nZx0xQ4I/EfQxg9J8Had3b408SV63nEtor2e+oiY63amTo9KTuh2a3XLObNwduxYwwA==",
             "dev": true
         },
         "err-code": {
@@ -5918,12 +6262,13 @@
             "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "eslint": {
-            "version": "7.4.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.4.0.tgz",
-            "integrity": "sha512-gU+lxhlPHu45H3JkEGgYhWhkR9wLHHEXC9FbWFnTlEkbKyZKWgWRLgf61E8zWmBuI6g5xKBph9ltg3NtZMVF8g==",
+            "version": "7.8.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-7.8.1.tgz",
+            "integrity": "sha512-/2rX2pfhyUG0y+A123d0ccXtMm7DV7sH1m3lk9nk2DZ2LReq39FXHueR9xZwshE5MdfSf0xunSaMWRqyIA6M1w==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
+                "@eslint/eslintrc": "^0.1.3",
                 "ajv": "^6.10.0",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -5931,9 +6276,9 @@
                 "doctrine": "^3.0.0",
                 "enquirer": "^2.3.5",
                 "eslint-scope": "^5.1.0",
-                "eslint-utils": "^2.0.0",
-                "eslint-visitor-keys": "^1.2.0",
-                "espree": "^7.1.0",
+                "eslint-utils": "^2.1.0",
+                "eslint-visitor-keys": "^1.3.0",
+                "espree": "^7.3.0",
                 "esquery": "^1.2.0",
                 "esutils": "^2.0.2",
                 "file-entry-cache": "^5.0.1",
@@ -5947,7 +6292,7 @@
                 "js-yaml": "^3.13.1",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "levn": "^0.4.1",
-                "lodash": "^4.17.14",
+                "lodash": "^4.17.19",
                 "minimatch": "^3.0.4",
                 "natural-compare": "^1.4.0",
                 "optionator": "^0.9.1",
@@ -5959,6 +6304,20 @@
                 "table": "^5.2.3",
                 "text-table": "^0.2.0",
                 "v8-compile-cache": "^2.0.3"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                },
+                "ignore": {
+                    "version": "4.0.6",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+                    "dev": true
+                }
             }
         },
         "eslint-config-prettier": {
@@ -5996,23 +6355,39 @@
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^1.1.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
             }
         },
         "eslint-visitor-keys": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
-            "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+            "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
             "dev": true
         },
         "espree": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-7.1.0.tgz",
-            "integrity": "sha512-dcorZSyfmm4WTuTnE5Y7MEN1DyoPYy1ZR783QW1FJoenn7RailyWFsq/UL6ZAAA7uXurN9FIpYyUs3OfiIW+Qw==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-7.3.0.tgz",
+            "integrity": "sha512-dksIWsvKCixn1yrEXO8UosNSxaDoSYpq9reEjZSbHLpT5hpaCAKTLBwq0RHtLrIr+c0ByiYzWT8KTMRzoRCNlw==",
             "dev": true,
             "requires": {
-                "acorn": "^7.2.0",
+                "acorn": "^7.4.0",
                 "acorn-jsx": "^5.2.0",
-                "eslint-visitor-keys": "^1.2.0"
+                "eslint-visitor-keys": "^1.3.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "1.3.0",
+                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+                    "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+                    "dev": true
+                }
             }
         },
         "esprima": {
@@ -6031,19 +6406,26 @@
             },
             "dependencies": {
                 "estraverse": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.1.0.tgz",
-                    "integrity": "sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
                     "dev": true
                 }
             }
         },
         "esrecurse": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
-            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+            "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "requires": {
-                "estraverse": "^4.1.0"
+                "estraverse": "^5.2.0"
+            },
+            "dependencies": {
+                "estraverse": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+                    "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ=="
+                }
             }
         },
         "estraverse": {
@@ -6485,40 +6867,17 @@
             "dev": true
         },
         "fast-glob": {
-            "version": "2.2.7",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-2.2.7.tgz",
-            "integrity": "sha512-g1KuQwHOZAmOZMuBtHdxDtju+T2RT8jgCC9aANsbpdiDDTSnjgfuVsIBNKbUeJI3oKMRExcfNDtJl4OhbffMsw==",
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+            "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
             "dev": true,
             "requires": {
-                "@mrmlnc/readdir-enhanced": "^2.2.1",
-                "@nodelib/fs.stat": "^1.1.2",
-                "glob-parent": "^3.1.0",
-                "is-glob": "^4.0.0",
-                "merge2": "^1.2.3",
-                "micromatch": "^3.1.10"
-            },
-            "dependencies": {
-                "glob-parent": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-3.1.0.tgz",
-                    "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^3.1.0",
-                        "path-dirname": "^1.0.0"
-                    },
-                    "dependencies": {
-                        "is-glob": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
-                            "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-                            "dev": true,
-                            "requires": {
-                                "is-extglob": "^2.1.0"
-                            }
-                        }
-                    }
-                }
+                "@nodelib/fs.stat": "^2.0.2",
+                "@nodelib/fs.walk": "^1.2.3",
+                "glob-parent": "^5.1.0",
+                "merge2": "^1.3.0",
+                "micromatch": "^4.0.2",
+                "picomatch": "^2.2.1"
             }
         },
         "fast-json-stable-stringify": {
@@ -6541,6 +6900,15 @@
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/fast-text-encoding/-/fast-text-encoding-1.0.3.tgz",
             "integrity": "sha512-dtm4QZH9nZtcDt8qJiOH9fcQd1NAgi+K1O2DbE6GG1PPCK/BWfOH3idCTRQ4ImXRUOyopDEgDEnVEE7Y/2Wrig=="
+        },
+        "fastq": {
+            "version": "1.8.0",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.8.0.tgz",
+            "integrity": "sha512-SMIZoZdLh/fgofivvIkmknUXyPnvxRE3DhtZ5Me3Mrsk5gyPL42F0xr51TdRXskBxHfMp+07bcYzfsYEsSQA9Q==",
+            "dev": true,
+            "requires": {
+                "reusify": "^1.0.4"
+            }
         },
         "figgy-pudding": {
             "version": "3.5.2",
@@ -6576,24 +6944,11 @@
             "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
         },
         "fill-range": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-            "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
             "requires": {
-                "extend-shallow": "^2.0.1",
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1",
-                "to-regex-range": "^2.1.0"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                }
+                "to-regex-range": "^5.0.1"
             }
         },
         "finalhandler": {
@@ -6717,6 +7072,103 @@
                 "is-glob": "^4.0.0",
                 "micromatch": "^3.0.4",
                 "resolve-dir": "^1.0.1"
+            },
+            "dependencies": {
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
+                    }
+                }
             }
         },
         "fizzy-ui-utils": {
@@ -7523,9 +7975,9 @@
             }
         },
         "git-up": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.1.tgz",
-            "integrity": "sha512-LFTZZrBlrCrGCG07/dm1aCjjpL1z9L3+5aEeI9SBhAqSc+kiA9Or1bgZhQFNppJX6h/f5McrvJt1mQXTFm6Qrw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/git-up/-/git-up-4.0.2.tgz",
+            "integrity": "sha512-kbuvus1dWQB2sSW4cbfTeGpCMd8ge9jx9RKnhXhuJ7tnvT+NIrTVfYZxjtflZddQYcmdOTlkAcjmx7bor+15AQ==",
             "dev": true,
             "requires": {
                 "is-ssh": "^1.3.0",
@@ -7533,9 +7985,9 @@
             }
         },
         "git-url-parse": {
-            "version": "11.1.2",
-            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.2.tgz",
-            "integrity": "sha512-gZeLVGY8QVKMIkckncX+iCq2/L8PlwncvDFKiWkBn9EtCfYDbliRTTp6qzyQ1VMdITUfq7293zDzfpjdiGASSQ==",
+            "version": "11.1.3",
+            "resolved": "https://registry.npmjs.org/git-url-parse/-/git-url-parse-11.1.3.tgz",
+            "integrity": "sha512-GPsfwticcu52WQ+eHp0IYkAyaOASgYdtsQDIt4rUp6GbiNt1P9ddrh3O0kQB0eD4UJZszVqNT3+9Zwcg40fywA==",
             "dev": true,
             "requires": {
                 "git-up": "^4.0.0"
@@ -7651,27 +8103,17 @@
             }
         },
         "globby": {
-            "version": "9.2.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-9.2.0.tgz",
-            "integrity": "sha512-ollPHROa5mcxDEkwg6bPt3QbEf4pDQSNtd6JPL1YvOvAo/7/0VAm9TccUeoTmarjPw4pfUthSCqcyfNB1I3ZSg==",
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+            "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
             "dev": true,
             "requires": {
-                "@types/glob": "^7.1.1",
-                "array-union": "^1.0.2",
-                "dir-glob": "^2.2.2",
-                "fast-glob": "^2.2.6",
-                "glob": "^7.1.3",
-                "ignore": "^4.0.3",
-                "pify": "^4.0.1",
-                "slash": "^2.0.0"
-            },
-            "dependencies": {
-                "slash": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/slash/-/slash-2.0.0.tgz",
-                    "integrity": "sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==",
-                    "dev": true
-                }
+                "array-union": "^2.1.0",
+                "dir-glob": "^3.0.1",
+                "fast-glob": "^3.1.1",
+                "ignore": "^5.1.4",
+                "merge2": "^1.3.0",
+                "slash": "^3.0.0"
             }
         },
         "good-listener": {
@@ -7719,20 +8161,20 @@
             }
         },
         "google-p12-pem": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.2.tgz",
-            "integrity": "sha512-tbjzndQvSIHGBLzHnhDs3cL4RBjLbLXc2pYvGH+imGVu5b4RMAttUTdnmW2UH0t11QeBTXZ7wlXPS7hrypO/tg==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/google-p12-pem/-/google-p12-pem-3.0.3.tgz",
+            "integrity": "sha512-wS0ek4ZtFx/ACKYF3JhyGe5kzH7pgiQ7J5otlumqR9psmWMYc+U9cErKlCYVYHoUaidXHdZ2xbo34kB+S+24hA==",
             "requires": {
-                "node-forge": "^0.9.0"
+                "node-forge": "^0.10.0"
             }
         },
         "googleapis": {
-            "version": "52.1.0",
-            "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-52.1.0.tgz",
-            "integrity": "sha512-8eHVXidZv/C/xos/rEIlWZCwuR638yaqjlBMMk2y9iT8hOe7ebkgW0pENUv8KeSFowTQFKCfQ/nLdBRM8z2hUg==",
+            "version": "59.0.0",
+            "resolved": "https://registry.npmjs.org/googleapis/-/googleapis-59.0.0.tgz",
+            "integrity": "sha512-GV/E4KRN89a4GxSk7D7cwUfRYgcJHR05sOgm/WGdwc/u8dxNXG5lWmz9gF5ZwFGk2yKtVxL4VZNn4zBuZ6rmGg==",
             "requires": {
                 "google-auth-library": "^6.0.0",
-                "googleapis-common": "^4.3.0"
+                "googleapis-common": "^4.4.0"
             }
         },
         "googleapis-common": {
@@ -7829,11 +8271,11 @@
             "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
-            "version": "5.1.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-            "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+            "version": "5.1.5",
+            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
+            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
             "requires": {
-                "ajv": "^6.5.5",
+                "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
             }
         },
@@ -7905,6 +8347,24 @@
                 "kind-of": "^4.0.0"
             },
             "dependencies": {
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
                 "kind-of": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
@@ -8088,6 +8548,12 @@
                 }
             }
         },
+        "human-signals": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
+            "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
+            "dev": true
+        },
         "humanize-ms": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/humanize-ms/-/humanize-ms-1.2.1.tgz",
@@ -8147,9 +8613,9 @@
             "integrity": "sha512-fj5vX5kkpRbMb5Qje6veIDzqoJpnCEqUDdSOwASOeQHYmb8hLYX6Ev2yXf3jjMs2MclwcYY3chyZ3diGKcr8DA=="
         },
         "ignore": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+            "version": "5.1.8",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+            "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
             "dev": true
         },
         "ignore-by-default": {
@@ -8415,26 +8881,21 @@
             "integrity": "sha512-HtszKchBQTcqw1DC09uD7i7vvMayHGM1OCo6AHt5pkgZEyo99ClhHTMJdf+Ezc9ovuNNxcH89QfyclGthjZJOw=="
         },
         "ircv3": {
-            "version": "0.24.1",
-            "resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.24.1.tgz",
-            "integrity": "sha512-wBKrY/IikmlIaqN0wMf8EYyCLaJn3X1O73OtztKg7pJWoaxymu/g4EgQrZiG/E5wlhdXOna6dtUEVLln39iP7A==",
+            "version": "0.26.0",
+            "resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.26.0.tgz",
+            "integrity": "sha512-/2vzYh5ut/9tmROt7q+MlBqq2rDKpPxR8yidBkbirODRR/xTn2FW9YrV4Fo3OQdQXayZzwjUWHYuo9oI50HxpQ==",
             "requires": {
                 "@d-fischer/connection": "^6.0.1",
                 "@d-fischer/escape-string-regexp": "^5.0.0",
                 "@d-fischer/klona": "^1.1.5",
-                "@d-fischer/logger": "^1.0.3",
-                "@d-fischer/shared-utils": "^2.0.0",
-                "@d-fischer/typed-event-emitter": "^3.0.0",
+                "@d-fischer/logger": "^2.0.0",
+                "@d-fischer/shared-utils": "^2.3.1",
+                "@d-fischer/typed-event-emitter": "^3.0.1",
                 "@types/clone": "^0.1.30",
-                "@types/node": "^14.0.11",
+                "@types/node": "^14.0.20",
                 "clone": "^2.1.2"
             },
             "dependencies": {
-                "@types/node": {
-                    "version": "14.6.0",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-                    "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
-                },
                 "clone": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -8630,22 +9091,9 @@
             "dev": true
         },
         "is-number": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-            "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-            "requires": {
-                "kind-of": "^3.0.2"
-            },
-            "dependencies": {
-                "kind-of": {
-                    "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-                    "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-                    "requires": {
-                        "is-buffer": "^1.1.5"
-                    }
-                }
-            }
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
         },
         "is-obj": {
             "version": "1.0.1",
@@ -8702,9 +9150,9 @@
             "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
         },
         "is-regex": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-            "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+            "integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
             "requires": {
                 "has-symbols": "^1.0.1"
             }
@@ -8715,9 +9163,9 @@
             "integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA=="
         },
         "is-ssh": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.1.tgz",
-            "integrity": "sha512-0eRIASHZt1E68/ixClI8bp2YK2wmBPVWEismTs6M+M099jKgrzl/3E976zIbImSIob48N2/XGe9y7ZiYdImSlg==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/is-ssh/-/is-ssh-1.3.2.tgz",
+            "integrity": "sha512-elEw0/0c2UscLrNG+OAorbP539E3rhliKPg+hDMWN9VwrDXfYK+4PBEykDPfxlYYtQvl84TascnQyobfQLHEhQ==",
             "dev": true,
             "requires": {
                 "protocols": "^1.1.0"
@@ -8820,9 +9268,9 @@
             }
         },
         "jpeg-js": {
-            "version": "0.3.7",
-            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.3.7.tgz",
-            "integrity": "sha512-9IXdWudL61npZjvLuVe/ktHiA41iE8qFyLB+4VDTblEsWBzeg8WQTlktdUK4CdncUqtUgUg0bbOmTE2bKBKaBQ=="
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.2.tgz",
+            "integrity": "sha512-+az2gi/hvex7eLTMTlbRLOhH6P6WFdk2ITI8HJsaH2VqYO0I594zXSYEP+tf4FW+8Cy68ScDXoAsQdyQanv3sw=="
         },
         "js-tokens": {
             "version": "4.0.0",
@@ -8867,6 +9315,12 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
             "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
+        },
+        "json-parse-even-better-errors": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+            "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+            "dev": true
         },
         "json-ptr": {
             "version": "1.3.2",
@@ -9047,17 +9501,17 @@
             "dev": true
         },
         "lit-element": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.3.1.tgz",
-            "integrity": "sha512-tOcUAmeO3BzwiQ7FGWdsshNvC0HVHcTFYw/TLIImmKwXYoV0E7zCBASa8IJ7DiP4cen/Yoj454gS0qqTnIGsFA==",
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-2.4.0.tgz",
+            "integrity": "sha512-pBGLglxyhq/Prk2H91nA0KByq/hx/wssJBQFiYqXhGDvEnY31PRGYf1RglVzyLeRysu0IHm2K0P196uLLWmwFg==",
             "requires": {
                 "lit-html": "^1.1.1"
             }
         },
         "lit-html": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.2.1.tgz",
-            "integrity": "sha512-GSJHHXMGLZDzTRq59IUfL9FCdAlGfqNp/dEa7k7aBaaWD+JKaCjsAk9KYm2V12ItonVaYx2dprN66Zdm1AuBTQ=="
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-1.3.0.tgz",
+            "integrity": "sha512-0Q1bwmaFH9O14vycPHw8C/IeHMk/uSDldVLIefu/kfbTBGIc44KGH6A8p1bDfxUfHdc8q6Ct7kQklWoHgr4t1Q=="
         },
         "load-json-file": {
             "version": "5.3.0",
@@ -9133,9 +9587,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.19",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
-            "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ=="
+            "version": "4.17.20",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+            "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
         },
         "lodash._reinterpolate": {
             "version": "3.0.0",
@@ -9228,9 +9682,9 @@
             }
         },
         "macos-release": {
-            "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.0.tgz",
-            "integrity": "sha512-ko6deozZYiAkqa/0gmcsz+p4jSy3gY7/ZsCEokPaYd8k+6/aXGkiTgr61+Owup7Sf+xjqW8u2ElhoM9SEcEfuA==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.4.1.tgz",
+            "integrity": "sha512-H/QHeBIN1fIGJX517pvK8IEK53yQOW7YcEI55oYtgjDdoCQQz7eJS94qt5kNrscReEyuD/JcdFCm2XBEcGOITg==",
             "dev": true
         },
         "make-dir": {
@@ -9323,18 +9777,16 @@
             }
         },
         "meow": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/meow/-/meow-7.0.1.tgz",
-            "integrity": "sha512-tBKIQqVrAHqwit0vfuFPY3LlzJYkEOFyKa3bPgxzNl6q/RtN8KQ+ALYEASYuFayzSAsjlhXj/JZ10rH85Q6TUw==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/meow/-/meow-7.1.1.tgz",
+            "integrity": "sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==",
             "dev": true,
             "requires": {
                 "@types/minimist": "^1.2.0",
-                "arrify": "^2.0.1",
-                "camelcase": "^6.0.0",
                 "camelcase-keys": "^6.2.2",
                 "decamelize-keys": "^1.1.0",
                 "hard-rejection": "^2.1.0",
-                "minimist-options": "^4.0.2",
+                "minimist-options": "4.1.0",
                 "normalize-package-data": "^2.5.0",
                 "read-pkg-up": "^7.0.1",
                 "redent": "^3.0.0",
@@ -9343,18 +9795,6 @@
                 "yargs-parser": "^18.1.3"
             },
             "dependencies": {
-                "arrify": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
-                    "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
-                    "dev": true
-                },
-                "camelcase": {
-                    "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.0.0.tgz",
-                    "integrity": "sha512-8KMDF1Vz2gzOq54ONPJS65IvTUaB1cHJ2DMM7MbPmLZljDH1qpzzLsWdiN9pHh6qvkRVDTi/07+eNGch/oLU4w==",
-                    "dev": true
-                },
                 "read-pkg": {
                     "version": "5.2.0",
                     "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
@@ -9408,14 +9848,6 @@
                     "requires": {
                         "camelcase": "^5.0.0",
                         "decamelize": "^1.2.0"
-                    },
-                    "dependencies": {
-                        "camelcase": {
-                            "version": "5.3.1",
-                            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-                            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-                            "dev": true
-                        }
                     }
                 }
             }
@@ -9443,23 +9875,12 @@
             "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
         },
         "micromatch": {
-            "version": "3.1.10",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-            "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+            "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
             "requires": {
-                "arr-diff": "^4.0.0",
-                "array-unique": "^0.3.2",
-                "braces": "^2.3.1",
-                "define-property": "^2.0.2",
-                "extend-shallow": "^3.0.2",
-                "extglob": "^2.0.4",
-                "fragment-cache": "^0.2.1",
-                "kind-of": "^6.0.2",
-                "nanomatch": "^1.2.9",
-                "object.pick": "^1.3.0",
-                "regex-not": "^1.0.0",
-                "snapdragon": "^0.8.1",
-                "to-regex": "^3.0.2"
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
             }
         },
         "midi": {
@@ -9694,6 +10115,17 @@
                 "array-union": "^1.0.2",
                 "arrify": "^1.0.1",
                 "minimatch": "^3.0.4"
+            },
+            "dependencies": {
+                "array-union": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+                    "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+                    "dev": true,
+                    "requires": {
+                        "array-uniq": "^1.0.1"
+                    }
+                }
             }
         },
         "mute-stream": {
@@ -9780,9 +10212,9 @@
             "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
         },
         "node-abi": {
-            "version": "2.18.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.18.0.tgz",
-            "integrity": "sha512-yi05ZoiuNNEbyT/xXfSySZE+yVnQW6fxPZuFbLyS1s6b5Kw3HzV2PHOM4XR+nsjzkHxByK+2Wg+yCQbe35l8dw==",
+            "version": "2.19.1",
+            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.1.tgz",
+            "integrity": "sha512-HbtmIuByq44yhAzK7b9j/FelKlHYISKQn0mtvcBrU5QBkhoCMp5bu8Hv5AI34DcKfOAcJBcOEMwLlwO62FFu9A==",
             "requires": {
                 "semver": "^5.4.1"
             },
@@ -9810,9 +10242,9 @@
             }
         },
         "node-forge": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.9.1.tgz",
-            "integrity": "sha512-G6RlQt5Sb4GMBzXvhfkeFmbqR6MzhtnT7VTHuLadjkii3rdYHNdw0m8zA4BTxVIh68FicCQ2NSUANpsqkr9jvQ=="
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-0.10.0.tgz",
+            "integrity": "sha512-PPmu8eEeG9saEUvI97fm4OYxXVB6bFvyNTyiUOBichBpFG8A1Ljw3bY62+5oOjDEMHRnd0Y7HQ+x7uzxOzC6JA=="
         },
         "node-gyp": {
             "version": "5.1.1",
@@ -9966,9 +10398,9 @@
             },
             "dependencies": {
                 "bl": {
-                    "version": "1.2.2",
-                    "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-                    "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
+                    "version": "1.2.3",
+                    "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+                    "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
                     "requires": {
                         "readable-stream": "^2.3.5",
                         "safe-buffer": "^5.1.1"
@@ -10087,9 +10519,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.28",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.28.tgz",
-                    "integrity": "sha512-dzjES1Egb4c1a89C7lKwQh8pwjYmlOAG9dW1pBgxEk57tMrLnssOfEthz8kdkNaBd7lIqQx7APm5+mZ619IiCQ=="
+                    "version": "10.17.29",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.29.tgz",
+                    "integrity": "sha512-zLo9rjUeQ5+QVhOufDwrb3XKyso31fJBJnk9wUUQIBDExF/O4LryvpOfozfUaxgqifTnlt7FyqsAPXUq5yFZSA=="
                 },
                 "cacache": {
                     "version": "11.3.3",
@@ -10521,9 +10953,9 @@
             }
         },
         "open": {
-            "version": "7.1.0",
-            "resolved": "https://registry.npmjs.org/open/-/open-7.1.0.tgz",
-            "integrity": "sha512-lLPI5KgOwEYCDKXf4np7y1PBEkj7HYIyP2DY8mVDRnx0VIIu6bNrRB0R66TuO7Mack6EnTNLm4uvcl1UoklTpA==",
+            "version": "7.2.1",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.2.1.tgz",
+            "integrity": "sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==",
             "requires": {
                 "is-docker": "^2.0.0",
                 "is-wsl": "^2.1.1"
@@ -10536,11 +10968,11 @@
             "dev": true
         },
         "openid": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/openid/-/openid-2.0.6.tgz",
-            "integrity": "sha1-cHN15Zq59zAliZcnZ5sgMoFxyao=",
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/openid/-/openid-2.0.7.tgz",
+            "integrity": "sha512-xH6qaz/hS55rEX8xURz4HRUO96cpj821WY6UEG9rgcusZ8Jsq54jGWP1EMCjGvgngonw8vgSljM1i2OESv16Gw==",
             "requires": {
-                "request": "^2.61.0"
+                "request": "^2.88.2"
             }
         },
         "optionator": {
@@ -10770,14 +11202,14 @@
             "dev": true
         },
         "parse-json": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
-            "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.1.0.tgz",
+            "integrity": "sha512-+mi/lmVVNKFNVyLXV31ERiy2CY5E1/F6QtJFEzoChPRwwngMNXRDQ9GJ5WdE2Z2P4AujsOi0/+2qHID68KwfIQ==",
             "dev": true,
             "requires": {
                 "@babel/code-frame": "^7.0.0",
                 "error-ex": "^1.3.1",
-                "json-parse-better-errors": "^1.0.1",
+                "json-parse-even-better-errors": "^2.3.0",
                 "lines-and-columns": "^1.1.6"
             }
         },
@@ -10787,9 +11219,9 @@
             "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
         },
         "parse-path": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.1.tgz",
-            "integrity": "sha512-d7yhga0Oc+PwNXDvQ0Jv1BuWkLVPXcAoQ/WREgd6vNNoKYaW52KI+RdOFjI63wjkmps9yUE8VS4veP+AgpQ/hA==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/parse-path/-/parse-path-4.0.2.tgz",
+            "integrity": "sha512-HSqVz6iuXSiL8C1ku5Gl1Z5cwDd9Wo0q8CoffdAghP6bz8pJa1tcMC+m4N+z6VAS8QdksnIGq1TB6EgR4vPR6w==",
             "dev": true,
             "requires": {
                 "is-ssh": "^1.3.0",
@@ -10797,9 +11229,9 @@
             }
         },
         "parse-url": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.1.tgz",
-            "integrity": "sha512-flNUPP27r3vJpROi0/R3/2efgKkyXqnXwyP1KQ2U0SfFRgdizOdWfvrrvJg1LuOoxs7GQhmxJlq23IpQ/BkByg==",
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/parse-url/-/parse-url-5.0.2.tgz",
+            "integrity": "sha512-Czj+GIit4cdWtxo3ISZCvLiUjErSo0iI3wJ+q9Oi3QuMYTI6OZu+7cewMWZ+C1YAnKhYTk6/TLuhIgCypLthPA==",
             "dev": true,
             "requires": {
                 "is-ssh": "^1.3.0",
@@ -11050,9 +11482,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-            "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+            "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
             "dev": true
         },
         "prettier-linter-helpers": {
@@ -11065,29 +11497,33 @@
             }
         },
         "pretty-quick": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-2.0.1.tgz",
-            "integrity": "sha512-y7bJt77XadjUr+P1uKqZxFWLddvj3SKY6EU4BuQtMxmmEFSMpbN132pUWdSG1g1mtUfO0noBvn7wBf0BVeomHg==",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/pretty-quick/-/pretty-quick-3.0.0.tgz",
+            "integrity": "sha512-oIXlGQUcUxt3XpoNfQECEWvH1Q9PtKfelF2pdp6UvC1CSQ5QcB7gUYKu0kuJGlm3LMBZzJaO/vbRkxA61pWlcg==",
             "dev": true,
             "requires": {
-                "chalk": "^2.4.2",
-                "execa": "^2.1.0",
+                "chalk": "^3.0.0",
+                "execa": "^4.0.0",
                 "find-up": "^4.1.0",
                 "ignore": "^5.1.4",
-                "mri": "^1.1.4",
+                "mri": "^1.1.5",
                 "multimatch": "^4.0.0"
             },
             "dependencies": {
+                "ansi-styles": {
+                    "version": "4.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+                    "integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+                    "dev": true,
+                    "requires": {
+                        "@types/color-name": "^1.1.1",
+                        "color-convert": "^2.0.1"
+                    }
+                },
                 "array-differ": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
                     "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
-                    "dev": true
-                },
-                "array-union": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-                    "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
                     "dev": true
                 },
                 "arrify": {
@@ -11097,46 +11533,60 @@
                     "dev": true
                 },
                 "chalk": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-                    "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+                    "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
                     "dev": true,
                     "requires": {
-                        "ansi-styles": "^3.2.1",
-                        "escape-string-regexp": "^1.0.5",
-                        "supports-color": "^5.3.0"
+                        "ansi-styles": "^4.1.0",
+                        "supports-color": "^7.1.0"
                     }
                 },
+                "color-convert": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+                    "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+                    "dev": true,
+                    "requires": {
+                        "color-name": "~1.1.4"
+                    }
+                },
+                "color-name": {
+                    "version": "1.1.4",
+                    "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+                    "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+                    "dev": true
+                },
                 "execa": {
-                    "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/execa/-/execa-2.1.0.tgz",
-                    "integrity": "sha512-Y/URAVapfbYy2Xp/gb6A0E7iR8xeqOCXsuuaoMn7A5PzrXUK84E1gyiEfq0wQd/GHA6GsoHWwhNq8anb0mleIw==",
+                    "version": "4.0.3",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.3.tgz",
+                    "integrity": "sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==",
                     "dev": true,
                     "requires": {
                         "cross-spawn": "^7.0.0",
                         "get-stream": "^5.0.0",
+                        "human-signals": "^1.1.1",
                         "is-stream": "^2.0.0",
                         "merge-stream": "^2.0.0",
-                        "npm-run-path": "^3.0.0",
+                        "npm-run-path": "^4.0.0",
                         "onetime": "^5.1.0",
-                        "p-finally": "^2.0.0",
                         "signal-exit": "^3.0.2",
                         "strip-final-newline": "^2.0.0"
                     }
                 },
                 "get-stream": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.1.0.tgz",
-                    "integrity": "sha512-EXr1FOzrzTfGeL0gQdeFEvOMm2mzMOglyiOXSTpPC+iAjAKftbr3jpCMWynogwYnM+eSj9sHGc6wjIcDvYiygw==",
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
+                    "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
                     "dev": true,
                     "requires": {
                         "pump": "^3.0.0"
                     }
                 },
-                "ignore": {
-                    "version": "5.1.8",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+                "has-flag": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+                    "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
                     "dev": true
                 },
                 "is-stream": {
@@ -11165,28 +11615,31 @@
                     }
                 },
                 "npm-run-path": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-3.1.0.tgz",
-                    "integrity": "sha512-Dbl4A/VfiVGLgQv29URL9xshU8XDY1GeLy+fsaZ1AA8JDSfjvr5P5+pzRbWqRSBxk6/DW7MIh8lTM/PaGnP2kg==",
+                    "version": "4.0.1",
+                    "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+                    "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
                     "dev": true,
                     "requires": {
                         "path-key": "^3.0.0"
                     }
                 },
                 "onetime": {
-                    "version": "5.1.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.0.tgz",
-                    "integrity": "sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==",
+                    "version": "5.1.2",
+                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+                    "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
                     "dev": true,
                     "requires": {
                         "mimic-fn": "^2.1.0"
                     }
                 },
-                "p-finally": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-                    "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-                    "dev": true
+                "supports-color": {
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+                    "dev": true,
+                    "requires": {
+                        "has-flag": "^4.0.0"
+                    }
                 }
             }
         },
@@ -11241,9 +11694,9 @@
             "dev": true
         },
         "protocols": {
-            "version": "1.4.7",
-            "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.7.tgz",
-            "integrity": "sha512-Fx65lf9/YDn3hUX08XUc0J8rSux36rEsyiv21ZGUC1mOyeM3lTRpZLcrm8aAolzS4itwVfm7TAPyxC2E5zd6xg==",
+            "version": "1.4.8",
+            "resolved": "https://registry.npmjs.org/protocols/-/protocols-1.4.8.tgz",
+            "integrity": "sha512-IgjKyaUSjsROSO8/D49Ab7hP8mJgTYcqApOqdPhLoPxAplXmkp+zRvsrSQjFn5by0rhm4VH0GAUELIPpx7B1yg==",
             "dev": true
         },
         "protoduck": {
@@ -11498,14 +11951,13 @@
             }
         },
         "read-package-json": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
-            "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.2.tgz",
+            "integrity": "sha512-D1KmuLQr6ZSJS0tW8hf3WGpRlwszJOXZ3E8Yd/DNRaM5d+1wVRZdHlpGBLAuovjr28LbWvjpWkBHMxpRGGjzNA==",
             "dev": true,
             "requires": {
                 "glob": "^7.1.1",
-                "graceful-fs": "^4.1.2",
-                "json-parse-better-errors": "^1.0.1",
+                "json-parse-even-better-errors": "^2.3.0",
                 "normalize-package-data": "^2.0.0",
                 "npm-normalize-package-bin": "^1.0.0"
             }
@@ -11898,6 +12350,12 @@
             "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
             "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
         },
+        "reusify": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
+        },
         "rimraf": {
             "version": "2.6.3",
             "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
@@ -11921,6 +12379,12 @@
             "integrity": "sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==",
             "dev": true
         },
+        "run-parallel": {
+            "version": "1.1.9",
+            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
+            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+            "dev": true
+        },
         "run-queue": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/run-queue/-/run-queue-1.0.3.tgz",
@@ -11930,9 +12394,9 @@
             }
         },
         "rxjs": {
-            "version": "6.6.0",
-            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.0.tgz",
-            "integrity": "sha512-3HMA8z/Oz61DUHe+SdOiQyzIf4tOx5oQHmMir7IZEu6TMqCLHT4LRcmNaUS0NwOz8VLvmmBduMsoaUvMaIiqzg==",
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.2.tgz",
+            "integrity": "sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==",
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
@@ -13135,12 +13599,11 @@
             }
         },
         "to-regex-range": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-            "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "requires": {
-                "is-number": "^3.0.0",
-                "repeat-string": "^1.6.1"
+                "is-number": "^7.0.0"
             }
         },
         "toidentifier": {
@@ -13203,9 +13666,9 @@
             "dev": true
         },
         "ts-loader": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.2.tgz",
-            "integrity": "sha512-oYT7wOTUawYXQ8XIDsRhziyW0KUEV38jISYlE+9adP6tDtG+O5GkRe4QKQXrHVH4mJJ88DysvEtvGP65wMLlhg==",
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.3.tgz",
+            "integrity": "sha512-wsqfnVdB7xQiqhqbz2ZPLGHLPZbHVV5Qn/MNFZkCFxRU1miDyxKORucDGxKtsQJ63Rfza0udiUxWF5nHY6bpdQ==",
             "requires": {
                 "chalk": "^2.3.0",
                 "enhanced-resolve": "^4.0.0",
@@ -13214,14 +13677,6 @@
                 "semver": "^6.0.0"
             },
             "dependencies": {
-                "braces": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-                    "requires": {
-                        "fill-range": "^7.0.1"
-                    }
-                },
                 "chalk": {
                     "version": "2.4.2",
                     "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -13232,40 +13687,10 @@
                         "supports-color": "^5.3.0"
                     }
                 },
-                "fill-range": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-                    "requires": {
-                        "to-regex-range": "^5.0.1"
-                    }
-                },
-                "is-number": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-                },
-                "micromatch": {
-                    "version": "4.0.2",
-                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-                    "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-                    "requires": {
-                        "braces": "^3.0.1",
-                        "picomatch": "^2.0.5"
-                    }
-                },
                 "semver": {
                     "version": "6.3.0",
                     "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
                     "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-                },
-                "to-regex-range": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-                    "requires": {
-                        "is-number": "^7.0.0"
-                    }
                 }
             }
         },
@@ -13315,31 +13740,53 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "twitch": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/twitch/-/twitch-4.1.3.tgz",
-            "integrity": "sha512-Cw800cREeZrmS8CJerb+kvg2uT0PzaAdS4MX5L2QrqEWYoMS212oZ6RqJAqYAUIK1TLJOhvdHEwv0BhJlya0bw==",
-            "requires": {
-                "@d-fischer/cache-decorators": "^2.0.0",
-                "@d-fischer/cross-fetch": "^4.0.1",
-                "@d-fischer/logger": "^1.1.1",
-                "@d-fischer/qs": "^7.0.2",
-                "@d-fischer/rate-limiter": "^0.2.4",
-                "@d-fischer/shared-utils": "^2.0.1",
-                "top-package": "^1.0.0",
-                "tslib": "^2.0.0"
-            }
-        },
-        "twitch-chat-client": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.1.3.tgz",
-            "integrity": "sha512-sTBZSTIQ5mn9FChyTmm1gmaAzgCEUSgElhWGaWc4I35UnfxfjraEtNopUz1yTd/v20G36jx0X3f03aNTQX3IXg==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/twitch/-/twitch-4.2.1.tgz",
+            "integrity": "sha512-TLNTvYibV/7y4I3NR5ntwIwHjnmowiQ/TZoveSF4XG8PfZcOFqGizxrcGzoDD3950zElXS8yfW72KsTWIBNzGg==",
             "requires": {
                 "@d-fischer/cache-decorators": "^2.0.0",
                 "@d-fischer/deprecate": "^2.0.1",
-                "@d-fischer/logger": "^1.1.1",
-                "@d-fischer/shared-utils": "^2.0.1",
+                "@d-fischer/logger": "^2.0.0",
+                "@d-fischer/rate-limiter": "^0.2.5",
+                "@d-fischer/shared-utils": "^2.3.1",
+                "top-package": "^1.0.0",
+                "tslib": "^2.0.0",
+                "twitch-api-call": "^4.2.1",
+                "twitch-auth": "^4.2.1"
+            }
+        },
+        "twitch-api-call": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/twitch-api-call/-/twitch-api-call-4.2.1.tgz",
+            "integrity": "sha512-gh121M0w4mPWzksDpm2I13LLutYLNP+DNqpZhNGIlXNbJMvG7uWq5sZlEnySwKPkCS3fpqlsDyt9Aj5YFiBvIQ==",
+            "requires": {
+                "@d-fischer/cross-fetch": "^4.0.1",
+                "@d-fischer/qs": "^7.0.2",
+                "tslib": "^2.0.0"
+            }
+        },
+        "twitch-auth": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.2.1.tgz",
+            "integrity": "sha512-pHdtI0nx4tw+/hSX9AiJaWWPLyRdoufh5blmgtU3/qMb/3WeYZCq0hPx/ksAaKqvZo26dfYMyMVnXztFmRqPOg==",
+            "requires": {
+                "@d-fischer/deprecate": "^2.0.1",
+                "@d-fischer/shared-utils": "^2.3.1",
+                "tslib": "^2.0.0",
+                "twitch-api-call": "^4.2.1"
+            }
+        },
+        "twitch-chat-client": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.2.1.tgz",
+            "integrity": "sha512-FgqajH7mh1HW3/Q43ad2QLURclCSQL5QTA/XnEFHFb5kTnnrsGJci9Za/QiFRGuIHRGhKrIKnRcxn7u2w/beEg==",
+            "requires": {
+                "@d-fischer/cache-decorators": "^2.0.0",
+                "@d-fischer/deprecate": "^2.0.1",
+                "@d-fischer/logger": "^2.0.0",
+                "@d-fischer/shared-utils": "^2.3.1",
                 "@d-fischer/typed-event-emitter": "^3.0.0",
-                "ircv3": "^0.24.1",
+                "ircv3": "^0.26.0",
                 "tslib": "^2.0.0"
             }
         },
@@ -13403,15 +13850,15 @@
             }
         },
         "typescript": {
-            "version": "3.9.6",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.6.tgz",
-            "integrity": "sha512-Pspx3oKAPJtjNwE92YS05HQoY7z2SFyOpHo9MqJor3BXAGNaPUs83CuVp9VISFkSjyRfiTpmKuAYGJB7S7hOxw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
+            "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
             "dev": true
         },
         "uglify-js": {
-            "version": "3.10.0",
-            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.0.tgz",
-            "integrity": "sha512-Esj5HG5WAyrLIdYU74Z3JdG2PxdIusvj6IWHMtlyESxc7kcDz7zYlYjpnSokn1UbpV0d/QX9fan7gkCNd/9BQA==",
+            "version": "3.10.3",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.10.3.tgz",
+            "integrity": "sha512-Lh00i69Uf6G74mvYpHCI9KVVXLcHW/xu79YTvH7Mkc9zyKUeSPz0owW0dguj0Scavns3ZOh3wY63J0Zb97Za2g==",
             "dev": true,
             "optional": true
         },
@@ -13585,9 +14032,9 @@
             "integrity": "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="
         },
         "update-notifier": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.0.tgz",
-            "integrity": "sha512-w3doE1qtI0/ZmgeoDoARmI5fjDoT93IfKgEGqm26dGUOh8oNpaSTsGNdYRN/SjOuo10jcJGwkEL3mroKzktkew==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-4.1.1.tgz",
+            "integrity": "sha512-9y+Kds0+LoLG6yN802wVXoIfxYEwh3FlZwzMwpCZp62S2i1/Jzeqb9Eeeju3NSHccGGasfGlK5/vEHbAifYRDg==",
             "dev": true,
             "requires": {
                 "boxen": "^4.2.0",
@@ -13647,9 +14094,9 @@
                     "dev": true
                 },
                 "supports-color": {
-                    "version": "7.1.0",
-                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-                    "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+                    "version": "7.2.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+                    "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
                     "dev": true,
                     "requires": {
                         "has-flag": "^4.0.0"
@@ -13658,9 +14105,9 @@
             }
         },
         "uri-js": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-            "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.0.tgz",
+            "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
             "requires": {
                 "punycode": "^2.1.0"
             }
@@ -13810,57 +14257,6 @@
                 "graceful-fs": "^4.1.2",
                 "neo-async": "^2.5.0",
                 "watchpack-chokidar2": "^2.0.0"
-            },
-            "dependencies": {
-                "braces": {
-                    "version": "3.0.2",
-                    "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-                    "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-                    "optional": true,
-                    "requires": {
-                        "fill-range": "^7.0.1"
-                    }
-                },
-                "chokidar": {
-                    "version": "3.4.2",
-                    "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
-                    "integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
-                    "optional": true,
-                    "requires": {
-                        "anymatch": "~3.1.1",
-                        "braces": "~3.0.2",
-                        "fsevents": "~2.1.2",
-                        "glob-parent": "~5.1.0",
-                        "is-binary-path": "~2.1.0",
-                        "is-glob": "~4.0.1",
-                        "normalize-path": "~3.0.0",
-                        "readdirp": "~3.4.0"
-                    }
-                },
-                "fill-range": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-                    "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-                    "optional": true,
-                    "requires": {
-                        "to-regex-range": "^5.0.1"
-                    }
-                },
-                "is-number": {
-                    "version": "7.0.0",
-                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-                    "optional": true
-                },
-                "to-regex-range": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-                    "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-                    "optional": true,
-                    "requires": {
-                        "is-number": "^7.0.0"
-                    }
-                }
             }
         },
         "watchpack-chokidar2": {
@@ -13899,6 +14295,35 @@
                     "integrity": "sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==",
                     "optional": true
                 },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "optional": true,
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "optional": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
                 "chokidar": {
                     "version": "2.1.8",
                     "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.8.tgz",
@@ -13917,6 +14342,29 @@
                         "path-is-absolute": "^1.0.0",
                         "readdirp": "^2.2.1",
                         "upath": "^1.1.1"
+                    }
+                },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "optional": true,
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "optional": true,
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
                     }
                 },
                 "fsevents": {
@@ -13959,6 +14407,47 @@
                         "binary-extensions": "^1.0.0"
                     }
                 },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "optional": true,
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "optional": true,
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "optional": true,
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
                 "readdirp": {
                     "version": "2.2.1",
                     "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.2.1.tgz",
@@ -13968,6 +14457,16 @@
                         "graceful-fs": "^4.1.11",
                         "micromatch": "^3.1.10",
                         "readable-stream": "^2.0.2"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "optional": true,
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
                     }
                 }
             }
@@ -14021,6 +14520,33 @@
                     "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
                     "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
                 },
+                "braces": {
+                    "version": "2.3.2",
+                    "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
+                    "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
+                    "requires": {
+                        "arr-flatten": "^1.1.0",
+                        "array-unique": "^0.3.2",
+                        "extend-shallow": "^2.0.1",
+                        "fill-range": "^4.0.0",
+                        "isobject": "^3.0.1",
+                        "repeat-element": "^1.1.2",
+                        "snapdragon": "^0.8.1",
+                        "snapdragon-node": "^2.0.1",
+                        "split-string": "^3.0.2",
+                        "to-regex": "^3.0.1"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
                 "eslint-scope": {
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
@@ -14030,6 +14556,45 @@
                         "estraverse": "^4.1.1"
                     }
                 },
+                "fill-range": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
+                    "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
+                    "requires": {
+                        "extend-shallow": "^2.0.1",
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1",
+                        "to-regex-range": "^2.1.0"
+                    },
+                    "dependencies": {
+                        "extend-shallow": {
+                            "version": "2.0.1",
+                            "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+                            "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+                            "requires": {
+                                "is-extendable": "^0.1.0"
+                            }
+                        }
+                    }
+                },
+                "is-number": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
+                    "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
+                    "requires": {
+                        "kind-of": "^3.0.2"
+                    },
+                    "dependencies": {
+                        "kind-of": {
+                            "version": "3.2.2",
+                            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+                            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+                            "requires": {
+                                "is-buffer": "^1.1.5"
+                            }
+                        }
+                    }
+                },
                 "memory-fs": {
                     "version": "0.4.1",
                     "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
@@ -14037,6 +14602,35 @@
                     "requires": {
                         "errno": "^0.1.3",
                         "readable-stream": "^2.0.1"
+                    }
+                },
+                "micromatch": {
+                    "version": "3.1.10",
+                    "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
+                    "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
+                    "requires": {
+                        "arr-diff": "^4.0.0",
+                        "array-unique": "^0.3.2",
+                        "braces": "^2.3.1",
+                        "define-property": "^2.0.2",
+                        "extend-shallow": "^3.0.2",
+                        "extglob": "^2.0.4",
+                        "fragment-cache": "^0.2.1",
+                        "kind-of": "^6.0.2",
+                        "nanomatch": "^1.2.9",
+                        "object.pick": "^1.3.0",
+                        "regex-not": "^1.0.0",
+                        "snapdragon": "^0.8.1",
+                        "to-regex": "^3.0.2"
+                    }
+                },
+                "to-regex-range": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
+                    "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
+                    "requires": {
+                        "is-number": "^3.0.0",
+                        "repeat-string": "^1.6.1"
                     }
                 }
             }
@@ -14305,9 +14899,9 @@
             }
         },
         "windows-release": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.1.tgz",
-            "integrity": "sha512-Pngk/RDCaI/DkuHPlGTdIkDiTAnAkyMjoQMZqRsxydNl1qGXNIoZrB7RK8g53F2tEgQBMqQJHQdYZuQEEAu54A==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.3.3.tgz",
+            "integrity": "sha512-OSOGH1QYiW5yVor9TtmXKQvt2vjQqbYS+DqmsZw+r7xDwLXEeT3JGW0ZppFmHx4diyXmxt238KFR3N9jzevBRg==",
             "dev": true,
             "requires": {
                 "execa": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -9,17 +9,17 @@
         "format": "prettier --write \"./**/*.{ts,html,css,json}\""
     },
     "devDependencies": {
-        "@typescript-eslint/eslint-plugin": "^3.6.0",
-        "@typescript-eslint/parser": "^3.6.0",
-        "eslint": "^7.4.0",
+        "@typescript-eslint/eslint-plugin": "^4.0.1",
+        "@typescript-eslint/parser": "^4.0.1",
+        "eslint": "^7.8.1",
         "eslint-config-prettier": "^6.11.0",
         "eslint-plugin-prettier": "^3.1.4",
         "husky": "^4.2.5",
         "lerna": "^3.22.1",
         "nodemon": "^2.0.4",
-        "prettier": "^2.0.5",
-        "pretty-quick": "^2.0.1",
-        "typescript": "^3.9.6"
+        "prettier": "^2.1.1",
+        "pretty-quick": "^3.0.0",
+        "typescript": "^4.0.2"
     },
     "husky": {
         "hooks": {

--- a/samples/ahk-sendcommand/package.json
+++ b/samples/ahk-sendcommand/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-ahk": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/discord-guild-chat/package.json
+++ b/samples/discord-guild-chat/package.json
@@ -21,8 +21,8 @@
     "dependencies": {
         "nodecg-io-discord": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/intellij-integration/package.json
+++ b/samples/intellij-integration/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-intellij": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/obs-scenelist/package.json
+++ b/samples/obs-scenelist/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-obs": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/philipshue-lights/package.json
+++ b/samples/philipshue-lights/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-philipshue": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/sacn-receiver-sample/package.json
+++ b/samples/sacn-receiver-sample/package.json
@@ -21,8 +21,8 @@
     "dependencies": {
         "nodecg-io-sacn-receiver": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/slack-post/package.json
+++ b/samples/slack-post/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-slack": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/streamdeck-rainbow/package.json
+++ b/samples/streamdeck-rainbow/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-streamdeck": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/streamelements-events/package.json
+++ b/samples/streamelements-events/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-streamelements": "0.2.2",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/telegram-bot/package.json
+++ b/samples/telegram-bot/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-telegram": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/twitch-chat/package.json
+++ b/samples/twitch-chat/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-twitch": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/twitter-timeline/package.json
+++ b/samples/twitter-timeline/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-twitter": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/websocket-server/package.json
+++ b/samples/websocket-server/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-websocket-server": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/xdotool-windowminimize/package.json
+++ b/samples/xdotool-windowminimize/package.json
@@ -15,8 +15,8 @@
     "dependencies": {
         "nodecg-io-xdotool": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }

--- a/samples/youtube-playlist/package.json
+++ b/samples/youtube-playlist/package.json
@@ -13,11 +13,11 @@
     },
     "license": "MIT",
     "dependencies": {
-        "googleapis": "^52.1.0",
+        "googleapis": "^59.0.0",
         "nodecg-io-youtube": "0.1.0",
         "nodecg-io-core": "0.1.0",
-        "@types/node": "^13.13.12",
+        "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
-        "typescript": "^3.9.6"
+        "typescript": "^4.0.2"
     }
 }


### PR DESCRIPTION
Updates all dependencies to the latest published versions.

## Updated
```
- @slack/web-api ^5.10.0                    -> ^5.11.0
- @types/node ^13.13.12                     -> ^14.6.4
- @types/ws ^7.2.5                          -> ^7.2.6
- @typescript-eslint/eslint-plugin ^3.6.0   -> ^4.0.1
- @typescript-eslint/parser ^3.6.0          -> ^4.0.1
- ajv ^6.12.2                               -> ^6.12.4
- discord.js 12.2.0                         -> ^12.3.1
- elgato-stream-deck ^3.3.0                 -> ^3.3.2
- eslint ^7.4.0                             -> ^7.8.1
- googleapis ^52.1.0                        -> ^59.0.0
- node-fetch ^2.5.7                         -> ^2.6.0
- node-hue-api ^4.0.7                       -> ^4.0.9
- open ^7.0.4                               -> ^7.2.1
- prettier ^2.0.5                           -> ^2.1.1
- pretty-quick ^2.0.1                       -> ^3.0.0
- ts-loader ^8.0.2                          -> ^8.0.3
- tslib ^2.0.0                              -> ^2.0.1
- twitch ^4.1.3                             -> ^4.2.1
- twitch-chat-client ^4.1.3                 -> ^4.2.1
- typescript ^3.9.6                         -> ^4.0.2
- ws ^7.3.0                                 -> ^7.3.1
```

## Removed
```
- @types/express ^4.17.6                    -> not needed, guaranteed to be provided by nodecg
- @types/is-ip ^3.0.0                       -> deprecated, typings are available in is-ip package
- @types/open ^6.2.1                        -> deprecated, typings are available in open package
```