### PR TITLE
Update package.json files

### DIFF
--- a/nodecg-io-ahk/package.json
+++ b/nodecg-io-ahk/package.json
@@ -2,10 +2,16 @@
     "name": "nodecg-io-ahk",
     "version": "0.1.0",
     "description": "Allows you to send commands to AutoHotkey.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/ahk",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"
+    },
+    "main": "extension",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-ahk"
     },
     "scripts": {
         "build": "tsc -b",
@@ -13,13 +19,13 @@
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -30,7 +36,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "node-fetch": "^2.6.1"
     }
 }

--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nodecg-io-dashboard",
     "version": "0.1.0",
-    "description": "",
+    "private": true,
     "scripts": {
         "build": "webpack",
         "watch": "webpack --watch"
@@ -15,7 +15,7 @@
     "dependencies": {
         "monaco-editor": "^0.20.0",
         "nodecg": "^1.6.1",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "typescript": "^4.0.2",
         "crypto-js": "^4.0.0"
     },

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -2,18 +2,24 @@
     "name": "nodecg-io-core",
     "version": "0.1.0",
     "description": "The core of nodecg-io. Connects everything up.",
-    "homepage": "http://codeoverflow.org",
+    "homepage": "https://nodecg.io",
     "author": {
         "name": "CodeOverflow team",
-        "url": "http://codeoverflow.org"
+        "url": "https://github.com/codeoverflow-org"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-core"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {

--- a/nodecg-io-discord/package.json
+++ b/nodecg-io-discord/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-discord",
     "version": "0.1.0",
     "description": "Allows to connect to discord via a discord-bot.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/discord",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-discord"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "discord.js": "^12.3.1"
     }
 }

--- a/nodecg-io-intellij/package.json
+++ b/nodecg-io-intellij/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-intellij",
     "version": "0.1.0",
     "description": "Allows to control JetBrains IDEs via nodecg-io",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/intellij",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-intellij"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -30,7 +36,7 @@
         "@types/node-fetch": "^2.5.7"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "node-fetch": "^2.6.1"
     }
 }

--- a/nodecg-io-irc/package.json
+++ b/nodecg-io-irc/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-irc",
     "version": "0.1.0",
     "description": "Allow to connect to IRC Servers.",
-    "homepage": "",
+    "homepage": "https://nodecg.io",
     "author": {
         "name": "ExtremTechniker",
         "url": "https://github.com/ExtremTechniker"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-irc"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -30,7 +36,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "irc": "0.5.2"
     }
 }

--- a/nodecg-io-midi-input/package.json
+++ b/nodecg-io-midi-input/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-midi-input",
     "version": "0.1.0",
     "description": "Connect to MIDI devices and control the volume of your voice or music with a fader.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/midi-input",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-midi-input"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "easymidi": "^2.0.1"
     }
 }

--- a/nodecg-io-midi-output/package.json
+++ b/nodecg-io-midi-output/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-midi-output",
     "version": "0.1.0",
     "description": "Connect to MIDI devices and control the volume of your voice or music with a fader.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/midi-output",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-midi-output"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "easymidi": "^2.0.1"
     }
 }

--- a/nodecg-io-obs/package.json
+++ b/nodecg-io-obs/package.json
@@ -1,28 +1,31 @@
 {
     "name": "nodecg-io-obs",
     "version": "0.1.0",
-    "description": "",
-    "homepage": "",
-    "contributor": "derNiklaas",
+    "description": "Allows to control your obs instance to e.g. switch scenes.",
+    "homepage": "https://nodecg.io",
+    "author": {
+        "name": "derNiklaas",
+        "url": "https://github.com/derNiklaas"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-obs"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
-    "files": [
-        "dashboard",
-        "graphics",
-        "extension.js",
-        "extension"
-    ],
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -32,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "obs-websocket-js": "^4.0.1"
     }
 }

--- a/nodecg-io-philipshue/package.json
+++ b/nodecg-io-philipshue/package.json
@@ -2,23 +2,30 @@
     "name": "nodecg-io-philipshue",
     "version": "0.1.0",
     "description": "Allows you to connect with your Philips Hue bridge. This allows you to control your lights etc.",
-    "homepage": "",
+    "homepage": "https://nodecg.io",
     "author": {
         "name": "TheCrether",
         "url": "https://thecrether.at"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-philipshue"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -30,6 +37,6 @@
     "dependencies": {
         "is-ip": "^3.1.0",
         "node-hue-api": "^4.0.9",
-        "nodecg-io-core": "0.1.0"
+        "nodecg-io-core": "^0.1.0"
     }
 }

--- a/nodecg-io-rcon/package.json
+++ b/nodecg-io-rcon/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-rcon",
     "version": "0.1.0",
     "description": "Allows you to send commands to a minecraft server via RCON.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/rcon",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-rcon"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "rcon-client": "^4.2.0"
     }
 }

--- a/nodecg-io-reddit/package.json
+++ b/nodecg-io-reddit/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nodecg-io-reddit",
     "version": "0.1.0",
-    "description": "Provides aninterface to the Reddit-API.",
+    "description": "Provides an interface to the Reddit-API.",
     "homepage": "https://nodecg.io/samples/reddit",
     "author": {
         "name": "noeppi_noeppi",

--- a/nodecg-io-reddit/package.json
+++ b/nodecg-io-reddit/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-reddit",
     "version": "0.1.0",
     "description": "Provides aninterface to the Reddit-API.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/reddit",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-reddit"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "reddit-ts": "noeppi-noeppi/npm-reddit-ts#build"
     }
 }

--- a/nodecg-io-sacn-receiver/package.json
+++ b/nodecg-io-sacn-receiver/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-sacn-receiver",
     "version": "0.1.0",
     "description": "Allows you to receive data via sACN from e.g professional lighting consoles.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/sacn-receiver",
     "author": {
         "name": "Tim-Tech-Dev",
         "url": "https://github.com/Tim-Tech-Dev"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-sacn-receiver"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "sacn": "^3.2.1"
     }
 }

--- a/nodecg-io-sacn-sender/package.json
+++ b/nodecg-io-sacn-sender/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-sacn-sender",
     "version": "0.1.0",
     "description": "Allows you to send data via sACN to e.g professional lights.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/sacn-sender",
     "author": {
         "name": "Tim-Tech-Dev",
         "url": "https://github.com/Tim-Tech-Dev"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-sacn-sender"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "sacn": "^3.2.1"
     }
 }

--- a/nodecg-io-serial/package.json
+++ b/nodecg-io-serial/package.json
@@ -10,7 +10,7 @@
     "repository": {
         "type": "git",
         "url": "https://github.com/codeoverflow-org/nodecg-io.git",
-        "directory": "nodecg-io-twitch"
+        "directory": "nodecg-io-serial"
     },
     "main": "extension",
     "scripts": {

--- a/nodecg-io-serial/package.json
+++ b/nodecg-io-serial/package.json
@@ -2,11 +2,17 @@
     "name": "nodecg-io-serial",
     "version": "0.1.0",
     "description": "Exposes serial deivces to nodecg-io",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/serial",
     "author": {
         "name": "Stefan Schmelz",
         "url": "https://github.com/StefanSchmelz"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-twitch"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
@@ -14,13 +20,13 @@
         "list": "npx @serialport/list"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -31,7 +37,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "serialport": "^9.0.1",
         "@serialport/parser-readline": "^9.0.1"
     }

--- a/nodecg-io-slack/package.json
+++ b/nodecg-io-slack/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-slack",
     "version": "0.1.0",
     "description": "Allows to connect to your slack. This enables you to e.g. send messages and list all channel. Visit https://api.slack.com/methods to see all methods ",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/slack",
     "author": {
         "name": "ExtremTechniker",
         "url": "https://github.com/ExtremTechniker"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-slack"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@slack/web-api": "^5.11.0"
     }
 }

--- a/nodecg-io-spotify/package.json
+++ b/nodecg-io-spotify/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-spotify",
     "version": "0.1.0",
     "description": "Allows to connect to your personal Spotify account. This enables you to e.g. control music playback or get current song information. ",
-    "homepage": "",
+    "homepage": "https://nodecg.io",
     "author": {
         "name": "CodeOverflow team",
         "url": "http://codeoverflow.org"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-spotify"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -30,7 +36,7 @@
     },
     "dependencies": {
         "@types/spotify-web-api-node": "^4.0.1",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "express": "^4.17.1",
         "open": "^7.2.1",
         "spotify-web-api-node": "^4.0.0"

--- a/nodecg-io-streamdeck/package.json
+++ b/nodecg-io-streamdeck/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-streamdeck",
     "version": "0.1.0",
     "description": "Allows to interface with the elgato streamdeck.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/streamdeck",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-streamdeck"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "elgato-stream-deck": "^3.3.2"
     }
 }

--- a/nodecg-io-streamelements/package.json
+++ b/nodecg-io-streamelements/package.json
@@ -1,32 +1,36 @@
 {
     "name": "nodecg-io-streamelements",
-    "version": "0.2.2",
-    "description": "",
-    "homepage": "",
+    "version": "0.1.0",
+    "description": "Allows to connect to streamelements to e.g. react to donations.",
+    "homepage": "https://nodecg.io",
+    "author": {
+        "name": "CodeOverflow team",
+        "url": "https://github.com/codeoverflow-org"
+    },
     "contributors": [
         "sebinside",
         "Extremtechniker",
         "derNiklaas"
     ],
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-streamelements"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
-    "files": [
-        "dashboard",
-        "graphics",
-        "extension.js",
-        "extension"
-    ],
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -37,7 +41,7 @@
     },
     "dependencies": {
         "@types/socket.io-client": "^1.4.33",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "socket.io-client": "^2.3.0"
     }
 }

--- a/nodecg-io-telegram/package.json
+++ b/nodecg-io-telegram/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-telegram",
     "version": "0.1.0",
     "description": "Allows you to control a telegram bot.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/telegram",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-telegram"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -30,7 +36,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "node-telegram-bot-api": "^0.50.0"
     }
 }

--- a/nodecg-io-tiane/package.json
+++ b/nodecg-io-tiane/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-tiane",
     "version": "0.1.0",
     "description": "Connect to TIANE and make her for example a discord bot. https://github.com/FerdiKr/TIANE",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/tiane",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-tiane"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -30,7 +36,7 @@
         "@types/ws": "^7.2.6"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "ws": "^7.3.1"
     }
 }

--- a/nodecg-io-twitch/package.json
+++ b/nodecg-io-twitch/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-twitch",
     "version": "0.1.0",
     "description": "Allows to connect to twitch with your account, send and receive messages and much more. It can be used to create Twitch-Bots.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/twitch",
     "author": {
         "name": "CodeOverflow team",
-        "url": "http://codeoverflow.org"
+        "url": "https://github.com/codeoverflow-org"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-twitch"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "twitch": "^4.2.1",
         "twitch-auth": "^4.2.1",
         "twitch-chat-client": "^4.2.1"

--- a/nodecg-io-twitter/package.json
+++ b/nodecg-io-twitter/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-twitter",
     "version": "0.1.0",
     "description": "Allows to connect to twitter, send, retweet or like messages.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/twitter",
     "author": {
         "name": "CodeOverflow team",
         "url": "http://codeoverflow.org"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-twitter"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -30,7 +36,7 @@
     },
     "dependencies": {
         "@types/twitter": "^1.7.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "twitter": "^1.7.1"
     }
 }

