### PR TITLE
Add password notice in dashbord on first startup

### DIFF
--- a/nodecg-io-core/dashboard/authentication.ts
+++ b/nodecg-io-core/dashboard/authentication.ts
@@ -9,6 +9,7 @@ const inputPassword = document.getElementById("inputPassword") as HTMLInputEleme
 const divAuth = document.getElementById("divAuth");
 const divMain = document.getElementById("divMain");
 const spanPasswordNotice = document.getElementById("spanPasswordNotice") as HTMLSpanElement;
+const pFirstStartup = document.getElementById("pFirstStartup");
 
 // Add key listener to password input
 inputPassword?.addEventListener("keyup", function (event) {
@@ -25,12 +26,14 @@ nodecg.socket.on("connect", () => {
         loadFramework();
     } else {
         updateLoadedStatus();
+        updateFirstStartupLabel();
     }
 });
 
 document.addEventListener("DOMContentLoaded", () => {
     // Render loaded status for initial load
     updateLoadedStatus();
+    updateFirstStartupLabel();
 });
 
 export async function isLoaded(): Promise<boolean> {
@@ -70,4 +73,13 @@ export async function loadFramework(): Promise<void> {
     }
 
     updateLoadedStatus();
+}
+
+async function updateFirstStartupLabel(): Promise<void> {
+    const isFirstStartup: boolean = await nodecg.sendMessage("isFirstStartup");
+    if (isFirstStartup) {
+        pFirstStartup?.classList.add("hidden");
+    } else {
+        pFirstStartup?.classList.remove("hidden");
+    }
 }

--- a/nodecg-io-core/dashboard/panel.html
+++ b/nodecg-io-core/dashboard/panel.html
@@ -10,6 +10,10 @@
         <p>Current status: <span id="spanLoaded">Unknown</span></p>
 
         <div id="divAuth">
+            <p id="pFirstStartup" class="hidden">
+                This seems to be your first startup of nodecg-io. Please choose a password which will be used to encrypt
+                all your credentials.
+            </p>
             <p>Login:</p>
             <div class="margins">
                 <label for="inputPassword">Password: </label>

--- a/nodecg-io-core/extension/messageManager.ts
+++ b/nodecg-io-core/extension/messageManager.ts
@@ -141,6 +141,12 @@ export class MessageManager {
                 ack?.(undefined, result);
             }
         });
+
+        this.nodecg.listenFor("isFirstStartup", (_msg: undefined, ack) => {
+            if (!ack?.handled) {
+                ack?.(undefined, this.persist.isFirstStartup());
+            }
+        });
     }
 
     authRequired<M extends PasswordMessage, V>(handler: ListenForCallback<M, V>): ListenForCallback<M, V> {

--- a/nodecg-io-core/extension/persistenceManager.ts
+++ b/nodecg-io-core/extension/persistenceManager.ts
@@ -87,6 +87,14 @@ export class PersistenceManager {
     }
 
     /**
+     * Returns whether this is the first startup aka. whether any encrypted data has been saved.
+     * If this returns true {{@link load}} will accept any password and use it to encrypt the configuration.
+     */
+    isFirstStartup(): boolean {
+        return this.encryptedData.value.cipherText !== undefined;
+    }
+
+    /**
      * Decrypts and loads the locally stored configuration using the passed password.
      * @param password the password of the encrypted config.
      * @return success if the password was correct and loading has been successful and an error if the password is wrong.


### PR DESCRIPTION
Adds a notice to the dasboard that explains that the password is freely choosable on first startup.
It is not clear that it is setting the password there so this should clarify things.
![Screenshot from 2021-01-01 12-17-06](https://user-images.githubusercontent.com/30466471/103438452-87c7e680-4c33-11eb-8dc8-e54d9a06ceea.png)
