### PR TITLE
Disallow empty instance names and show instance creation errors

### DIFF
--- a/nodecg-io-core/dashboard/authentication.ts
+++ b/nodecg-io-core/dashboard/authentication.ts
@@ -12,7 +12,7 @@ const spanPasswordNotice = document.getElementById("spanPasswordNotice") as HTML
 
 // Add key listener to password input
 inputPassword?.addEventListener("keyup", function (event) {
-    if (event.keyCode === 13) {
+    if (event.keyCode === 13 || event.key === "Enter") {
         event.preventDefault();
         loadFramework();
     }

--- a/nodecg-io-core/dashboard/serviceInstance.ts
+++ b/nodecg-io-core/dashboard/serviceInstance.ts
@@ -146,6 +146,7 @@ export async function deleteInstance(): Promise<void> {
 
 // Create button
 export async function createInstance(): Promise<void> {
+    showError(undefined);
     const service = selectService.options[selectService.options.selectedIndex].value;
     const name = inputInstanceName.value;
 
@@ -154,7 +155,13 @@ export async function createInstance(): Promise<void> {
         instanceName: name,
     };
 
-    await sendAuthenticatedMessage("createServiceInstance", msg);
+    try {
+        await sendAuthenticatedMessage("createServiceInstance", msg);
+    } catch (e) {
+        showError(e);
+        return;
+    }
+
     // Give the browser some time to create the new instance select option and to add them to the DOM
     setTimeout(() => {
         selectServiceInstance(name);

--- a/nodecg-io-core/extension/instanceManager.ts
+++ b/nodecg-io-core/extension/instanceManager.ts
@@ -45,6 +45,10 @@ export class InstanceManager extends EventEmitter {
      * @return void if everything went fine and a string describing the issue if not
      */
     createServiceInstance(serviceType: string, instanceName: string): Result<void> {
+        if (!instanceName) {
+            return error("Instance name must not be empty.");
+        }
+
         // Check if a instance with the same name already exists.
         if (this.serviceInstances[instanceName] !== undefined) {
             return error("A service instance with the same name already exists.");


### PR DESCRIPTION
A instance should propably not be named with an empty string.