--- a/nodecg-io-websocket-client/package.json
+++ b/nodecg-io-websocket-client/package.json
@@ -1,25 +1,31 @@
 {
     "name": "nodecg-io-websocket-client",
-    "version": "0.2.0",
+    "version": "0.1.0",
     "description": "Allows to connect to a external WebSocket server.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/websocket-client/",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-websocket-client"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/ws": "^7.2.6",
         "ws": "^7.3.1"
     }

--- a/nodecg-io-websocket-server/package.json
+++ b/nodecg-io-websocket-server/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-websocket-server",
     "version": "0.1.0",
     "description": "Allows to create a custom WebSocket server.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/websocket-server/",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-websocket-server"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -29,7 +35,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/ws": "^7.2.6",
         "ws": "^7.3.1"
     }

--- a/nodecg-io-xdotool/package.json
+++ b/nodecg-io-xdotool/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-xdotool",
     "version": "0.1.0",
     "description": "Allows you to send commands to xdotool.",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/xdotool",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-xdotool"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -30,7 +36,7 @@
         "typescript": "^4.0.2"
     },
     "dependencies": {
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "node-fetch": "^2.6.1",
         "@rauschma/stringio": "^1.4.0"
     }

--- a/nodecg-io-youtube/package.json
+++ b/nodecg-io-youtube/package.json
@@ -2,24 +2,30 @@
     "name": "nodecg-io-youtube",
     "version": "0.1.0",
     "description": "Allows to connect and interact to youtube",
-    "homepage": "",
+    "homepage": "https://nodecg.io/samples/youtube",
     "author": {
         "name": "CodeOverflow team",
         "url": "http://codeoverflow.org"
     },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-youtube"
+    },
+    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",
         "clean": "tsc -b --clean"
     },
     "keywords": [
-        "",
+        "nodecg-io",
         "nodecg-bundle"
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "0.1.0"
+            "nodecg-io-core": "^0.1.0"
         }
     },
     "license": "MIT",
@@ -32,7 +38,7 @@
         "@types/gapi": "0.0.39",
         "express": "^4.17.1",
         "googleapis": "^59.0.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "open": "^7.2.1"
     }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,18 +12,18 @@
             }
         },
         "@babel/core": {
-            "version": "7.11.6",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.11.6.tgz",
-            "integrity": "sha512-Wpcv03AGnmkgm6uS6k8iwhIwTrcP0m17TL1n1sy7qD0qelDu4XNeW0dN0mHfa+Gei211yDaLoEe/VlbXQzM4Bg==",
+            "version": "7.12.3",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.12.3.tgz",
+            "integrity": "sha512-0qXcZYKZp3/6N2jKYVxZv0aNCsxTSVCiK72DTiTYZAu7sjg73W0/aynWjMbiGd87EQL4WyA8reiJVh92AVla9g==",
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.6",
-                "@babel/helper-module-transforms": "^7.11.0",
-                "@babel/helpers": "^7.10.4",
-                "@babel/parser": "^7.11.5",
+                "@babel/generator": "^7.12.1",
+                "@babel/helper-module-transforms": "^7.12.1",
+                "@babel/helpers": "^7.12.1",
+                "@babel/parser": "^7.12.3",
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.11.5",
-                "@babel/types": "^7.11.5",
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.1",
@@ -42,11 +42,11 @@
             }
         },
         "@babel/generator": {
-            "version": "7.11.6",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.11.6.tgz",
-            "integrity": "sha512-DWtQ1PV3r+cLbySoHrwn9RWEgKMBLLma4OBQloPRyDYvc5msJM9kvTLo1YnlJd1P/ZuKbdli3ijr5q3FvAF3uA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.12.1.tgz",
+            "integrity": "sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==",
             "requires": {
-                "@babel/types": "^7.11.5",
+                "@babel/types": "^7.12.1",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             }
@@ -70,32 +70,34 @@
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.11.0.tgz",
-            "integrity": "sha512-JbFlKHFntRV5qKw3YC0CvQnDZ4XMwgzzBbld7Ly4Mj4cbFy3KywcR8NtNctRToMWJOVvLINJv525Gd6wwVEx/Q==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.12.1.tgz",
+            "integrity": "sha512-k0CIe3tXUKTRSoEx1LQEPFU9vRQfqHtl+kf8eNnDqb4AUJEy5pz6aIiog+YWtVm2jpggjS1laH68bPsR+KWWPQ==",
             "requires": {
-                "@babel/types": "^7.11.0"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.10.4.tgz",
-            "integrity": "sha512-nEQJHqYavI217oD9+s5MUBzk6x1IlvoS9WTPfgG43CbMEeStE0v+r+TucWdx8KFGowPGvyOkDT9+7DHedIDnVw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz",
+            "integrity": "sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==",
             "requires": {
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.11.0",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz",
-            "integrity": "sha512-02EVu8COMuTRO1TAzdMtpBPbe6aQ1w/8fePD2YgQmxZU4gpNWaL9gK3Jp7dxlkUlUCJOTaSeA+Hrm1BRQwqIhg==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.12.1.tgz",
+            "integrity": "sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==",
             "requires": {
-                "@babel/helper-module-imports": "^7.10.4",
-                "@babel/helper-replace-supers": "^7.10.4",
-                "@babel/helper-simple-access": "^7.10.4",
+                "@babel/helper-module-imports": "^7.12.1",
+                "@babel/helper-replace-supers": "^7.12.1",
+                "@babel/helper-simple-access": "^7.12.1",
                 "@babel/helper-split-export-declaration": "^7.11.0",
+                "@babel/helper-validator-identifier": "^7.10.4",
                 "@babel/template": "^7.10.4",
-                "@babel/types": "^7.11.0",
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1",
                 "lodash": "^4.17.19"
             }
         },
@@ -113,23 +115,22 @@
             "integrity": "sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg=="
         },
         "@babel/helper-replace-supers": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.4.tgz",
-            "integrity": "sha512-sPxZfFXocEymYTdVK1UNmFPBN+Hv5mJkLPsYWwGBxZAxaWfFu+xqp7b6qWD0yjNuNL2VKc6L5M18tOXUP7NU0A==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz",
+            "integrity": "sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==",
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.10.4",
+                "@babel/helper-member-expression-to-functions": "^7.12.1",
                 "@babel/helper-optimise-call-expression": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.10.4.tgz",
-            "integrity": "sha512-0fMy72ej/VEvF8ULmX6yb5MtHG4uH4Dbd6I/aHDb/JVg0bbivwt9Wg+h3uMvX+QSFtwr5MeItvazbrc4jtRAXw==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.12.1.tgz",
+            "integrity": "sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==",
             "requires": {
-                "@babel/template": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/helper-split-export-declaration": {
@@ -146,13 +147,13 @@
             "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw=="
         },
         "@babel/helpers": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.10.4.tgz",
-            "integrity": "sha512-L2gX/XeUONeEbI78dXSrJzGdz4GQ+ZTA/aazfUsFaWjSe95kiCuOZ5HsXvkiw3iwF+mFHSRUfJU8t6YavocdXA==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.12.1.tgz",
+            "integrity": "sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==",
             "requires": {
                 "@babel/template": "^7.10.4",
-                "@babel/traverse": "^7.10.4",
-                "@babel/types": "^7.10.4"
+                "@babel/traverse": "^7.12.1",
+                "@babel/types": "^7.12.1"
             }
         },
         "@babel/highlight": {
@@ -178,9 +179,9 @@
             }
         },
         "@babel/parser": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.11.5.tgz",
-            "integrity": "sha512-X9rD8qqm695vgmeaQ4fvz/o3+Wk4ZzQvSHkDBgpYKxpD4qTAUm88ZKtHkVqIOsYFFbIQ6wQYhC6q7pjqVK0E0Q=="
+            "version": "7.12.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.12.3.tgz",
+            "integrity": "sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw=="
         },
         "@babel/plugin-syntax-dynamic-import": {
             "version": "7.8.3",
@@ -201,16 +202,16 @@
             }
         },
         "@babel/traverse": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.11.5.tgz",
-            "integrity": "sha512-EjiPXt+r7LiCZXEfRpSJd+jUMnBd4/9OUv7Nx3+0u9+eimMwJmG0Q98lw4/289JCoxSE8OolDMNZaaF/JZ69WQ==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.12.1.tgz",
+            "integrity": "sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==",
             "requires": {
                 "@babel/code-frame": "^7.10.4",
-                "@babel/generator": "^7.11.5",
+                "@babel/generator": "^7.12.1",
                 "@babel/helper-function-name": "^7.10.4",
                 "@babel/helper-split-export-declaration": "^7.11.0",
-                "@babel/parser": "^7.11.5",
-                "@babel/types": "^7.11.5",
+                "@babel/parser": "^7.12.1",
+                "@babel/types": "^7.12.1",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0",
                 "lodash": "^4.17.19"
@@ -224,9 +225,9 @@
             }
         },
         "@babel/types": {
-            "version": "7.11.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.11.5.tgz",
-            "integrity": "sha512-bvM7Qz6eKnJVFIn+1LPtjlBFPVN5jNDc1XmN15vWe7Q3DPBufWWsLiIvUu7xW87uTG6QoggpIDnUgLQvPheU+Q==",
+            "version": "7.12.1",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.12.1.tgz",
+            "integrity": "sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==",
             "requires": {
                 "@babel/helper-validator-identifier": "^7.10.4",
                 "lodash": "^4.17.19",
@@ -234,62 +235,56 @@
             }
         },
         "@d-fischer/cache-decorators": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-2.0.0.tgz",
-            "integrity": "sha512-KTcQr0upyw+Sj8m4uakV2Y/63Qww24+MGNiopg+1YFfP+oO/XAAPIVpq6zb2N+kCswP3xFo/CInyzhtO4zqkPw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-2.1.0.tgz",
+            "integrity": "sha512-w0LJp+hBQOesVxQjMpirv3rZfxqOoWKu4GzJ+/lEVpQTrEos9ckBLnvPNBewG6/AUyuk/xYYijekp8E9r7UBrA==",
             "requires": {
-                "@d-fischer/shared-utils": "^2.0.0",
-                "@types/node": "^12.12.14",
-                "tslib": "^1.10.0"
+                "@d-fischer/shared-utils": "^2.4.0",
+                "@types/node": "^14.11.2",
+                "tslib": "^2.0.1"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "12.12.62",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-                    "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
-                },
-                "tslib": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+                    "version": "14.14.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+                    "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
                 }
             }
         },
         "@d-fischer/connection": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/@d-fischer/connection/-/connection-6.0.2.tgz",
-            "integrity": "sha512-thcyWe04fg1zdJVetwXJ1OKPE3pdvdCb0OvsfpCaUGr9pp//wxW8a15pNlDMED37QWnPndPc9Lt2zdQR/Oe2dg==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@d-fischer/connection/-/connection-6.2.0.tgz",
+            "integrity": "sha512-koam3kWfdkWJXlczji2iDBPILTSddDxCujjdhNDrF1DEORgjrHfBwB4CvNKjQL3jTgOuaAUcSgfgGYZJ92ngXA==",
             "requires": {
                 "@d-fischer/isomorphic-ws": "^5.0.2",
-                "@d-fischer/logger": "^2.0.0",
-                "@d-fischer/shared-utils": "^2.1.2",
-                "@d-fischer/typed-event-emitter": "^3.0.1",
-                "@types/node": "^14.0.13",
-                "@types/ws": "^7.2.5",
-                "tslib": "^2.0.0",
-                "ws": "^7.3.0"
-            }
-        },
-        "@d-fischer/cross-fetch": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/@d-fischer/cross-fetch/-/cross-fetch-4.0.1.tgz",
-            "integrity": "sha512-N2wdpOaSSLtCERlOFLPU3UpW27VSWiPfu65SKWdVrYJP2DeH2ZBwwvDz2OYAWkXb0fSUKQWuWk+yWhDpcmQljQ==",
-            "requires": {
-                "node-fetch": "2.6.0",
-                "whatwg-fetch": "3.0.0"
+                "@d-fischer/logger": "^2.1.0",
+                "@d-fischer/shared-utils": "^2.4.0",
+                "@d-fischer/typed-event-emitter": "^3.1.0",
+                "@types/node": "^14.11.2",
+                "@types/ws": "^7.2.7",
+                "tslib": "^2.0.1",
+                "ws": "^7.3.1"
             },
             "dependencies": {
-                "node-fetch": {
-                    "version": "2.6.0",
-                    "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
-                    "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA=="
+                "@types/node": {
+                    "version": "14.14.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+                    "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
                 }
             }
         },
