### PR TITLE
Added simple rcon sample

### DIFF
--- a/samples/rcon-minecraft/extension/index.ts
+++ b/samples/rcon-minecraft/extension/index.ts
@@ -1,0 +1,18 @@
+import { NodeCG } from "nodecg/types/server";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { RconServiceClient } from "nodecg-io-rcon/extension";
+
+module.exports = function (nodecg: NodeCG) {
+    nodecg.log.info("Sample bundle for sACN started");
+
+    const rcon = requireService<RconServiceClient>(nodecg, "rcon");
+
+    rcon?.onAvailable(async (client) => {
+        nodecg.log.info("RCON sample has been updated, performing /list and a /say command.");
+        const response = await client.sendMessage("list");
+        nodecg.log.info(response);
+        client.sendMessage("say nodecg-io speaking here!");
+    });
+
+    rcon?.onUnavailable(() => nodecg.log.info("RCON sample has been unset."));
+};

--- a/samples/rcon-minecraft/package.json
+++ b/samples/rcon-minecraft/package.json
@@ -1,0 +1,29 @@
+{
+    "name": "rcon-minecraft",
+    "version": "0.1.0",
+    "description": "Example nodecg-io-rcon Bundle. Sends simple commands to a server",
+    "homepage": "",
+    "author": {
+        "name": "derNiklaas",
+        "url": "https://github.com/derNiklaas"
+    },
+    "nodecg": {
+        "compatibleRange": "^1.1.1",
+        "bundleDependencies": {
+            "nodecg-io-rcon": "0.1.0"
+        }
+    },
+    "scripts": {
+        "build": "tsc -b",
+        "watch": "tsc -b -w",
+        "clean": "tsc -b --clean"
+    },
+    "license": "MIT",
+    "dependencies": {
+        "nodecg-io-rcon": "0.1.0",
+        "nodecg-io-core": "0.1.0",
+        "@types/node": "^14.6.4",
+        "nodecg": "^1.6.1",
+        "typescript": "^4.0.2"
+    }
+}

--- a/samples/rcon-minecraft/tsconfig.json
+++ b/samples/rcon-minecraft/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.common.json"
+}


### PR DESCRIPTION
This is a simple rcon-minecraft sample.
It sends /list to a minecraft server, prints the output and then performs /say nodecg-io speaking here!