### PR TITLE
Clear timeouts/intervals in sample bundles

### DIFF
--- a/samples/serial/extension/index.ts
+++ b/samples/serial/extension/index.ts
@@ -6,16 +6,23 @@ module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for serial started");
 
     const service = requireService<SerialServiceClient>(nodecg, "serial");
+    let interval: NodeJS.Timeout | undefined;
+
     service?.onAvailable((client) => {
         nodecg.log.info("Client has been updated.");
         client.onData((data: string) => {
             nodecg.log.info(data);
         });
 
-        setInterval(() => {
+        interval = setInterval(() => {
             client.send("ping\n");
         }, 10000);
     });
 
-    service?.onUnavailable(() => nodecg.log.info("Client has been unset."));
+    service?.onUnavailable(() => {
+        nodecg.log.info("Client has been unset.");
+        if (interval) {
+            clearInterval(interval);
+        }
+    });
 };

--- a/samples/streamdeck-rainbow/extension/index.ts
+++ b/samples/streamdeck-rainbow/extension/index.ts
@@ -6,6 +6,7 @@ module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for streamdeck started");
 
     const streamdeck = requireService<StreamdeckServiceClient>(nodecg, "streamdeck");
+    let timeout: NodeJS.Timeout | undefined;
 
     streamdeck?.onAvailable((client) => {
         nodecg.log.info("Streamdeck client has been updated, painting the streamdeck.");
@@ -30,7 +31,7 @@ module.exports = function (nodecg: NodeCG) {
             ];
             let i = 0;
 
-            setInterval(() => {
+            timeout = setInterval(() => {
                 try {
                     deck.fillColor(
                         i % deck.NUM_KEYS,
@@ -48,5 +49,10 @@ module.exports = function (nodecg: NodeCG) {
         }
     });
 
-    streamdeck?.onUnavailable(() => nodecg.log.info("Streamdeck client has been unset."));
+    streamdeck?.onUnavailable(() => {
+        nodecg.log.info("Streamdeck client has been unset.");
+        if (timeout) {
+            clearTimeout(timeout);
+        }
+    });
 };

--- a/samples/websocket-client/extension/index.ts
+++ b/samples/websocket-client/extension/index.ts
@@ -6,17 +6,24 @@ module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for websocket-client started");
 
     const service = requireService<WSClientServiceClient>(nodecg, "websocket-client");
+    let interval: NodeJS.Timeout | undefined;
+
     service?.onAvailable((client) => {
         nodecg.log.info("Client has been updated.");
 
         client.onMessage((message) => {
             nodecg.log.info(`recieved message "${message}"`);
         });
-        setInterval(() => {
+        interval = setInterval(() => {
             nodecg.log.info("Sending ping ...");
             client.send("ping");
         }, 10000);
     });
 
-    service?.onUnavailable(() => nodecg.log.info("Client has been unset."));
+    service?.onUnavailable(() => {
+        nodecg.log.info("Client has been unset.");
+        if (interval) {
+            clearInterval(interval);
+        }
+    });
 };


### PR DESCRIPTION
If the streamdeck was once available a timeout gets registered but never cleared.
This makes problems e.g. when the instance gets deleted: https://discord.com/channels/577412066994946060/577495348898168832/793590990475755550