+        "@d-fischer/cross-fetch": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@d-fischer/cross-fetch/-/cross-fetch-4.0.2.tgz",
+            "integrity": "sha512-3ONhZxPmgCerBi8rU9kDQktF2zMpv7gkVJuoR8I+pYeO4QWccEcqQem0i1mLBh7/y7ejR474RZb3S3EO/Sdi3A==",
+            "requires": {
+                "node-fetch": "2.6.1"
+            }
+        },
         "@d-fischer/deprecate": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@d-fischer/deprecate/-/deprecate-2.0.1.tgz",
-            "integrity": "sha512-HrK3Yu3iRJo1YzG52bt2TyhRGZRIyFumbV/fH0h6IWa43ZJeAI3o4LXzBVLLdA7ITLTMtYP8yJnpHuFftQwQ2A=="
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@d-fischer/deprecate/-/deprecate-2.0.2.tgz",
+            "integrity": "sha512-wlw3HwEanJFJKctwLzhfOM6LKwR70FPfGZGoKOhWBKyOPXk+3a9Cc6S9zhm6tka7xKtpmfxVIReGUwPnMbIaZg=="
         },
         "@d-fischer/escape-string-regexp": {
             "version": "5.0.0",
@@ -301,18 +296,13 @@
             "resolved": "https://registry.npmjs.org/@d-fischer/isomorphic-ws/-/isomorphic-ws-5.0.2.tgz",
             "integrity": "sha512-FeULiS37jd5M7nroqUw7kfnntlIW6Kilr2kn38Xjoyw/WZqwdxSAihJ2Y09aoDamrVKEW9/flbo2/y/VwHVZ6g=="
         },
-        "@d-fischer/klona": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/@d-fischer/klona/-/klona-1.1.5.tgz",
-            "integrity": "sha512-fdXM0iXtYcGbIxpWpUYsUi7cAMw8jXbJ75OJDFuScL/TXrrtMlZ9JOLpsZFVMzgeBOTpHLefG5KydsZEAzj95Q=="
-        },
         "@d-fischer/logger": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-2.0.0.tgz",
-            "integrity": "sha512-KIVO0U8sqoulnepMEvXP/FjJAavfmKHLoFIn+D0iqzmFgaY8eaZ464y8nuMVgZGYUGAFxY953XVAeijBf07vcw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-2.1.0.tgz",
+            "integrity": "sha512-NK2SFtNYfzI5V0/Nws1ANJC2b0K3JB1Uhp7CdS6VH2v3wPBlfM/NXcrrsiPTbCM5QgsZxJDIlQKcI+UYw9terg==",
             "requires": {
                 "detect-node": "^2.0.4",
-                "tslib": "^2.0.0"
+                "tslib": "^2.0.1"
             }
         },
         "@d-fischer/promise.allsettled": {
@@ -332,50 +322,52 @@
             "integrity": "sha512-yAu3xDooiL+ef84Jo8nLjDjWBRk7RXk163Y6aTvRB7FauYd3spQD/dWvgT7R4CrN54Juhrrc3dMY7mc+jZGurQ=="
         },
         "@d-fischer/rate-limiter": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/@d-fischer/rate-limiter/-/rate-limiter-0.2.5.tgz",
-            "integrity": "sha512-JnnhFeB1dMT4ooaIcnZKtvepnf/wtAJTVEKEnu7i3Pl9Q7JTU0dEPoTsEdAqMjGyQHKc0msCv47Yg1htqcmH/A==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/@d-fischer/rate-limiter/-/rate-limiter-0.2.6.tgz",
+            "integrity": "sha512-tu8OSno3WEd18CmAqezH17rRNX8rMGmsoIfOwt01r4q0vb+krvftcCLxiN8UwJsSXFgMTp11CXfdsl0wu2VjPg==",
             "requires": {
-                "@d-fischer/logger": "^2.0.0",
+                "@d-fischer/logger": "^2.1.0",
                 "@d-fischer/promise.allsettled": "^2.0.1",
                 "@types/node": "^12.12.5",
-                "tslib": "^1.9.3"
-            },
-            "dependencies": {
-                "@types/node": {
-                    "version": "12.12.62",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.62.tgz",
-                    "integrity": "sha512-qAfo81CsD7yQIM9mVyh6B/U47li5g7cfpVQEDMfQeF8pSZVwzbhwU3crc0qG4DmpsebpJPR49AKOExQyJ05Cpg=="
-                },
-                "tslib": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
-                }
-            }
-        },
-        "@d-fischer/shared-utils": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/@d-fischer/shared-utils/-/shared-utils-2.3.2.tgz",
-            "integrity": "sha512-/eOhwUcdbWrpdPDWu77Q21UDuL6q9GJAp1dfXr6QgGs4pHTg9ZUFSs6Vhotk0Muu6xNkwwlOlZFwds3CRXhTmg==",
-            "requires": {
-                "@types/node": "^14.0.5",
-                "tslib": "^2.0.0"
-            }
-        },
-        "@d-fischer/typed-event-emitter": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@d-fischer/typed-event-emitter/-/typed-event-emitter-3.0.2.tgz",
-            "integrity": "sha512-8wd8Nv9c0H0/eeagiXRongLdwv510EriTj9+Ja2gkIebGFp8Irrxcx9pL6+4jdnr+R7MV3sEoJBQ8FynSFH7Tw==",
-            "requires": {
-                "@types/node": "^14.11.1",
                 "tslib": "^2.0.1"
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "14.11.2",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.11.2.tgz",
-                    "integrity": "sha512-jiE3QIxJ8JLNcb1Ps6rDbysDhN4xa8DJJvuC9prr6w+1tIh+QAbYyNF3tyiZNLDBIuBCf4KEcV2UvQm/V60xfA=="
+                    "version": "12.19.3",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-12.19.3.tgz",
+                    "integrity": "sha512-8Jduo8wvvwDzEVJCOvS/G6sgilOLvvhn1eMmK3TW8/T217O7u1jdrK6ImKLv80tVryaPSVeKu6sjDEiFjd4/eg=="
+                }
+            }
+        },
+        "@d-fischer/shared-utils": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@d-fischer/shared-utils/-/shared-utils-2.4.0.tgz",
+            "integrity": "sha512-HqS4PAyzJXzs+CtomhsqcvAl34UmDHoiP8BqOkTdMZCkcqW+SMoGekBAxDyX23p7q8E39zRy0S3uyIHD/GPmuA==",
+            "requires": {
+                "@types/node": "^14.11.2",
+                "tslib": "^2.0.1"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "14.14.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+                    "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
+                }
+            }
+        },
+        "@d-fischer/typed-event-emitter": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/@d-fischer/typed-event-emitter/-/typed-event-emitter-3.1.0.tgz",
+            "integrity": "sha512-s0ZokqR2kR3NX6C7Em4gdf6sXtyH17yqhQzDEXEvFjBeWaYSRbRVUV/73DxU2ZTR+4h2obwL+Gru4TAEXrFfdQ==",
+            "requires": {
+                "@types/node": "^14.11.2",
+                "tslib": "^2.0.1"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "14.14.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+                    "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
                 }
             }
         },
@@ -2663,9 +2655,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.35",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
-                    "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+                    "version": "10.17.44",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
+                    "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
                 }
             }
         },
@@ -2684,25 +2676,24 @@
             }
         },
         "@slack/types": {
-            "version": "1.9.0",
-            "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.9.0.tgz",
-            "integrity": "sha512-RmwgMWqOtzd2JPXdiaD/tyrDD0vtjjRDFdxN1I3tAxwBbg4aryzDUVqFc8na16A+3Xik/UN8X1hvVTw8J4EB9w=="
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/@slack/types/-/types-1.10.0.tgz",
+            "integrity": "sha512-tA7GG7Tj479vojfV3AoxbckalA48aK6giGjNtgH6ihpLwTyHE3fIgRrvt8TWfLwW8X8dyu7vgmAsGLRG7hWWOg=="
         },
         "@slack/web-api": {
-            "version": "5.12.0",
-            "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.12.0.tgz",
-            "integrity": "sha512-ygSnNHVid7PltGo7W36f2SNVHyliemkzxn9uSwgnWNF7CHmWBKWAylU/eoDml9l5K7akMOxbousiurOw4XqOFg==",
+            "version": "5.13.0",
+            "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-5.13.0.tgz",
+            "integrity": "sha512-xT27bhYvkjidKCmGt3Dy4tx12Hk4oI9G/6vQFUdDXV1WSk50tysswHe67ckgcSU95yRPcnLVQicVpM3cAH6/AA==",
             "requires": {
                 "@slack/logger": ">=1.0.0 <3.0.0",
                 "@slack/types": "^1.7.0",
                 "@types/is-stream": "^1.1.0",
                 "@types/node": ">=8.9.0",
-                "@types/p-queue": "^2.3.2",
                 "axios": "^0.19.0",
                 "eventemitter3": "^3.1.0",
                 "form-data": "^2.5.0",
                 "is-stream": "^1.1.0",
-                "p-queue": "^2.4.2",
+                "p-queue": "^6.6.1",
                 "p-retry": "^4.0.0"
             },
             "dependencies": {
@@ -2717,9 +2708,20 @@
                     }
                 },
                 "p-queue": {
-                    "version": "2.4.2",
-                    "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-2.4.2.tgz",
-                    "integrity": "sha512-n8/y+yDJwBjoLQe1GSJbbaYQLTI7QHNZI2+rpmCDbe++WLf9HC3gf6iqj5yfPAV71W4UF3ql5W1+UBPXoXTxng=="
+                    "version": "6.6.2",
+                    "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+                    "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+                    "requires": {
+                        "eventemitter3": "^4.0.4",
+                        "p-timeout": "^3.2.0"
+                    },
+                    "dependencies": {
+                        "eventemitter3": {
+                            "version": "4.0.7",
+                            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+                            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+                        }
+                    }
                 }
             }
         },
@@ -2750,11 +2752,6 @@
             "version": "0.12.2",
             "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
             "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
