### PR TITLE
Properly format obs client creation errors in createClient

### DIFF
--- a/nodecg-io-obs/extension/index.ts
+++ b/nodecg-io-obs/extension/index.ts
@@ -31,7 +31,11 @@ class OBSService extends ServiceBundle<OBSServiceConfig, OBSServiceClient> {
 
     async createClient(config: OBSServiceConfig): Promise<Result<OBSServiceClient>> {
         const client = new OBSWebSocket();
-        await client.connect({ address: `${config.host}:${config.port}`, password: config.password });
+        try {
+            await client.connect({ address: `${config.host}:${config.port}`, password: config.password });
+        } catch (e) {
+            return error(e.error);
+        }
 
         return success({
             getNativeClient() {


### PR DESCRIPTION
The obs client throws a object when a error happens. When the framework catches the error it just tries to convert it to a string but when doing this with a object it just produces `[object Object]`.
This PR catches the exception and extracts the actual error message of the object to solve this, as it is also done in the `validateConfig` method.