### PR TITLE
Move exposed type deps from devDependencies to dependencies

### DIFF
--- a/nodecg-io-irc/package.json
+++ b/nodecg-io-irc/package.json
@@ -30,12 +30,12 @@
     },
     "license": "MIT",
     "devDependencies": {
-        "@types/irc": "^0.3.33",
         "@types/node": "^14.14.13",
         "nodecg": "^1.7.4",
         "typescript": "^4.1.3"
     },
     "dependencies": {
+        "@types/irc": "^0.3.33",
         "irc": "^0.5.2",
         "nodecg-io-core": "^0.1.0"
     }

--- a/nodecg-io-serial/package.json
+++ b/nodecg-io-serial/package.json
@@ -32,11 +32,11 @@
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^14.14.13",
-        "@types/serialport": "^8.0.1",
         "nodecg": "^1.7.4",
         "typescript": "^4.1.3"
     },
     "dependencies": {
+        "@types/serialport": "^8.0.1",
         "@serialport/parser-readline": "^9.0.1",
         "nodecg-io-core": "^0.1.0",
         "serialport": "^9.0.3"

--- a/nodecg-io-telegram/package.json
+++ b/nodecg-io-telegram/package.json
@@ -31,12 +31,12 @@
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^14.14.13",
-        "@types/node-telegram-bot-api": "^0.50.4",
         "nodecg": "^1.7.4",
         "typescript": "^4.1.3"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.1.0",
-        "node-telegram-bot-api": "^0.50.0"
+        "@types/node-telegram-bot-api": "^0.50.4",
+        "node-telegram-bot-api": "^0.50.0",
+        "nodecg-io-core": "^0.1.0"
     }
 }


### PR DESCRIPTION
Moves irc, serial and telegram type dependencies that are exposed from `devDependencies` to `dependencies` so that they can be imported properly once these packages are published.