-        },
-        "@types/clone": {
-            "version": "0.1.30",
-            "resolved": "https://registry.npmjs.org/@types/clone/-/clone-0.1.30.tgz",
-            "integrity": "sha1-5zZWSMG0ITalnH1QQGN7O1yDthQ="
         },
         "@types/color-name": {
             "version": "1.1.1",
@@ -2893,9 +2890,9 @@
             }
         },
         "@types/node-telegram-bot-api": {
-            "version": "0.50.3",
-            "resolved": "https://registry.npmjs.org/@types/node-telegram-bot-api/-/node-telegram-bot-api-0.50.3.tgz",
-            "integrity": "sha512-ANBR2YEtGOTDIhrSqyLTcwXCapM8yx+giBec1pKsPpj9BJ4WFYIcJcRf3njVSuMjGk18XV6DKic1W+74Jt9evA==",
+            "version": "0.50.4",
+            "resolved": "https://registry.npmjs.org/@types/node-telegram-bot-api/-/node-telegram-bot-api-0.50.4.tgz",
+            "integrity": "sha512-3wS5AOsMvIUCY1UU8l0zB0yERNOm2qEQNknPaxrDsN/ISSbLfa0blSsdfxoO63L/acdffF+Udn9XfXaJnGDF5g==",
             "requires": {
                 "@types/node": "*",
                 "@types/request": "*"
@@ -2906,11 +2903,6 @@
             "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
             "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
             "dev": true
-        },
-        "@types/p-queue": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/@types/p-queue/-/p-queue-2.3.2.tgz",
-            "integrity": "sha512-eKAv5Ql6k78dh3ULCsSBxX6bFNuGjTmof5Q/T6PiECDq0Yf8IIn46jCyp3RJvCi8owaEmm3DZH1PEImjBMd/vQ=="
         },
         "@types/parse-json": {
             "version": "4.0.0",
@@ -2965,12 +2957,12 @@
             "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA=="
         },
         "@types/serve-static": {
-            "version": "1.13.5",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.5.tgz",
-            "integrity": "sha512-6M64P58N+OXjU432WoLLBQxbA0LRGBCRm7aAGQJ+SMC1IMl0dgRVi9EFfoDcS2a7Xogygk/eGN94CfwU9UF7UQ==",
+            "version": "1.13.6",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.6.tgz",
+            "integrity": "sha512-nuRJmv7jW7VmCVTn+IgYDkkbbDGyIINOeu/G0d74X3lm6E5KfMeQPJhxIt1ayQeQB3cSxvYs1RA/wipYoFB4EA==",
             "requires": {
-                "@types/express-serve-static-core": "*",
-                "@types/mime": "*"
+                "@types/mime": "*",
+                "@types/node": "*"
             }
         },
         "@types/socket.io": {
@@ -2983,9 +2975,9 @@
             }
         },
         "@types/socket.io-client": {
-            "version": "1.4.33",
-            "resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.33.tgz",
-            "integrity": "sha512-m4LnxkljsI9fMsjwpW5QhRpMixo2BeeLpFmg0AE+sS4H1pzAd/cs/ftTiL60FLZgfFa8PFRPx5KsHu8O0bADKQ=="
+            "version": "1.4.34",
+            "resolved": "https://registry.npmjs.org/@types/socket.io-client/-/socket.io-client-1.4.34.tgz",
+            "integrity": "sha512-Lzia5OTQFJZJ5R4HsEEldywiiqT9+W2rDbyHJiiTGqOcju89sCsQ8aUXDljY6Ls33wKZZGC0bfMhr/VpOyjtXg=="
         },
         "@types/soundjs": {
             "version": "0.6.28",
@@ -3034,9 +3026,9 @@
             }
         },
         "@types/uglify-js": {
-            "version": "3.9.3",
-            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.9.3.tgz",
-            "integrity": "sha512-KswB5C7Kwduwjj04Ykz+AjvPcfgv/37Za24O2EDzYNbwyzOo8+ydtvzUfZ5UMguiVu29Gx44l1A6VsPPcmYu9w==",
+            "version": "3.11.1",
+            "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.11.1.tgz",
+            "integrity": "sha512-7npvPKV+jINLu1SpSYVWG8KvyJBhBa8tmzMMdDoVc2pWUYHN8KIXlPJhjJ4LT97c4dXJA2SHL/q6ADbDriZN+Q==",
             "requires": {
                 "source-map": "^0.6.1"
             },
@@ -3049,9 +3041,9 @@
             }
         },
         "@types/webpack": {
-            "version": "4.41.22",
-            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.22.tgz",
-            "integrity": "sha512-JQDJK6pj8OMV9gWOnN1dcLCyU9Hzs6lux0wBO4lr1+gyEhIBR9U3FMrz12t2GPkg110XAxEAw2WHF6g7nZIbRQ==",
+            "version": "4.41.24",
+            "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.24.tgz",
+            "integrity": "sha512-1A0MXPwZiMOD3DPMuOKUKcpkdPo8Lq33UGggZ7xio6wJ/jV1dAu5cXDrOfGDnldUroPIRLsr/DT43/GqOA4RFQ==",
             "requires": {
                 "@types/anymatch": "*",
                 "@types/node": "*",
@@ -3069,9 +3061,9 @@
             }
         },
         "@types/webpack-sources": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-1.4.2.tgz",
-            "integrity": "sha512-77T++JyKow4BQB/m9O96n9d/UUHWLQHlcqXb9Vsf4F1+wKNrrlWNFPDLKNT92RJnCSL6CieTc+NDXtCVZswdTw==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-2.0.0.tgz",
+            "integrity": "sha512-a5kPx98CNFRKQ+wqawroFunvFqv7GHm/3KOI52NY9xWADgc8smu4R6prt4EU/M4QfVjvgBkMqU4fBhw3QfMVkg==",
             "requires": {
                 "@types/node": "*",
                 "@types/source-list-map": "*",
@@ -3086,9 +3078,9 @@
             }
         },
         "@types/ws": {
-            "version": "7.2.6",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.6.tgz",
-            "integrity": "sha512-Q07IrQUSNpr+cXU4E4LtkSIBPie5GLZyyMC1QtQYRLWz701+XcoVygGUZgvLqElq1nU4ICldMYPnexlBsg3dqQ==",
+            "version": "7.2.9",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.2.9.tgz",
+            "integrity": "sha512-gmXYAXr7G4BrRMnkGQGkGonc3ArVro9VZd//C1uns/qqsJyl2dxaJdlPMhZbcq5MTxFFC+ttFWtHSfVW5+hlRA==",
             "requires": {
                 "@types/node": "*"
             }
@@ -3213,9 +3205,9 @@
             }
         },
         "@vaadin/vaadin-lumo-styles": {
-            "version": "1.6.0",
-            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.6.0.tgz",
-            "integrity": "sha512-MTJ2JssEVF3Go5b+zIe86Jw8nNtaN91wHmO2Ic1eI27PEJ5dRRGcLWX9CjTEx/8Zu9+3Fk4YeVP9ABWhiZZGUw==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/@vaadin/vaadin-lumo-styles/-/vaadin-lumo-styles-1.6.1.tgz",
+            "integrity": "sha512-Yh9ZcekpY7byXP1QJnfx94rVvK71xHBEspsVV7LL7YMvqXU4EAYuzQGYsljryV4PGS9PFPD6sqbGqhEkIhHPnQ==",
             "requires": {
                 "@polymer/iron-icon": "^3.0.0",
                 "@polymer/iron-iconset-svg": "^3.0.0",
@@ -3431,14 +3423,14 @@
             }
         },
         "@webcomponents/shadycss": {
-            "version": "1.10.1",
-            "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.1.tgz",
-            "integrity": "sha512-XEVDA7oH6o4Au9apyRDucjcIzvP44Ur4sqTMGRKCcE6sCAeKiOkRE03TCYNJAFkzckMWWT8Xx3IxG3iwjAcsRQ=="
+            "version": "1.10.2",
+            "resolved": "https://registry.npmjs.org/@webcomponents/shadycss/-/shadycss-1.10.2.tgz",
+            "integrity": "sha512-9Iseu8bRtecb0klvv+WXZOVZatsRkbaH7M97Z+f+Pt909R4lDfgUODAnra23DOZTpeMTAkVpf4m/FZztN7Ox1A=="
         },
         "@webcomponents/webcomponentsjs": {
-            "version": "2.4.4",
-            "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.4.4.tgz",
-            "integrity": "sha512-UWXZYbaDLLfhm+xONXTiDciyhOSwKRrZieGQHFMSMGSxY4mbjZ5uYzOKgnuX0luYFvjJw32G3r0sCwQZPJIR4Q=="
+            "version": "2.5.0",
+            "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-2.5.0.tgz",
+            "integrity": "sha512-C0l51MWQZ9kLzcxOZtniOMohpIFdCLZum7/TEHv3XWFc1Fvt5HCpbSX84x8ltka/JuNKcuiDnxXFkiB2gaePcg=="
         },
         "@xtuc/ieee754": {
             "version": "1.2.0",
@@ -3913,9 +3905,9 @@
             }
         },
         "base64-arraybuffer": {
-            "version": "0.1.5",
-            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
-            "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
+            "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
         },
         "base64-js": {
             "version": "1.3.1",
@@ -3960,9 +3952,9 @@
             "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ=="
         },
         "bignumber.js": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.0.tgz",
-            "integrity": "sha512-t/OYhhJ2SD+YGBQcjY8GzzDHEk9f3nerxjtfa6tlMXfe7frs/WozhvCNoGvpM0P3bNf3Gq5ZRMlGr5f3r4/N8A=="
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.1.tgz",
+            "integrity": "sha512-IdZR9mh6ahOBv/hYGiXyVuyCetmGJhtYkqLBpTStdhEGjegpPlUawydyaF3pbIOFynJTpllEs+NP+CS9jKFLjA=="
         },
         "binary-extensions": {
             "version": "2.1.0",
@@ -4283,12 +4275,12 @@
             "dev": true
         },
         "buffer": {
-            "version": "5.6.0",
-            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-            "integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+            "version": "5.7.0",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.0.tgz",
+            "integrity": "sha512-cd+5r1VLBwUqTrmnzW+D7ABkJUM6mr7uv1dv+6jRw4Rcl7tFIFHDqHPL98LhpGFn3dbAt3gtLxtrWp4m1kFrqg==",
             "requires": {
-                "base64-js": "^1.0.2",
-                "ieee754": "^1.1.4"
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
             }
         },
         "buffer-equal-constant-time": {
@@ -4446,6 +4438,15 @@
                     "integrity": "sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==",
                     "dev": true
                 }
+            }
+        },
+        "call-bind": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+            "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "get-intrinsic": "^1.0.0"
             }
         },
         "call-me-maybe": {
@@ -4617,9 +4618,9 @@
             },
             "dependencies": {
                 "tslib": {
-                    "version": "1.13.0",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
-                    "integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q=="
+                    "version": "1.14.1",
+                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
                 }
             }
         },
@@ -5851,14 +5852,14 @@
             }
         },
         "discord.js": {
-            "version": "12.3.1",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.3.1.tgz",
-            "integrity": "sha512-mSFyV/mbvzH12UXdS4zadmeUf8IMQOo/YdunubG1wWt1xjWvtaJz/s9CGsFD2B5pTw1W/LXxxUbrQjIZ/xlUdw==",
+            "version": "12.4.1",
+            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-12.4.1.tgz",
+            "integrity": "sha512-KxOB8LOAN3GmrvkD6a6Fr1nlfArIFZ+q7Uqg4T/5duB90GZy9a0/Py2E+Y+eHKP6ZUCR2mbNMLCcHGjahiaNqA==",
             "requires": {
                 "@discordjs/collection": "^0.1.6",
                 "@discordjs/form-data": "^3.0.1",
                 "abort-controller": "^3.0.0",
-                "node-fetch": "^2.6.0",
+                "node-fetch": "^2.6.1",
                 "prism-media": "^1.2.2",
                 "setimmediate": "^1.0.5",
                 "tweetnacl": "^1.0.3",
@@ -6071,23 +6072,46 @@
             }
         },
         "engine.io-client": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.3.tgz",
