### PR TITLE
Don't publish dashboard with core

### DIFF
--- a/nodecg-io-core/.npmignore
+++ b/nodecg-io-core/.npmignore
@@ -1,0 +1,1 @@
+dashboard

--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -1,7 +1,6 @@
 {
     "name": "nodecg-io-dashboard",
     "version": "0.1.0",
-    "private": true,
     "scripts": {
         "build": "webpack",
         "watch": "webpack --watch"


### PR DESCRIPTION
When packing nodecg-io-core it would include the dashboard, which has a symlink to the core in the node-modules directory which resulted in a infinte loop when trying to pack the core.
The dashboard will now also be published to npm and in the planed yeoman generator, which will install releases of nodecg-io, will download it separately.