### PR TITLE
Display createClient errors on the dashboard

### DIFF
--- a/nodecg-io-core/dashboard/serviceInstance.ts
+++ b/nodecg-io-core/dashboard/serviceInstance.ts
@@ -211,8 +211,11 @@ function selectServiceInstance(instanceName: string) {
     for (let i = 0; i < selectInstance.options.length; i++) {
         const opt = selectInstance.options[i];
         if (opt?.value === instanceName) {
-            selectInstance.selectedIndex = i;
-            onInstanceSelectChange(instanceName);
+            // If already selected a re-render monaco is not needed
+            if (selectInstance.selectedIndex !== i) {
+                selectInstance.selectedIndex = i;
+                onInstanceSelectChange(instanceName);
+            }
             break;
         }
     }


### PR DESCRIPTION
Previously errors by the `createClient` methods were just logged to the console but not displayed in the dashboard like the config validation errors.