-            "integrity": "sha512-0NGY+9hioejTEJCaSJZfWZLk4FPI9dN+1H1C4+wj2iuFba47UgZbJzfWs4aNFajnX/qAaYKbe2lLTfEEWzCmcw==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.4.4.tgz",
+            "integrity": "sha512-iU4CRr38Fecj8HoZEnFtm2EiKGbYZcPn3cHxqNGl/tmdWRf60KhK+9vE0JeSjgnlS/0oynEfLgKbT9ALpim0sQ==",
             "requires": {
                 "component-emitter": "~1.3.0",
                 "component-inherit": "0.0.3",
-                "debug": "~4.1.0",
+                "debug": "~3.1.0",
                 "engine.io-parser": "~2.2.0",
                 "has-cors": "1.1.0",
                 "indexof": "0.0.1",
-                "parseqs": "0.0.5",
-                "parseuri": "0.0.5",
+                "parseqs": "0.0.6",
+                "parseuri": "0.0.6",
                 "ws": "~6.1.0",
                 "xmlhttprequest-ssl": "~1.5.4",
                 "yeast": "0.1.2"
             },
             "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                },
+                "parseqs": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+                    "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
+                },
+                "parseuri": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+                    "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
+                },
                 "ws": {
                     "version": "6.1.4",
                     "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
@@ -6099,13 +6123,13 @@
             }
         },
         "engine.io-parser": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.0.tgz",
-            "integrity": "sha512-6I3qD9iUxotsC5HEMuuGsKA0cXerGz+4uGcXQEkfBidgKf0amsjrrtwcbwK/nzpZBxclXlV7gGl9dgWvu4LF6w==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
+            "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
             "requires": {
                 "after": "0.8.2",
                 "arraybuffer.slice": "~0.0.7",
-                "base64-arraybuffer": "0.1.5",
+                "base64-arraybuffer": "0.1.4",
                 "blob": "0.0.5",
                 "has-binary2": "~1.0.2"
             }
@@ -7425,9 +7449,9 @@
             }
         },
         "gaxios": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-3.2.0.tgz",
-            "integrity": "sha512-+6WPeVzPvOshftpxJwRi2Ozez80tn/hdtOUag7+gajDHRJvAblKxTFSSMPtr2hmnLy7p0mvYz0rMXLBl8pSO7Q==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-4.0.1.tgz",
+            "integrity": "sha512-jOin8xRZ/UytQeBpSXFqIzqU7Fi5TqgPNLlUsSB8kjJ76+FiGBfImF8KJu++c6J4jOldfJUtt0YmkRj2ZpSHTQ==",
             "requires": {
                 "abort-controller": "^3.0.0",
                 "extend": "^3.0.2",
@@ -7437,9 +7461,9 @@
             },
             "dependencies": {
                 "agent-base": {
-                    "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.1.tgz",
-                    "integrity": "sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==",
+                    "version": "6.0.2",
+                    "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+                    "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
                     "requires": {
                         "debug": "4"
                     }
@@ -7461,11 +7485,11 @@
             }
         },
         "gcp-metadata": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.0.tgz",
-            "integrity": "sha512-vQZD57cQkqIA6YPGXM/zc+PIZfNRFdukWGsGZ5+LcJzesi5xp6Gn7a02wRJi4eXPyArNMIYpPET4QMxGqtlk6Q==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-4.2.1.tgz",
+            "integrity": "sha512-tSk+REe5iq/N+K+SK1XjZJUrFPuDqGZVzCy2vocIHIGmPlTGsa8owXMJwGkrXr73NO0AzhPW4MF2DEHz7P2AVw==",
             "requires": {
-                "gaxios": "^3.0.0",
+                "gaxios": "^4.0.0",
                 "json-bigint": "^1.0.0"
             }
         },
@@ -7492,14 +7516,24 @@
             "dev": true
         },
         "gensync": {
-            "version": "1.0.0-beta.1",
-            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-            "integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+            "version": "1.0.0-beta.2",
+            "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+            "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
         },
         "get-caller-file": {
             "version": "2.0.5",
             "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
             "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+        },
+        "get-intrinsic": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+            "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+            "requires": {
+                "function-bind": "^1.1.1",
+                "has": "^1.0.3",
+                "has-symbols": "^1.0.1"
+            }
         },
         "get-pkg-repo": {
             "version": "1.4.0",
@@ -8115,17 +8149,17 @@
             }
         },
         "google-auth-library": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.0.tgz",
-            "integrity": "sha512-GbalszIADE1YPWhUyfFMrkLhFHnlAgoRcqGVW+MsLDPsuaOB5MRPk7NNafPDv9SherNE4EKzcYuxMJjaxzXMOw==",
+            "version": "6.1.3",
+            "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-6.1.3.tgz",
+            "integrity": "sha512-m9mwvY3GWbr7ZYEbl61isWmk+fvTmOt0YNUfPOUY2VH8K5pZlAIWJjxEi0PqR3OjMretyiQLI6GURMrPSwHQ2g==",
             "requires": {
                 "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
                 "ecdsa-sig-formatter": "^1.0.11",
                 "fast-text-encoding": "^1.0.0",
-                "gaxios": "^3.0.0",
-                "gcp-metadata": "^4.1.0",
-                "gtoken": "^5.0.0",
+                "gaxios": "^4.0.0",
+                "gcp-metadata": "^4.2.0",
+                "gtoken": "^5.0.4",
                 "jws": "^4.0.0",
                 "lru-cache": "^6.0.0"
             },
@@ -8168,12 +8202,12 @@
             }
         },
         "googleapis-common": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-4.4.0.tgz",
-            "integrity": "sha512-Bgrs8/1OZQFFIfVuX38L9t48rPAkVUXttZy6NzhhXxFOEMSHgfFIjxou7RIXOkBHxmx2pVwct9WjKkbnqMYImQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/googleapis-common/-/googleapis-common-4.4.3.tgz",
+            "integrity": "sha512-W46WKCk3QtlCCfmZyQIH5zxmDOyeV5Qj+qs7nr2ox08eRkEJMWp6iwv542R/PsokXaGUSrmif4vCC4+rGzRSsQ==",
             "requires": {
                 "extend": "^3.0.2",
-                "gaxios": "^3.0.0",
+                "gaxios": "^4.0.0",
                 "google-auth-library": "^6.0.0",
                 "qs": "^6.7.0",
                 "url-template": "^2.0.8",
@@ -8186,9 +8220,9 @@
                     "integrity": "sha512-A1kFqHekCTM7cz0udomYUoYNWjBebHm/5wzU/XqrBRBNWectVH0QIiN+NEcZ0Dte5hvzHwbr8+XQmguPhJ6WdQ=="
                 },
                 "uuid": {
-                    "version": "8.3.0",
-                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.0.tgz",
-                    "integrity": "sha512-fX6Z5o4m6XsXBdli9g7DtWgAx+osMsRRZFKma1mIUsLCz6vRvv+pz5VNbyu9UEDzpMWulZfvpgb/cmDXVulYFQ=="
+                    "version": "8.3.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.1.tgz",
+                    "integrity": "sha512-FOmRr+FmWEIG8uhZv6C2bTgEVXsHk08kE7mPlrBbEe+c3r9pjceVPgupIfNIhc4yx55H69OXANrUaSuu9eInKg=="
                 }
             }
         },
@@ -8217,12 +8251,12 @@
             "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
         "gtoken": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.3.tgz",
-            "integrity": "sha512-Nyd1wZCMRc2dj/mAD0LlfQLcAO06uKdpKJXvK85SGrF5+5+Bpfil9u/2aw35ltvEHjvl0h5FMKN5knEU+9JrOg==",
+            "version": "5.0.5",
+            "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-5.0.5.tgz",
+            "integrity": "sha512-wvjkecutFh8kVfbcdBdUWqDRrXb+WrgD79DBDEYf1Om8S1FluhylhtFjrL7Tx69vNhh259qA3Q1P4sPtb+kUYw==",
             "requires": {
-                "gaxios": "^3.0.0",
-                "google-p12-pem": "^3.0.0",
+                "gaxios": "^4.0.0",
+                "google-p12-pem": "^3.0.3",
                 "jws": "^4.0.0",
                 "mime": "^2.2.0"
             },
@@ -8588,9 +8622,9 @@
             }
         },
         "ieee754": {
-            "version": "1.1.13",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+            "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
         },
         "iferr": {
             "version": "0.1.5",
@@ -8846,9 +8880,9 @@
             "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
         },
         "ip-regex": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.1.0.tgz",
-            "integrity": "sha512-pKnZpbgCTfH/1NLIlOduP/V+WRXzC2MOz3Qo8xmxk8C5GudJLgK5QyLVXOSWy3ParAH7Eemurl3xjv/WXYFvMA=="
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-4.2.0.tgz",
+            "integrity": "sha512-n5cDDeTWWRwK1EBoWwRti+8nP4NbytBBY0pldmnIkq6Z55KNFmWofh4rl9dPZpj+U/nVq7gweR3ylrvMt4YZ5A=="
         },
         "ipaddr.js": {
             "version": "1.9.1",
@@ -8871,25 +8905,24 @@
             "integrity": "sha512-HtszKchBQTcqw1DC09uD7i7vvMayHGM1OCo6AHt5pkgZEyo99ClhHTMJdf+Ezc9ovuNNxcH89QfyclGthjZJOw=="
         },
         "ircv3": {
-            "version": "0.26.0",
-            "resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.26.0.tgz",
-            "integrity": "sha512-/2vzYh5ut/9tmROt7q+MlBqq2rDKpPxR8yidBkbirODRR/xTn2FW9YrV4Fo3OQdQXayZzwjUWHYuo9oI50HxpQ==",
+            "version": "0.26.4",
+            "resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.26.4.tgz",
+            "integrity": "sha512-7exmf76YORH9OSEn0zy4u6zuyrK0WSex2usP9GKjaMDDUnbwkjT2eyslJ5wE0A5s5F87MPI7cTC21T80UpSVdg==",
             "requires": {
-                "@d-fischer/connection": "^6.0.1",
+                "@d-fischer/connection": "^6.2.0",
                 "@d-fischer/escape-string-regexp": "^5.0.0",
-                "@d-fischer/klona": "^1.1.5",
-                "@d-fischer/logger": "^2.0.0",
-                "@d-fischer/shared-utils": "^2.3.1",
-                "@d-fischer/typed-event-emitter": "^3.0.1",
-                "@types/clone": "^0.1.30",
-                "@types/node": "^14.0.20",
-                "clone": "^2.1.2"
+                "@d-fischer/logger": "^2.1.0",
+                "@d-fischer/shared-utils": "^2.4.0",
+                "@d-fischer/typed-event-emitter": "^3.1.0",
+                "@types/node": "^14.11.2",
+                "klona": "^2.0.4",
+                "tslib": "^2.0.1"
             },
             "dependencies": {
-                "clone": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-                    "integrity": "sha1-G39Ln1kfHo+DZwQBYANFoCiHQ18="
+                "@types/node": {
+                    "version": "14.14.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+                    "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw=="
                 }
             }
         },
@@ -9073,6 +9106,11 @@
                 "jsonpointer": "^4.0.0",
                 "xtend": "^4.0.0"
             }
+        },
+        "is-negative-zero": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
+            "integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE="
         },
         "is-npm": {
             "version": "4.0.0",
@@ -9430,6 +9468,11 @@
             "version": "6.0.3",
             "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
             "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+        },
+        "klona": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.4.tgz",
+            "integrity": "sha512-ZRbnvdg/NxqzC7L9Uyqzf4psi1OM4Cuc+sJAkQPjO6XkQIJTNbfK2Rsmbw8fx1p2mkZdp2FZYo2+LwXYY/uwIA=="
         },
         "latest-version": {
             "version": "5.1.0",
@@ -10131,9 +10174,9 @@
             }
         },
         "nan": {
-            "version": "2.14.1",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-            "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+            "version": "2.14.2",
+            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
         },
         "nanomatch": {
             "version": "1.2.13",
@@ -10411,9 +10454,9 @@
             }
         },
         "nodecg": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/nodecg/-/nodecg-1.7.0.tgz",
