### PR TITLE
Remove sending message from twitch-chat sample

### DIFF
--- a/samples/twitch-chat/extension/index.ts
+++ b/samples/twitch-chat/extension/index.ts
@@ -35,8 +35,6 @@ function addListeners(nodecg: NodeCG, client: TwitchServiceClient, channel: stri
                     nodecg.log.info(`Twitch chat: ${user}@${channel}: ${message}`);
                 }
             });
-
-            client.getNativeClient().say(channel, "Hello, nodecg-io speaking here!");
         })
         .catch((reason) => {
             nodecg.log.error(`Couldn't connect to twitch: ${reason}.`);


### PR DESCRIPTION
It created spam in streams and also everybody who didn't want to spam the twitch chat commented it out anyway.