### PR TITLE
Simplify importing of core

### DIFF
--- a/nodecg-io-ahk/extension/index.ts
+++ b/nodecg-io-ahk/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { AHK } from "./AHK";
 
 interface AHKServiceConfig {

--- a/nodecg-io-core/index.ts
+++ b/nodecg-io-core/index.ts
@@ -1,0 +1,8 @@
+// Re-exports all important stuff from nodecg-io-core.
+// This can be used by services and bundles to import everything by just using "nodecg-io-core" and they don't need to know paths
+// or where the thing they want to import is located.
+// You can obviously still provide the full path if you wish.
+export * from "./extension/types";
+export * from "./extension/utils/result";
+export { ServiceBundle } from "./extension/serviceBundle";
+export { requireService } from "./extension/serviceClientWrapper";

--- a/nodecg-io-core/index.ts
+++ b/nodecg-io-core/index.ts
@@ -2,7 +2,7 @@
 // This can be used by services and bundles to import everything by just using "nodecg-io-core" and they don't need to know paths
 // or where the thing they want to import is located.
 // You can obviously still provide the full path if you wish.
-export * from "./extension/types";
+export type { ObjectMap, Service, ServiceClient, ServiceDependency, ServiceInstance } from "./extension/types";
 export * from "./extension/utils/result";
 export { ServiceBundle } from "./extension/serviceBundle";
 export { requireService } from "./extension/serviceClientWrapper";

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -12,7 +12,6 @@
         "url": "https://github.com/codeoverflow-org/nodecg-io.git",
         "directory": "nodecg-io-core"
     },
-    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",