-            "integrity": "sha512-83fheIWJrN+FXfWwlo6OIvsdTA8P7jlUtDowMWhqNuRJmwto7CWqBQ7UAtxa8Psz9AjfcKW83pXtkcwtuYRphg==",
+            "version": "1.7.1",
+            "resolved": "https://registry.npmjs.org/nodecg/-/nodecg-1.7.1.tgz",
+            "integrity": "sha512-PDaaYXJ+jCOqgyVbcBmmAFac6c/42kRPKs/CbtAMB3fInWhR1JGTSttFNnhFfhEaACRAOifNgVES1yj3pVKgjA==",
             "requires": {
                 "@babel/core": "^7.4.3",
                 "@polymer/app-layout": "^3.0.0",
@@ -10505,9 +10548,9 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "10.17.35",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.35.tgz",
-                    "integrity": "sha512-gXx7jAWpMddu0f7a+L+txMplp3FnHl53OhQIF9puXKq3hDGY/GjH+MF04oWnV/adPSCrbtHumDCFwzq2VhltWA=="
+                    "version": "10.17.44",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.44.tgz",
+                    "integrity": "sha512-vHPAyBX1ffLcy4fQHmDyIUMUb42gHZjPHU66nhvbMzAWJqHnySGZ6STwN3rwrnSd1FHB0DI/RWgGELgKSYRDmw=="
                 },
                 "cacache": {
                     "version": "11.3.3",
@@ -10828,12 +10871,49 @@
             "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA=="
         },
         "object-is": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.2.tgz",
-            "integrity": "sha512-5lHCz+0uufF6wZ7CRFWJN3hp8Jqblpgve06U5CMQ3f//6iDjPr2PEo9MWCjEssDsa+UZEL4PkFpr+BMop6aKzQ==",
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/object-is/-/object-is-1.1.3.tgz",
+            "integrity": "sha512-teyqLvFWzLkq5B9ki8FVWA902UER2qkxmdA4nLf+wjOLAWgxzCWZNCxpDq9MvE8MmhWNr+I8w3BN49Vx36Y6Xg==",
             "requires": {
                 "define-properties": "^1.1.3",
-                "es-abstract": "^1.17.5"
+                "es-abstract": "^1.18.0-next.1"
+            },
+            "dependencies": {
+                "es-abstract": {
+                    "version": "1.18.0-next.1",
+                    "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+                    "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+                    "requires": {
+                        "es-to-primitive": "^1.2.1",
+                        "function-bind": "^1.1.1",
+                        "has": "^1.0.3",
+                        "has-symbols": "^1.0.1",
+                        "is-callable": "^1.2.2",
+                        "is-negative-zero": "^2.0.0",
+                        "is-regex": "^1.1.1",
+                        "object-inspect": "^1.8.0",
+                        "object-keys": "^1.1.1",
+                        "object.assign": "^4.1.1",
+                        "string.prototype.trimend": "^1.0.1",
+                        "string.prototype.trimstart": "^1.0.1"
+                    }
+                },
+                "is-callable": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+                    "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA=="
+                },
+                "object.assign": {
+                    "version": "4.1.2",
+                    "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+                    "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+                    "requires": {
+                        "call-bind": "^1.0.0",
+                        "define-properties": "^1.1.3",
+                        "has-symbols": "^1.0.1",
+                        "object-keys": "^1.1.1"
+                    }
+                }
             }
         },
         "object-keys": {
@@ -10842,9 +10922,9 @@
             "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA=="
         },
         "object-path": {
-            "version": "0.11.4",
-            "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.4.tgz",
-            "integrity": "sha1-NwrnUvvzfePqcKhhwju6iRVpGUk="
+            "version": "0.11.5",
+            "resolved": "https://registry.npmjs.org/object-path/-/object-path-0.11.5.tgz",
+            "integrity": "sha512-jgSbThcoR/s+XumvGMTMf81QVBmah+/Q7K7YduKeKVWL7N111unR2d6pZZarSk6kY/caeNxUDyxOvMWyzoU2eg=="
         },
         "object-visit": {
             "version": "1.0.1",
@@ -10939,9 +11019,9 @@
             }
         },
         "open": {
-            "version": "7.2.1",
-            "resolved": "https://registry.npmjs.org/open/-/open-7.2.1.tgz",
-            "integrity": "sha512-xbYCJib4spUdmcs0g/2mK1nKo/jO2T7INClWd/beL7PFkXRWgr8B23ssDHX/USPn2M2IjDR5UdpYs6I67SnTSA==",
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-7.3.0.tgz",
+            "integrity": "sha512-mgLwQIx2F/ye9SmbrUkurZCnkoXyXyu9EbHtJZrICjVAJfyMArdHp3KkixGdZx1ZHFPNIwl0DDM1dFFqXbTLZw==",
             "requires": {
                 "is-docker": "^2.0.0",
                 "is-wsl": "^2.1.1"
@@ -11031,8 +11111,7 @@
         "p-finally": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
-            "dev": true
+            "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "p-limit": {
             "version": "2.3.0",
@@ -11100,6 +11179,14 @@
                     "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
                     "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
                 }
+            }
+        },
+        "p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+            "requires": {
+                "p-finally": "^1.0.0"
             }
         },
         "p-try": {
@@ -11434,15 +11521,15 @@
             "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs="
         },
         "prebuild-install": {
-            "version": "5.3.5",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.5.tgz",
-            "integrity": "sha512-YmMO7dph9CYKi5IR/BzjOJlRzpxGGVo1EsLSUZ0mt/Mq0HWZIHOKHHcHdT69yG54C9m6i45GpItwRHpk0Py7Uw==",
+            "version": "5.3.6",
+            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.6.tgz",
+            "integrity": "sha512-s8Aai8++QQGi4sSbs/M1Qku62PFK49Jm1CbgXklGz4nmHveDq0wzJkg7Na5QbnO1uNH8K7iqx2EQ/mV0MZEmOg==",
             "requires": {
                 "detect-libc": "^1.0.3",
                 "expand-template": "^2.0.3",
                 "github-from-package": "0.0.0",
                 "minimist": "^1.2.3",
-                "mkdirp": "^0.5.1",
+                "mkdirp-classic": "^0.5.3",
                 "napi-build-utils": "^1.0.1",
                 "node-abi": "^2.7.0",
                 "noop-logger": "^0.1.1",
@@ -12821,34 +12908,13 @@
                 "socket.io-adapter": "~1.1.0",
                 "socket.io-client": "2.3.0",
                 "socket.io-parser": "~3.4.0"
-            }
-        },
-        "socket.io-adapter": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
-            "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g=="
-        },
-        "socket.io-client": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
-            "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
-            "requires": {
-                "backo2": "1.0.2",
-                "base64-arraybuffer": "0.1.5",
-                "component-bind": "1.0.0",
-                "component-emitter": "1.2.1",
-                "debug": "~4.1.0",
-                "engine.io-client": "~3.4.0",
-                "has-binary2": "~1.0.2",
-                "has-cors": "1.1.0",
-                "indexof": "0.0.1",
-                "object-component": "0.0.3",
-                "parseqs": "0.0.5",
-                "parseuri": "0.0.5",
-                "socket.io-parser": "~3.3.0",
-                "to-array": "0.1.4"
             },
             "dependencies": {
+                "base64-arraybuffer": {
+                    "version": "0.1.5",
+                    "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.5.tgz",
+                    "integrity": "sha1-c5JncZI7Whl0etZmqlzUv5xunOg="
+                },
                 "component-emitter": {
                     "version": "1.2.1",
                     "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.2.1.tgz",
@@ -12864,24 +12930,115 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
                 },
-                "socket.io-parser": {
-                    "version": "3.3.0",
-                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.0.tgz",
-                    "integrity": "sha512-hczmV6bDgdaEbVqhAeVMM/jfUfzuEZHsQg6eOmLgJht6G3mPKMxYm75w2+qhAQZ+4X+1+ATZ+QFKeOZD5riHng==",
+                "socket.io-client": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.0.tgz",
+                    "integrity": "sha512-cEQQf24gET3rfhxZ2jJ5xzAOo/xhZwK+mOqtGRg5IowZsMgwvHwnf/mCRapAAkadhM26y+iydgwsXGObBB5ZdA==",
                     "requires": {
+                        "backo2": "1.0.2",
+                        "base64-arraybuffer": "0.1.5",
+                        "component-bind": "1.0.0",
                         "component-emitter": "1.2.1",
-                        "debug": "~3.1.0",
-                        "isarray": "2.0.1"
+                        "debug": "~4.1.0",
+                        "engine.io-client": "~3.4.0",
+                        "has-binary2": "~1.0.2",
+                        "has-cors": "1.1.0",
+                        "indexof": "0.0.1",
+                        "object-component": "0.0.3",
+                        "parseqs": "0.0.5",
+                        "parseuri": "0.0.5",
+                        "socket.io-parser": "~3.3.0",
+                        "to-array": "0.1.4"
                     },
                     "dependencies": {
-                        "debug": {
-                            "version": "3.1.0",
-                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                        "socket.io-parser": {
+                            "version": "3.3.1",
+                            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+                            "integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
                             "requires": {
-                                "ms": "2.0.0"
+                                "component-emitter": "~1.3.0",
+                                "debug": "~3.1.0",
+                                "isarray": "2.0.1"
+                            },
+                            "dependencies": {
+                                "component-emitter": {
+                                    "version": "1.3.0",
+                                    "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
+                                    "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+                                },
+                                "debug": {
+                                    "version": "3.1.0",
+                                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                                    "requires": {
+                                        "ms": "2.0.0"
+                                    }
+                                }
                             }
                         }
+                    }
+                }
+            }
+        },
+        "socket.io-adapter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-1.1.2.tgz",
+            "integrity": "sha512-WzZRUj1kUjrTIrUKpZLEzFZ1OLj5FwLlAFQs9kuZJzJi5DKdU7FsWc36SNmA8iDOtwBQyT8FkrriRM8vXLYz8g=="
+        },
+        "socket.io-client": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.3.1.tgz",
+            "integrity": "sha512-YXmXn3pA8abPOY//JtYxou95Ihvzmg8U6kQyolArkIyLd0pgVhrfor/iMsox8cn07WCOOvvuJ6XKegzIucPutQ==",
+            "requires": {
+                "backo2": "1.0.2",
+                "component-bind": "1.0.0",
+                "component-emitter": "~1.3.0",
+                "debug": "~3.1.0",
+                "engine.io-client": "~3.4.0",
+                "has-binary2": "~1.0.2",
+                "indexof": "0.0.1",
+                "parseqs": "0.0.6",
+                "parseuri": "0.0.6",
+                "socket.io-parser": "~3.3.0",
+                "to-array": "0.1.4"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
+                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+                },
+                "ms": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                },
+                "parseqs": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/parseqs/-/parseqs-0.0.6.tgz",
+                    "integrity": "sha512-jeAGzMDbfSHHA091hr0r31eYfTig+29g3GKKE/PPbEQ65X0lmMwlEoqmhzu0iztID5uJpZsFlUPDP8ThPL7M8w=="
+                },
+                "parseuri": {
+                    "version": "0.0.6",
+                    "resolved": "https://registry.npmjs.org/parseuri/-/parseuri-0.0.6.tgz",
+                    "integrity": "sha512-AUjen8sAkGgao7UyCX6Ahv0gIK2fABKmYjvP4xmy5JaKvcbTRueIqIPHLAfq30xJddqSE033IOMUSOMCcK3Sow=="
+                },
+                "socket.io-parser": {
+                    "version": "3.3.1",
+                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.1.tgz",
+                    "integrity": "sha512-1QLvVAe8dTz+mKmZ07Swxt+LAo4Y1ff50rlyoEx00TQmDFVQYPfcqGvIDJLGaBdhdNCecXtyKpD+EgKGcmmbuQ==",
+                    "requires": {
+                        "component-emitter": "~1.3.0",
+                        "debug": "~3.1.0",
+                        "isarray": "2.0.1"
                     }
                 }
             }
