### PR TITLE
Save spotify refresh token

### DIFF
--- a/nodecg-io-spotify/package.json
+++ b/nodecg-io-spotify/package.json
@@ -35,7 +35,7 @@
         "typescript": "^4.1.3"
     },
     "dependencies": {
-        "@types/spotify-web-api-node": "^4.0.2",
+        "@types/spotify-web-api-node": "^5.0.0",
         "express": "^4.17.1",
         "nodecg-io-core": "^0.1.0",
         "open": "^7.3.0",

--- a/nodecg-io-spotify/spotify-schema.json
+++ b/nodecg-io-spotify/spotify-schema.json
@@ -17,6 +17,10 @@
                 "type": "string"
             },
             "description": "A list of scopes. More information: https://developer.spotify.com/documentation/general/guides/scopes/"
+        },
+        "refreshToken": {
+            "type": "string",
+            "description": "A refresh token to get and refresh access tokens. Gets set by nodecg-io. You don't need to set this!"
         }
     },
     "required": ["clientId", "clientSecret", "scopes"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -3229,9 +3229,9 @@
             "integrity": "sha512-44WK9Mx0WOEsGg6xWlhOhgGROm0rIfDbrLOWTPBQMIx1amOxt559UnSEm95TH+IJUy0P/sr0QvrHivq44QDlgQ=="
         },
         "@types/spotify-web-api-node": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/spotify-web-api-node/-/spotify-web-api-node-4.0.2.tgz",
-            "integrity": "sha512-4Rivh7vIxiY7+vlhVk95AmLfnZPWqtFcCsVg95kpERDfN0MkkS2nDBY6oRfiXdvZ9UkvC+2hH8Z1JXUcAY/icQ==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/@types/spotify-web-api-node/-/spotify-web-api-node-5.0.0.tgz",
+            "integrity": "sha512-F2fDANMgtZAgocjebCg9z/mJAvz8JR0uzpsOJ9Yr9JRi0vzYuK6LBXanqvVf6B/zTJG5HPEXNyJRK3ZRZ/sYag==",
             "requires": {
                 "@types/spotify-api": "*"
             }


### PR DESCRIPTION
(VS Code GitHub extension messed up branch name LULW)

Saves the spotify refresh token so that it can be re-used to create a access token at startup. That way we only need to open a tab to login once (the first start) instead of every time.
This can also be used as a workarround to get spotify working on a headless server.

Also updates spotify typings to 5.0.0 (from https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50333).