### PR TITLE
Add sample for spotify

### DIFF
--- a/samples/spotify-current-song/extension/index.ts
+++ b/samples/spotify-current-song/extension/index.ts
@@ -1,0 +1,19 @@
+import { NodeCG } from "nodecg/types/server";
+import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { SpotifyServiceClient } from "nodecg-io-spotify";
+
+module.exports = function (nodecg: NodeCG) {
+    nodecg.log.info("Sample bundle for spotify started");
+
+    const service = requireService<SpotifyServiceClient>(nodecg, "spotify");
+    service?.onAvailable(async (client) => {
+        nodecg.log.info("Client has been updated.");
+
+        const track = await client.getNativeClient().getMyCurrentPlayingTrack();
+        const name = track.body.item?.name;
+        const artists = track.body.item?.artists.map((a) => a.name);
+        nodecg.log.info(`Currently playing "${name}" by "${artists}".`);
+    });
+
+    service?.onUnavailable(() => nodecg.log.info("Client has been unset."));
+};

--- a/samples/spotify-current-song/package.json
+++ b/samples/spotify-current-song/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "spotify-current-song",
+    "private": true,
+    "version": "0.1.0",
+    "nodecg": {
+        "compatibleRange": "^1.1.1",
+        "bundleDependencies": {
+            "nodecg-io-spotify": "^0.1.0"
+        }
+    },
+    "scripts": {
+        "build": "tsc -b",
+        "watch": "tsc -b -w",
+        "clean": "tsc -b --clean"
+    },
+    "license": "MIT",
+    "dependencies": {
+        "nodecg-io-spotify": "^0.1.0",
+        "nodecg-io-core": "^0.1.0",
+        "@types/node": "^14.14.13",
+        "nodecg": "^1.7.4",
+        "typescript": "^4.1.3"
+    }
+}

--- a/samples/spotify-current-song/tsconfig.json
+++ b/samples/spotify-current-song/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.common.json"
+}


### PR DESCRIPTION
Adds missing sample for the spotify service as noted in #111.
Displays the currently playing song in the console.
Sample doc PR: https://github.com/codeoverflow-org/nodecg-io-docs/pull/39