--- a/nodecg-io-discord/extension/index.ts
+++ b/nodecg-io-discord/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { Client as DiscordClient } from "discord.js";
 
 interface DiscordServiceConfig {

--- a/nodecg-io-intellij/extension/index.ts
+++ b/nodecg-io-intellij/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { IntelliJ } from "./intellij";
 
 interface IntelliJServiceConfig {

--- a/nodecg-io-irc/extension/index.ts
+++ b/nodecg-io-irc/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { Client as IRCClient } from "irc";
 
 interface IRCServiceConfig {

--- a/nodecg-io-midi-input/extension/index.ts
+++ b/nodecg-io-midi-input/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, Result, success, error } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import * as easymidi from "easymidi";
 
 interface MidiInputServiceConfig {

--- a/nodecg-io-midi-output/extension/index.ts
+++ b/nodecg-io-midi-output/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, Result, success, error } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import * as easymidi from "easymidi";
 
 interface MidiOutputServiceConfig {

--- a/nodecg-io-obs/extension/index.ts
+++ b/nodecg-io-obs/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import * as OBSWebSocket from "obs-websocket-js";
 
 interface OBSServiceConfig {

--- a/nodecg-io-philipshue/extension/index.ts
+++ b/nodecg-io-philipshue/extension/index.ts
@@ -1,9 +1,8 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { v4 as ipv4 } from "is-ip";
 import { v3 } from "node-hue-api";
+// Only needed for type because of that it is "unused" but still needed
 // eslint-disable-next-line @typescript-eslint/no-unused-vars-experimental
 import HueApi = require("node-hue-api/lib/api/Api");
 const { api, discovery } = v3;

--- a/nodecg-io-rcon/extension/index.ts
+++ b/nodecg-io-rcon/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { Rcon } from "rcon-client";
 
 interface RconServiceConfig {

--- a/nodecg-io-reddit/extension/index.ts
+++ b/nodecg-io-reddit/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, success, Result } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import RedditAPI from "reddit-ts";
 
 interface RedditServiceConfig {

--- a/nodecg-io-sacn-receiver/extension/index.ts
+++ b/nodecg-io-sacn-receiver/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle } from "nodecg-io-core";
 import { SacnReceiverServiceClient } from "./sacnReceiverClient";
 import { Receiver } from "sacn";
 

--- a/nodecg-io-sacn-receiver/extension/sacnReceiverClient.ts
+++ b/nodecg-io-sacn-receiver/extension/sacnReceiverClient.ts
@@ -1,4 +1,4 @@
-import { ServiceClient } from "nodecg-io-core/extension/types";
+import { ServiceClient } from "nodecg-io-core";
 import { Packet, Receiver } from "sacn";
 import { AssertionError } from "assert";
 

--- a/nodecg-io-sacn-sender/extension/index.ts
+++ b/nodecg-io-sacn-sender/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle } from "nodecg-io-core";
 import { Sender } from "sacn";
 import { SacnSenderServiceClient } from "./sacnSenderClient";
 

--- a/nodecg-io-sacn-sender/extension/sacnSenderClient.ts
+++ b/nodecg-io-sacn-sender/extension/sacnSenderClient.ts
@@ -1,4 +1,4 @@
-import { ServiceClient } from "nodecg-io-core/extension/types";
+import { ServiceClient } from "nodecg-io-core";
 import { Packet, Sender } from "sacn";
 
 export class SacnSenderServiceClient implements ServiceClient<Sender> {

--- a/nodecg-io-serial/extension/SerialClient.ts
+++ b/nodecg-io-serial/extension/SerialClient.ts
@@ -1,5 +1,5 @@
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { success, error, Result, emptySuccess } from "nodecg-io-core/extension/utils/result";
+import { ServiceClient } from "nodecg-io-core";
+import { success, error, Result, emptySuccess } from "nodecg-io-core";
 import * as SerialPort from "serialport"; // This is neccesary, because serialport only likes require!
 
 export interface DeviceInfo {

--- a/nodecg-io-serial/extension/index.ts
+++ b/nodecg-io-serial/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, success, Result, error } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle } from "nodecg-io-core";
 import { SerialServiceClient, SerialServiceConfig } from "./SerialClient";
 
 module.exports = (nodecg: NodeCG) => {

--- a/nodecg-io-slack/extension/index.ts
+++ b/nodecg-io-slack/extension/index.ts
@@ -1,8 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { WebClient } from "@slack/web-api";
-import { ServiceClient } from "nodecg-io-core/extension/types";
 
 interface SlackServiceConfig {
     token: string;

--- a/nodecg-io-spotify/extension/index.ts
+++ b/nodecg-io-spotify/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import * as express from "express";
 import { Router } from "express";
 import SpotifyWebApi = require("spotify-web-api-node");

--- a/nodecg-io-streamdeck/extension/index.ts
+++ b/nodecg-io-streamdeck/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import * as streamdeck from "elgato-stream-deck";
 import { StreamDeck } from "elgato-stream-deck";
 

--- a/nodecg-io-streamelements/extension/StreamElements.ts
+++ b/nodecg-io-streamelements/extension/StreamElements.ts
@@ -1,8 +1,7 @@
 import io = require("socket.io-client");
-import { emptySuccess, error, Result } from "nodecg-io-core/extension/utils/result";
+import { Result, emptySuccess, error, ServiceClient } from "nodecg-io-core";
 import { StreamElementsEvent } from "./types";
 import { EventEmitter } from "events";
-import { ServiceClient } from "nodecg-io-core/extension/types";
 
 export class StreamElementsServiceClient extends EventEmitter implements ServiceClient<SocketIOClient.Socket> {
     private socket: SocketIOClient.Socket;

--- a/nodecg-io-streamelements/extension/index.ts
+++ b/nodecg-io-streamelements/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { success, ServiceBundle } from "nodecg-io-core";
 import { StreamElementsServiceClient } from "./StreamElements";
 
 interface StreamElementsServiceConfig {

--- a/nodecg-io-telegram/extension/index.ts
+++ b/nodecg-io-telegram/extension/index.ts
@@ -1,8 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import TelegramBot = require("node-telegram-bot-api");
-import { ServiceClient } from "nodecg-io-core/extension/types";
 
 interface TelegramServiceConfig {
     token: string;

--- a/nodecg-io-tiane/extension/index.ts
+++ b/nodecg-io-tiane/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { Tiane, connectTiane } from "./tiane";
 
 interface TianeServiceConfig {

--- a/nodecg-io-twitch-chat/extension/index.ts
+++ b/nodecg-io-twitch-chat/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle } from "nodecg-io-core";
 import { TwitchServiceClient } from "./twitchClient";
 
 export interface TwitchServiceConfig {

--- a/nodecg-io-twitch-chat/extension/twitchClient.ts
+++ b/nodecg-io-twitch-chat/extension/twitchClient.ts
@@ -1,4 +1,4 @@
-import { ServiceClient } from "nodecg-io-core/extension/types";
+import { ServiceClient } from "nodecg-io-core";
 import { ChatClient } from "twitch-chat-client";
 import { getTokenInfo, StaticAuthProvider, TokenInfo } from "twitch-auth";
 import { TwitchServiceConfig } from "./index";

--- a/nodecg-io-twitch-pubsub/extension/index.ts
+++ b/nodecg-io-twitch-pubsub/extension/index.ts
@@ -1,6 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle } from "nodecg-io-core";
 import { PubSubServiceClient } from "./pubSubClient";
 
 export { PubSubServiceClient } from "./pubSubClient";

--- a/nodecg-io-twitch-pubsub/extension/pubSubClient.ts
+++ b/nodecg-io-twitch-pubsub/extension/pubSubClient.ts
@@ -1,4 +1,4 @@
-import { ServiceClient } from "nodecg-io-core/extension/types";
+import { ServiceClient } from "nodecg-io-core";
 import { getTokenInfo, StaticAuthProvider, TokenInfo } from "twitch-auth";
 import { PubSubServiceConfig } from "./index";
 import {

--- a/nodecg-io-twitter/extension/index.ts
+++ b/nodecg-io-twitter/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import Twitter = require("twitter");
 
 interface TwitterServiceConfig {

--- a/nodecg-io-websocket-client/extension/index.ts
+++ b/nodecg-io-websocket-client/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import * as WebSocket from "ws";
 
 interface WSClientServiceConfig {

--- a/nodecg-io-websocket-server/extension/index.ts
+++ b/nodecg-io-websocket-server/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import * as WebSocket from "ws";
 
 interface WSServerServiceConfig {

--- a/nodecg-io-xdotool/extension/index.ts
+++ b/nodecg-io-xdotool/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ServiceClient } from "nodecg-io-core/extension/types";
-import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { Xdotool } from "./xdotool";
 
 interface XdotoolServiceConfig {

--- a/nodecg-io-youtube/extension/index.ts
+++ b/nodecg-io-youtube/extension/index.ts
@@ -1,10 +1,8 @@
 import { NodeCG } from "nodecg/types/server";
-import { emptySuccess, error, Result, success } from "nodecg-io-core/extension/utils/result";
-import { ServiceBundle } from "nodecg-io-core/extension/serviceBundle";
+import { Result, emptySuccess, success, error, ServiceBundle, ServiceClient } from "nodecg-io-core";
 import { google, youtube_v3 } from "googleapis";
 import * as express from "express";
 import opn = require("open");
-import { ServiceClient } from "nodecg-io-core/extension/types";
 
 interface YoutubeServiceConfig {
     clientID: string;

--- a/samples/ahk-sendcommand/extension/index.ts
+++ b/samples/ahk-sendcommand/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { AHKServiceClient } from "nodecg-io-ahk";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for AHK started");

--- a/samples/discord-guild-chat/extension/index.ts
+++ b/samples/discord-guild-chat/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { DiscordServiceClient } from "nodecg-io-discord";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for discord started");

--- a/samples/intellij/extension/index.ts
+++ b/samples/intellij/extension/index.ts
@@ -1,7 +1,7 @@
 import { NodeCG } from "nodecg/types/server";
 import { IntelliJServiceClient } from "nodecg-io-intellij";
-import * as intellij from "nodecg-io-intellij/extension/intellij";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { Plugin } from "nodecg-io-intellij/extension/intellij";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for intellij started");
@@ -15,7 +15,7 @@ module.exports = function (nodecg: NodeCG) {
             .getNativeClient()
             .pluginManager.getPlugins(true)
             .then((plugins) => {
-                plugins.forEach((plugin: intellij.Plugin) => {
+                plugins.forEach((plugin: Plugin) => {
                     plugin
                         .getName()
                         .then((name) => {

--- a/samples/midi-input/extension/index.ts
+++ b/samples/midi-input/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { MidiInputServiceClient } from "nodecg-io-midi-input";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/midi-io/extension/index.ts
+++ b/samples/midi-io/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { MidiInputServiceClient } from "nodecg-io-midi-input";
 import { MidiOutputServiceClient } from "nodecg-io-midi-output";
 import { Input, Output } from "easymidi";

--- a/samples/midi-output/extension/index.ts
+++ b/samples/midi-output/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { MidiOutputServiceClient } from "nodecg-io-midi-output";
 import { Note, Channel } from "easymidi";
 

--- a/samples/obs-scenelist/extension/index.ts
+++ b/samples/obs-scenelist/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { OBSServiceClient } from "nodecg-io-obs";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/philipshue-lights/extension/index.ts
+++ b/samples/philipshue-lights/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { PhilipsHueServiceClient } from "nodecg-io-philipshue";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG): void {
     nodecg.log.info("Sample bundle for Philips Hue started");

--- a/samples/rcon-minecraft/extension/index.ts
+++ b/samples/rcon-minecraft/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { RconServiceClient } from "nodecg-io-rcon";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/reddit-msg-read/extension/index.ts
+++ b/samples/reddit-msg-read/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { RedditServiceClient } from "nodecg-io-reddit";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for discord started");

--- a/samples/sacn-receiver/extension/index.ts
+++ b/samples/sacn-receiver/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { SacnReceiverServiceClient } from "nodecg-io-sacn-receiver";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for sACN started");

--- a/samples/sacn-sender/extension/index.ts
+++ b/samples/sacn-sender/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { SacnSenderServiceClient } from "nodecg-io-sacn-sender";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/serial/extension/index.ts
+++ b/samples/serial/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { SerialServiceClient } from "nodecg-io-serial";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/slack-post/extension/index.ts
+++ b/samples/slack-post/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { SlackServiceClient } from "nodecg-io-slack";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for Slack WebAPI started");

--- a/samples/spotify-current-song/extension/index.ts
+++ b/samples/spotify-current-song/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { SpotifyServiceClient } from "nodecg-io-spotify";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/streamdeck-rainbow/extension/index.ts
+++ b/samples/streamdeck-rainbow/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { StreamdeckServiceClient } from "nodecg-io-streamdeck";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for streamdeck started");

--- a/samples/streamelements-events/extension/index.ts
+++ b/samples/streamelements-events/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { StreamElementsServiceClient } from "nodecg-io-streamelements";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for StreamElements started");

--- a/samples/telegram-bot/extension/index.ts
+++ b/samples/telegram-bot/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { TelegramServiceClient } from "nodecg-io-telegram";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for telegram started");

--- a/samples/tiane-discord/extension/index.ts
+++ b/samples/tiane-discord/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { DiscordServiceClient } from "nodecg-io-discord";
 import { TianeServiceClient } from "nodecg-io-tiane";
 import { TextChannel, User } from "discord.js";

--- a/samples/twitch-chat/extension/index.ts
+++ b/samples/twitch-chat/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { TwitchServiceClient } from "nodecg-io-twitch-chat";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for twitch started");

--- a/samples/twitch-pubsub/extension/index.ts
+++ b/samples/twitch-pubsub/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
-import { PubSubServiceClient } from "nodecg-io-twitch-pubsub/extension";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { PubSubServiceClient } from "nodecg-io-twitch-pubsub";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for twitch-pubsub started");

--- a/samples/twitter-timeline/extension/index.ts
+++ b/samples/twitter-timeline/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { TwitterServiceClient } from "nodecg-io-twitter";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for twitter started");

--- a/samples/websocket-client/extension/index.ts
+++ b/samples/websocket-client/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 import { WSClientServiceClient } from "nodecg-io-websocket-client";
 
 module.exports = function (nodecg: NodeCG) {

--- a/samples/websocket-server/extension/index.ts
+++ b/samples/websocket-server/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { WSServerServiceClient } from "nodecg-io-websocket-server";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for WebSocket Server started");

--- a/samples/xdotool-windowminimize/extension/index.ts
+++ b/samples/xdotool-windowminimize/extension/index.ts
@@ -1,6 +1,6 @@
 import { NodeCG } from "nodecg/types/server";
 import { XdotoolServiceClient } from "nodecg-io-xdotool";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for xdotool started");

--- a/samples/youtube-playlist/extension/index.ts
+++ b/samples/youtube-playlist/extension/index.ts
@@ -1,7 +1,7 @@
 import { NodeCG } from "nodecg/types/server";
 import { YoutubeServiceClient } from "nodecg-io-youtube";
 import { youtube_v3 } from "googleapis";
-import { requireService } from "nodecg-io-core/extension/serviceClientWrapper";
+import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for youtube started");


### PR DESCRIPTION
Adds a `index.ts` to core that re-exports everything important. That way services and bundles can import everything they need by just doing this:
```typescript
import { ... } from "nodecg-io-core";
```

Previously bundle/service developers would need to know in which file is which class and provide the full path.
Everything obviously still can be imported by using the full path but if anything is moved this doesn't need fixing of the paths and therefore is prefered.

This is a follow up on #131 which simplified importing of services.

Docs update PR: https://github.com/codeoverflow-org/nodecg-io-docs/pull/42