@@ -13513,9 +13670,9 @@
             "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "timers-browserify": {
-            "version": "2.0.11",
-            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.11.tgz",
-            "integrity": "sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==",
+            "version": "2.0.12",
+            "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.12.tgz",
+            "integrity": "sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==",
             "requires": {
                 "setimmediate": "^1.0.4"
             }
@@ -13652,9 +13809,9 @@
             "dev": true
         },
         "ts-loader": {
-            "version": "8.0.4",
-            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.4.tgz",
-            "integrity": "sha512-5u8KF1SW8eCUb/Ff7At81e3wznPmT/27fvaGRO9CziVy+6NlPVRvrzSox4OwU0/e6OflOUB32Err4VquysCSAQ==",
+            "version": "8.0.7",
+            "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-8.0.7.tgz",
+            "integrity": "sha512-ooa4wxlZ9TOXaJ/iVyZlWsim79Ul4KyifSwyT2hOrbQA6NZJypsLOE198o8Ko+JV+ZHnMArvWcl4AnRqpCU/Mw==",
             "requires": {
                 "chalk": "^2.3.0",
                 "enhanced-resolve": "^4.0.0",
@@ -13681,9 +13838,9 @@
             }
         },
         "tslib": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.1.tgz",
-            "integrity": "sha512-SgIkNheinmEBgx1IUNirK0TUD4X9yjjBRTqqjggWCU3pUEqIk3/Uwl3yRixYKT6WjQuGiwDv4NomL3wqRCj+CQ=="
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.0.3.tgz",
+            "integrity": "sha512-uZtkfKblCEQtZKBF6EBXVZeQNl82yqtDQdv+eck8u7tdPxjLu2/lp5/uPW+um2tpuxINHWy3GhiccY7QgEaVHQ=="
         },
         "tsutils": {
             "version": "3.17.1",
@@ -13726,9 +13883,9 @@
             "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
         },
         "twitch": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/twitch/-/twitch-4.2.4.tgz",
-            "integrity": "sha512-Al/Wj9581YpHAsBYC7BDIcqhWy8bYQNASgRiz7gKxrIopU7GyJ439qJ6MPWHGYc6DJjww5Anv+3QvMFBsUsSXg==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/twitch/-/twitch-4.2.7.tgz",
+            "integrity": "sha512-5k9mDM4Xk3DnnJxHrC0dm1dU7pcnSfIXICt96gKOR/SLtjCFrc/+H6vASc/FB2AK0pXVbyhM7yfbEMXVLrsrUw==",
             "requires": {
                 "@d-fischer/cache-decorators": "^2.0.0",
                 "@d-fischer/deprecate": "^2.0.1",
@@ -13737,14 +13894,14 @@
                 "@d-fischer/shared-utils": "^2.3.2",
                 "top-package": "^1.0.0",
                 "tslib": "^2.0.0",
-                "twitch-api-call": "^4.2.4",
-                "twitch-auth": "^4.2.4"
+                "twitch-api-call": "^4.2.7",
+                "twitch-auth": "^4.2.7"
             }
         },
         "twitch-api-call": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/twitch-api-call/-/twitch-api-call-4.2.4.tgz",
-            "integrity": "sha512-riLO068ahkoAjEjHTuDFGQkKHYNKsFdwJInVgE5hYT/SsrOvjWwtf4UlVdmF73IEKWMnoXDXdEhVsQ+DXmzCGQ==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/twitch-api-call/-/twitch-api-call-4.2.7.tgz",
+            "integrity": "sha512-nnDnPxDC4+mvE5ijb7T3XGm0tL/AEMgKajgn6Ick5IyyKWHg9GIu2PWhDE/ZyrJIIS5+hcTEnlUTbdN7fRBSjA==",
             "requires": {
                 "@d-fischer/cross-fetch": "^4.0.1",
                 "@d-fischer/qs": "^7.0.2",
@@ -13752,27 +13909,27 @@
             }
         },
         "twitch-auth": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.2.4.tgz",
-            "integrity": "sha512-MWoSOf616PgCtBdDNZlloNqZZT02qXAkT6IiZSukPfFkzOtoCTUhZ5wsK1pS1hIm0yq2MjNyKrQVHCqC2psiYQ==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/twitch-auth/-/twitch-auth-4.2.7.tgz",
+            "integrity": "sha512-B/hAPZFnrdt+qB/tPRYPvdkMpNy5BVDUBf7nJMCodApXehHwbAYHmP5boS/B3+WYQ64vu3O2ArVpLjlXO5Ajxw==",
             "requires": {
                 "@d-fischer/deprecate": "^2.0.1",
                 "@d-fischer/shared-utils": "^2.3.2",
                 "tslib": "^2.0.0",
-                "twitch-api-call": "^4.2.4"
+                "twitch-api-call": "^4.2.7"
             }
         },
         "twitch-chat-client": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.2.4.tgz",
-            "integrity": "sha512-TFlTuGjrnzpP3byoTiMpbqNQXlR5/6aOH+X+pKvOO301u44yWfcGPVa/iQoAa8HTmNX3UCqpUvNYYt5WHxb0hg==",
+            "version": "4.2.7",
+            "resolved": "https://registry.npmjs.org/twitch-chat-client/-/twitch-chat-client-4.2.7.tgz",
+            "integrity": "sha512-n3KTPjiC7kC8eoJIQrWmmJAf+tV5YURwItMsNJ/NyJzZqSNERt7FuitoBeM/ZU6HgyXD+/r1vP1FYiDz1cdFBw==",
             "requires": {
                 "@d-fischer/cache-decorators": "^2.0.0",
                 "@d-fischer/deprecate": "^2.0.1",
                 "@d-fischer/logger": "^2.0.0",
                 "@d-fischer/shared-utils": "^2.3.2",
-                "@d-fischer/typed-event-emitter": "^3.0.0",
-                "ircv3": "^0.26.0",
+                "@d-fischer/typed-event-emitter": "^3.0.2",
+                "ircv3": "^0.26.4",
                 "tslib": "^2.0.0"
             }
         },
@@ -14497,9 +14654,9 @@
             },
             "dependencies": {
                 "acorn": {
-                    "version": "6.4.1",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
-                    "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
+                    "version": "6.4.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.2.tgz",
+                    "integrity": "sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ=="
                 },
                 "braces": {
                     "version": "2.3.2",
@@ -14778,11 +14935,6 @@
                     "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
                 }
             }
