### PR TITLE
Move typescript to devDependencies in core and dashboard

### DIFF
--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -9,6 +9,7 @@
     "devDependencies": {
         "clean-webpack-plugin": "^3.0.0",
         "ts-loader": "^8.0.12",
+        "typescript": "^4.1.3",
         "webpack": "^5.10.1",
         "webpack-cli": "^4.2.0"
     },
@@ -16,8 +17,7 @@
         "crypto-js": "^4.0.0",
         "monaco-editor": "^0.21.2",
         "nodecg": "^1.7.4",
-        "nodecg-io-core": "^0.1.0",
-        "typescript": "^4.1.3"
+        "nodecg-io-core": "^0.1.0"
     },
     "license": "MIT"
 }

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -43,7 +43,6 @@
     },
     "dependencies": {
         "ajv": "^6.12.6",
-        "crypto-js": "^4.0.0",
-        "tslib": "^2.0.3"
+        "crypto-js": "^4.0.0"
     }
 }

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -38,12 +38,12 @@
     "devDependencies": {
         "@types/crypto-js": "^4.0.1",
         "@types/node": "^14.14.13",
-        "nodecg": "^1.7.4"
+        "nodecg": "^1.7.4",
+        "typescript": "^4.1.3"
     },
     "dependencies": {
         "ajv": "^6.12.6",
         "crypto-js": "^4.0.0",
-        "tslib": "^2.0.3",
-        "typescript": "^4.1.3"
+        "tslib": "^2.0.3"
     }
 }


### PR DESCRIPTION
`typescript` is only needed to execute the compiler but not for execution. It is also not needed for imports. Therefore it should be a dev dependency like it is in all other packages instead of the core and the dashboard for whatever reason.