### PR TITLE
Remove ready handler from discord sample

### DIFF
--- a/samples/discord-guild-chat/extension/index.ts
+++ b/samples/discord-guild-chat/extension/index.ts
@@ -9,18 +9,14 @@ module.exports = function (nodecg: NodeCG) {
 
     discord?.onAvailable((client) => {
         nodecg.log.info("Discord client has been updated, adding handlers for messages.");
-        addListeners(nodecg, client);
+        addListeners(client);
     });
 
     discord?.onUnavailable(() => nodecg.log.info("Discord client has been unset."));
 };
 
-function addListeners(nodecg: NodeCG, client: DiscordServiceClient) {
+function addListeners(client: DiscordServiceClient) {
     const dc = client.getNativeClient();
-
-    dc.on("ready", () => {
-        nodecg.log.info(`Logged in!`);
-    });
 
     dc.on("message", (msg) => {
         if (msg.content === "ping" || msg.content === "!ping") {


### PR DESCRIPTION
The `ready` event [doesn't seem to fire consistently](https://discord.com/channels/577412066994946060/577495219399032864/798265088954990632) and therefore shoudn't be used.