-        },
-        "whatwg-fetch": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz",
-            "integrity": "sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q=="
         },
         "whatwg-url": {
             "version": "7.1.0",

--- a/samples/ahk-sendcommand/extension/index.ts
+++ b/samples/ahk-sendcommand/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { AHKServiceClient } from "nodecg-io-ahk/extension";
+import { AHKServiceClient } from "nodecg-io-ahk";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/ahk-sendcommand/package.json
+++ b/samples/ahk-sendcommand/package.json
@@ -1,10 +1,11 @@
 {
     "name": "ahk-sendcommand",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-ahk": "0.1.0"
+            "nodecg-io-ahk": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-ahk": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-ahk": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/discord-guild-chat/extension/index.ts
+++ b/samples/discord-guild-chat/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { DiscordServiceClient } from "nodecg-io-discord/extension";
+import { DiscordServiceClient } from "nodecg-io-discord";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/discord-guild-chat/package.json
+++ b/samples/discord-guild-chat/package.json
@@ -2,7 +2,7 @@
     "name": "discord-guild-chat",
     "version": "0.1.0",
     "description": "Example nodecg-io Discord-Bundle. At the end of the day another Discord-bot",
-    "homepage": "",
+    "private": true,
     "author": {
         "name": "Tim-Tech-Dev",
         "url": "https://github.com/Tim-Tech-Dev"
@@ -10,7 +10,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-discord": "0.1.0"
+            "nodecg-io-discord": "^0.1.0"
         }
     },
     "scripts": {
@@ -20,8 +20,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-discord": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-discord": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/intellij-integration/extension/index.ts
+++ b/samples/intellij-integration/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { IntelliJServiceClient } from "nodecg-io-intellij/extension";
+import { IntelliJServiceClient } from "nodecg-io-intellij";
 import * as intellij from "nodecg-io-intellij/extension/intellij";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 

--- a/samples/intellij-integration/package.json
+++ b/samples/intellij-integration/package.json
@@ -1,10 +1,11 @@
 {
     "name": "intellij-integration",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-intellij": "0.1.0"
+            "nodecg-io-intellij": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-intellij": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-intellij": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/midi-input/extension/index.ts
+++ b/samples/midi-input/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
-import { MidiInputServiceClient } from "nodecg-io-midi-input/extension";
+import { MidiInputServiceClient } from "nodecg-io-midi-input";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for midi-input started");

--- a/samples/midi-input/package.json
+++ b/samples/midi-input/package.json
@@ -1,10 +1,11 @@
 {
     "name": "midi-input",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-midi-input": "0.1.0"
+            "nodecg-io-midi-input": "^0.1.0"
         }
     },
     "scripts": {
@@ -15,8 +16,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-midi-input": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-midi-input": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/midi-io/extension/index.ts
+++ b/samples/midi-io/extension/index.ts
@@ -1,7 +1,7 @@
 import { NodeCG } from "nodecg/types/server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
-import { MidiInputServiceClient } from "nodecg-io-midi-input/extension";
-import { MidiOutputServiceClient } from "nodecg-io-midi-output/extension";
+import { MidiInputServiceClient } from "nodecg-io-midi-input";
+import { MidiOutputServiceClient } from "nodecg-io-midi-output";
 import { Input, Output } from "easymidi";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/midi-io/package.json
+++ b/samples/midi-io/package.json
@@ -1,11 +1,12 @@
 {
     "name": "midi-io",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-midi-input": "0.1.0",
-            "nodecg-io-midi-output": "0.1.0"
+            "nodecg-io-midi-input": "^0.1.0",
+            "nodecg-io-midi-output": "^0.1.0"
         }
     },
     "scripts": {
@@ -16,9 +17,9 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-midi-input": "0.1.0",
-        "nodecg-io-midi-output": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-midi-input": "^0.1.0",
+        "nodecg-io-midi-output": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/midi-output/extension/index.ts
+++ b/samples/midi-output/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
-import { MidiOutputServiceClient } from "nodecg-io-midi-output/extension";
+import { MidiOutputServiceClient } from "nodecg-io-midi-output";
 import { Note, Channel } from "easymidi";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/midi-output/package.json
+++ b/samples/midi-output/package.json
@@ -1,10 +1,11 @@
 {
     "name": "midi-output",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-midi-output": "0.1.0"
+            "nodecg-io-midi-output": "^0.1.0"
         }
     },
     "scripts": {
@@ -15,8 +16,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-midi-output": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-midi-output": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/obs-scenelist/extension/index.ts
+++ b/samples/obs-scenelist/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
-import { OBSServiceClient } from "nodecg-io-obs/extension";
+import { OBSServiceClient } from "nodecg-io-obs";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for OBS started");

--- a/samples/obs-scenelist/package.json
+++ b/samples/obs-scenelist/package.json
@@ -1,10 +1,11 @@
 {
     "name": "obs-scenelist",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-obs": "0.1.0"
+            "nodecg-io-obs": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-obs": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-obs": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/philipshue-lights/extension/index.ts
+++ b/samples/philipshue-lights/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { PhilipsHueServiceClient } from "nodecg-io-philipshue/extension";
+import { PhilipsHueServiceClient } from "nodecg-io-philipshue";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG): void {

--- a/samples/philipshue-lights/package.json
+++ b/samples/philipshue-lights/package.json
@@ -1,10 +1,11 @@
 {
     "name": "philipshue-lights",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-philipshue": "0.1.0"
+            "nodecg-io-philipshue": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-philipshue": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-philipshue": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/rcon-minecraft/extension/index.ts
+++ b/samples/rcon-minecraft/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
-import { RconServiceClient } from "nodecg-io-rcon/extension";
+import { RconServiceClient } from "nodecg-io-rcon";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for sACN started");

--- a/samples/rcon-minecraft/package.json
+++ b/samples/rcon-minecraft/package.json
@@ -2,7 +2,7 @@
     "name": "rcon-minecraft",
     "version": "0.1.0",
     "description": "Example nodecg-io-rcon Bundle. Sends simple commands to a server",
-    "homepage": "",
+    "private": true,
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"
@@ -10,7 +10,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-rcon": "0.1.0"
+            "nodecg-io-rcon": "^0.1.0"
         }
     },
     "scripts": {
@@ -20,8 +20,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-rcon": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-rcon": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/reddit-msg-read/extension/index.ts
+++ b/samples/reddit-msg-read/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { RedditServiceClient } from "nodecg-io-reddit/extension";
+import { RedditServiceClient } from "nodecg-io-reddit";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/reddit-msg-read/package.json
+++ b/samples/reddit-msg-read/package.json
@@ -2,7 +2,7 @@
     "name": "reddit-msg-read",
     "version": "0.1.0",
     "description": "Example nodecg-io Reddit-Bundle that monitors messages from reddit.",
-    "homepage": "",
+    "private": true,
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"
@@ -10,7 +10,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-reddit": "0.1.0"
+            "nodecg-io-reddit": "^0.1.0"
         }
     },
     "scripts": {
@@ -20,8 +20,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-reddit": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-reddit": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/sacn-receiver-sample/extension/index.ts
+++ b/samples/sacn-receiver-sample/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { SacnReceiverServiceClient } from "nodecg-io-sacn-receiver/extension";
+import { SacnReceiverServiceClient } from "nodecg-io-sacn-receiver";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/sacn-receiver-sample/package.json
+++ b/samples/sacn-receiver-sample/package.json
@@ -2,7 +2,7 @@
     "name": "sacn-receiver-sample",
     "version": "0.1.0",
     "description": "Example nodecg-io-sacn-receiver Bundle. Receives data via sACN",
-    "homepage": "",
+    "private": true,
     "author": {
         "name": "Tim-Tech-Dev",
         "url": "https://github.com/Tim-Tech-Dev"
@@ -10,7 +10,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-sacn-receiver": "0.1.0"
+            "nodecg-io-sacn-receiver": "^0.1.0"
         }
     },
     "scripts": {
@@ -20,8 +20,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-sacn-receiver": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-sacn-receiver": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/sacn-sender/extension/index.ts
+++ b/samples/sacn-sender/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
-import { SacnSenderServiceClient } from "nodecg-io-sacn-sender/extension";
+import { SacnSenderServiceClient } from "nodecg-io-sacn-sender";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for sacn-sender started");

--- a/samples/sacn-sender/package.json
+++ b/samples/sacn-sender/package.json
@@ -1,10 +1,11 @@
 {
     "name": "sacn-sender",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-sacn-sender": "0.1.0"
+            "nodecg-io-sacn-sender": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-sacn-sender": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-sacn-sender": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/serial/extension/index.ts
+++ b/samples/serial/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
-import { SerialServiceClient } from "nodecg-io-serial/extension/SerialClient";
+import { SerialServiceClient } from "nodecg-io-serial";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for serial started");

--- a/samples/serial/package.json
+++ b/samples/serial/package.json
@@ -5,7 +5,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-serial": "0.1.0"
+            "nodecg-io-serial": "^0.1.0"
         }
     },
     "scripts": {
@@ -15,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-serial": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-serial": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/slack-post/extension/index.ts
+++ b/samples/slack-post/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { SlackServiceClient } from "nodecg-io-slack/extension";
+import { SlackServiceClient } from "nodecg-io-slack";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/slack-post/package.json
+++ b/samples/slack-post/package.json
@@ -1,10 +1,11 @@
 {
     "name": "slack-post",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-slack": "0.1.0"
+            "nodecg-io-slack": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-slack": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-slack": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/streamdeck-rainbow/extension/index.ts
+++ b/samples/streamdeck-rainbow/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { StreamdeckServiceClient } from "nodecg-io-streamdeck/extension";
+import { StreamdeckServiceClient } from "nodecg-io-streamdeck";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/streamdeck-rainbow/package.json
+++ b/samples/streamdeck-rainbow/package.json
@@ -1,10 +1,11 @@
 {
     "name": "streamdeck-rainbow",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-streamdeck": "0.1.0"
+            "nodecg-io-streamdeck": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-streamdeck": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-streamdeck": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/streamelements-events/extension/index.ts
+++ b/samples/streamelements-events/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { StreamElementsServiceClient } from "nodecg-io-streamelements/extension";
+import { StreamElementsServiceClient } from "nodecg-io-streamelements";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/streamelements-events/package.json
+++ b/samples/streamelements-events/package.json
@@ -1,10 +1,11 @@
 {
     "name": "streamelements-events",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-streamelements": "0.2.2"
+            "nodecg-io-streamelements": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-streamelements": "0.2.2",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-streamelements": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/telegram-bot/extension/index.ts
+++ b/samples/telegram-bot/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { TelegramServiceClient } from "nodecg-io-telegram/extension";
+import { TelegramServiceClient } from "nodecg-io-telegram";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/telegram-bot/package.json
+++ b/samples/telegram-bot/package.json
@@ -1,10 +1,11 @@
 {
     "name": "telegram-bot",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-telegram": "0.1.0"
+            "nodecg-io-telegram": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-telegram": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-telegram": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/tiane-discord/extension/index.ts
+++ b/samples/tiane-discord/extension/index.ts
@@ -1,7 +1,7 @@
 import { NodeCG } from "nodecg/types/server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
-import { DiscordServiceClient } from "nodecg-io-discord/extension";
-import { TianeServiceClient } from "nodecg-io-tiane/extension";
+import { DiscordServiceClient } from "nodecg-io-discord";
+import { TianeServiceClient } from "nodecg-io-tiane";
 import { TextChannel, User } from "discord.js";
 
 /*

--- a/samples/tiane-discord/package.json
+++ b/samples/tiane-discord/package.json
@@ -1,11 +1,12 @@
 {
     "name": "tiane-discord",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-discord": "0.1.0",
-            "nodecg-io-tiane": "0.1.0"
+            "nodecg-io-discord": "^0.1.0",
+            "nodecg-io-tiane": "^0.1.0"
         }
     },
     "scripts": {
@@ -15,9 +16,9 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-tiane": "0.1.0",
-        "nodecg-io-discord": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-tiane": "^0.1.0",
+        "nodecg-io-discord": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/twitch-chat/extension/index.ts
+++ b/samples/twitch-chat/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { TwitchServiceClient } from "nodecg-io-twitch/extension";
+import { TwitchServiceClient } from "nodecg-io-twitch";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/twitch-chat/package.json
+++ b/samples/twitch-chat/package.json
@@ -1,10 +1,11 @@
 {
     "name": "twitch-chat",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-twitch": "0.1.0"
+            "nodecg-io-twitch": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-twitch": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-twitch": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/twitter-timeline/extension/index.ts
+++ b/samples/twitter-timeline/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { TwitterServiceClient } from "nodecg-io-twitter/extension";
+import { TwitterServiceClient } from "nodecg-io-twitter";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/twitter-timeline/package.json
+++ b/samples/twitter-timeline/package.json
@@ -1,10 +1,11 @@
 {
     "name": "twitter-timeline",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-twitter": "0.1.0"
+            "nodecg-io-twitter": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-twitter": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-twitter": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/websocket-client/extension/index.ts
+++ b/samples/websocket-client/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
-import { WSClientServiceClient } from "nodecg-io-websocket-client/extension";
+import { WSClientServiceClient } from "nodecg-io-websocket-client";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for websocket-client started");

--- a/samples/websocket-client/package.json
+++ b/samples/websocket-client/package.json
@@ -1,10 +1,11 @@
 {
     "name": "websocket-client",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-websocket-client": "0.2.0"
+            "nodecg-io-websocket-client": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-websocket-client": "0.2.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-websocket-client": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/websocket-server/extension/index.ts
+++ b/samples/websocket-server/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { WSServerServiceClient } from "nodecg-io-websocket-server/extension";
+import { WSServerServiceClient } from "nodecg-io-websocket-server";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/websocket-server/package.json
+++ b/samples/websocket-server/package.json
@@ -1,10 +1,11 @@
 {
     "name": "websocket-server",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-websocket-server": "0.1.0"
+            "nodecg-io-websocket-server": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-websocket-server": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-websocket-server": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/xdotool-windowminimize/extension/index.ts
+++ b/samples/xdotool-windowminimize/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { XdotoolServiceClient } from "nodecg-io-xdotool/extension";
+import { XdotoolServiceClient } from "nodecg-io-xdotool";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/xdotool-windowminimize/package.json
+++ b/samples/xdotool-windowminimize/package.json
@@ -1,10 +1,11 @@
 {
     "name": "xdotool-windowminimize",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-xdotool": "0.1.0"
+            "nodecg-io-xdotool": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,8 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "nodecg-io-xdotool": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-xdotool": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"

--- a/samples/youtube-playlist/extension/index.ts
+++ b/samples/youtube-playlist/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { YoutubeServiceClient } from "nodecg-io-youtube/extension";
+import { YoutubeServiceClient } from "nodecg-io-youtube";
 import { youtube_v3 } from "googleapis";
 import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
 

--- a/samples/youtube-playlist/package.json
+++ b/samples/youtube-playlist/package.json
@@ -1,10 +1,11 @@
 {
     "name": "youtube-playlist",
     "version": "0.1.0",
+    "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-youtube": "0.1.0"
+            "nodecg-io-youtube": "^0.1.0"
         }
     },
     "scripts": {
@@ -14,9 +15,8 @@
     },
     "license": "MIT",
     "dependencies": {
-        "googleapis": "^59.0.0",
-        "nodecg-io-youtube": "0.1.0",
-        "nodecg-io-core": "0.1.0",
+        "nodecg-io-youtube": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
         "@types/node": "^14.6.4",
         "nodecg": "^1.6.1",
         "typescript": "^4.0.2"


### PR DESCRIPTION
Services:
- Set homepage to https://nodecg.io
- Set main so services can be used by using `nodecg-io-service` instead of `nodecg-io-service/extension`
- Add `nodecg-io` keyword
- Use semver breaking range for nodecg-io versions
- Align all versions to `0.1.0` (I want to adopt similar versioning as in ChatOverflow)

Samples:
- set private to `true` because they won't be published to npm
- use semver ranges for nodecg-io versions