### PR TITLE
Warn on console.log usage and embrace nodecg logger

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,8 @@ module.exports = {
 
         // We simply have empty functions at some places, so we ignore this rule.
         "@typescript-eslint/no-empty-function": ["warn", { allow: ["arrowFunctions"] }],
+
+        // Instead of console the integrated nodecg logger should be used.
+        "no-console": ["warn"],
     },
 };

--- a/nodecg-io-ahk/extension/AHK.ts
+++ b/nodecg-io-ahk/extension/AHK.ts
@@ -1,9 +1,10 @@
 import fetch from "node-fetch";
+import { NodeCG } from "nodecg/types/server";
 
 export class AHK {
     private readonly address: string;
 
-    public constructor(host: string, port: number) {
+    public constructor(private nodecg: NodeCG, host: string, port: number) {
         this.address = `http://${host}:${port}`;
     }
 
@@ -16,7 +17,7 @@ export class AHK {
         try {
             await fetch(`${this.address}/send/${command}`, { method: "GET" });
         } catch (err) {
-            console.error(`Error while using the AHK Connector: ${err}`);
+            this.nodecg.log.error(`Error while using the AHK Connector: ${err}`);
         }
     }
 }

--- a/nodecg-io-ahk/extension/index.ts
+++ b/nodecg-io-ahk/extension/index.ts
@@ -15,13 +15,13 @@ module.exports = (nodecg: NodeCG) => {
 
 class AhkService extends ServiceBundle<AHKServiceConfig, AHKServiceClient> {
     async validateConfig(config: AHKServiceConfig): Promise<Result<void>> {
-        const ahk = new AHK(config.host, config.port);
+        const ahk = new AHK(this.nodecg, config.host, config.port);
         await ahk.testConnection(); // Will throw an error if server doesn't exist.
         return emptySuccess();
     }
 
     async createClient(config: AHKServiceConfig): Promise<Result<AHKServiceClient>> {
-        const ahk = new AHK(config.host, config.port);
+        const ahk = new AHK(this.nodecg, config.host, config.port);
         return success({
             getNativeClient() {
                 return ahk;

--- a/nodecg-io-android/extension/android.ts
+++ b/nodecg-io-android/extension/android.ts
@@ -4,6 +4,7 @@ import { spawn } from "child_process";
 import { onExit, readableToString } from "@rauschma/stringio";
 import { AddressInfo } from "net";
 import { buffer as readableToBuffer } from "get-stream";
+import { NodeCG } from "nodecg/types/server";
 
 /**
  * Represents an android device that is connected via ADB.
@@ -27,7 +28,7 @@ export class Android {
     public readonly packageManager: PackageManager;
     public readonly contactManager: ContactManager;
 
-    constructor(device: string) {
+    constructor(private nodecg: NodeCG, device: string) {
         this.device = device;
         this.connected = false;
 
@@ -92,7 +93,7 @@ export class Android {
                 try {
                     await handler();
                 } catch (err) {
-                    console.log(`A disconnect handler for nodecg-io-android threw an error: ${err}`);
+                    this.nodecg.log.error(`A disconnect handler for nodecg-io-android threw an error: ${err}`);
                 }
             }
             await this.rawRequest("cancel_all_subscriptions", {});

--- a/nodecg-io-android/extension/index.ts
+++ b/nodecg-io-android/extension/index.ts
@@ -14,14 +14,14 @@ module.exports = (nodecg: NodeCG) => {
 
 class AndroidService extends ServiceBundle<AndroidServiceConfig, AndroidServiceClient> {
     async validateConfig(config: AndroidServiceConfig): Promise<Result<void>> {
-        const client = new Android(config.device);
+        const client = new Android(this.nodecg, config.device);
         await client.connect();
         await client.disconnect();
         return emptySuccess();
     }
 
     async createClient(config: AndroidServiceConfig): Promise<Result<AndroidServiceClient>> {
-        const client = new Android(config.device);
+        const client = new Android(this.nodecg, config.device);
         await client.connect();
         this.nodecg.log.info("Successfully connected to adb.");
         return success({

--- a/nodecg-io-core/dashboard/bundles.ts
+++ b/nodecg-io-core/dashboard/bundles.ts
@@ -91,6 +91,6 @@ export async function setServiceDependency(): Promise<void> {
     try {
         await sendAuthenticatedMessage("setServiceDependency", msg);
     } catch (err) {
-        console.log(err);
+        nodecg.log.error(err);
     }
 }

--- a/nodecg-io-core/dashboard/serviceInstance.ts
+++ b/nodecg-io-core/dashboard/serviceInstance.ts
@@ -127,7 +127,7 @@ export async function saveInstanceConfig(): Promise<void> {
         await sendAuthenticatedMessage("updateInstanceConfig", msg);
         showNotice("Successfully saved.");
     } catch (err) {
-        console.log(err);
+        nodecg.log.error(`Couldn't save instance config: ${err}`);
         showNotice(err);
     }
 }
@@ -142,7 +142,9 @@ export async function deleteInstance(): Promise<void> {
     if (deleted) {
         selectServiceInstance("select");
     } else {
-        console.log(`Couldn't delete the instance "${msg.instanceName}" for some reason, please check the nodecg log`);
+        nodecg.log.info(
+            `Couldn't delete the instance "${msg.instanceName}" for some reason, please check the nodecg log`,
+        );
     }
 }
 

--- a/nodecg-io-philipshue/extension/index.ts
+++ b/nodecg-io-philipshue/extension/index.ts
@@ -105,7 +105,7 @@ class PhilipsHueService extends ServiceBundle<PhilipsHueServiceConfig, PhilipsHu
         const discoveryResults = await discovery.nupnpSearch();
 
         if (discoveryResults.length === 0) {
-            console.error("Failed to resolve any Hue Bridges");
+            this.nodecg.log.error("Failed to resolve any Hue Bridges");
             return null;
         } else {
             // Ignoring that you could have more than one Hue Bridge on a network as this is unlikely in 99.9% of users situations

--- a/nodecg-io-xdotool/extension/index.ts
+++ b/nodecg-io-xdotool/extension/index.ts
@@ -16,7 +16,7 @@ module.exports = (nodecg: NodeCG) => {
 class XdotoolServiceBundle extends ServiceBundle<XdotoolServiceConfig, XdotoolServiceClient> {
     async validateConfig(config: XdotoolServiceConfig): Promise<Result<void>> {
         try {
-            const xd = new Xdotool(config.host, config.port);
+            const xd = new Xdotool(this.nodecg, config.host, config.port);
             await xd.testConnection();
             return emptySuccess();
         } catch (err) {
@@ -26,7 +26,7 @@ class XdotoolServiceBundle extends ServiceBundle<XdotoolServiceConfig, XdotoolSe
 
     async createClient(config: XdotoolServiceConfig): Promise<Result<XdotoolServiceClient>> {
         try {
-            const xd = new Xdotool(config.host, config.port);
+            const xd = new Xdotool(this.nodecg, config.host, config.port);
             return success({
                 getNativeClient() {
                     return xd;

--- a/nodecg-io-xdotool/extension/xdotool.ts
+++ b/nodecg-io-xdotool/extension/xdotool.ts
@@ -1,11 +1,12 @@
 import fetch from "node-fetch";
 import { spawn } from "child_process";
 import { onExit } from "@rauschma/stringio";
+import { NodeCG } from "nodecg/types/server";
 
 export class Xdotool {
     private readonly address: string | null;
 
-    constructor(host: string, port: number) {
+    constructor(private nodecg: NodeCG, host: string, port: number) {
         if ((host.startsWith("127.0.0.") || host == "localhost") && port < 0) {
             this.address = null;
         } else {
@@ -50,7 +51,7 @@ export class Xdotool {
             try {
                 await fetch(`${this.address}/send/${command}`, { method: "GET" });
             } catch (err) {
-                console.error(`Error while using the xdotool Connector: ${err}`);
+                this.nodecg.log.error(`Error while using the xdotool Connector: ${err}`);
             }
         }
     }

--- a/samples/midi-input/helperscripts/listDevices.ts
+++ b/samples/midi-input/helperscripts/listDevices.ts
@@ -2,6 +2,10 @@ import * as midi from "easymidi";
 const inputs = midi.getInputs();
 const outputs = midi.getOutputs();
 
+// This script is executed by itself and not by nodecg.
+// Therefore we can't use the nodecg logger and fall back to console.log.
+/* eslint-disable no-console */
+
 console.log("Midi Inputs");
 inputs.forEach((element: string) => {
     console.log("    " + element);

--- a/samples/twitch-pubsub/extension/index.ts
+++ b/samples/twitch-pubsub/extension/index.ts
@@ -10,16 +10,16 @@ module.exports = function (nodecg: NodeCG) {
     pubsub?.onAvailable((client) => {
         nodecg.log.info("PubSub client has been updated, adding handlers for messages.");
         client.onSubscription((message) => {
-            console.log(`${message.userDisplayName} just subscribed (${message.cumulativeMonths} months)`);
+            nodecg.log.info(`${message.userDisplayName} just subscribed (${message.cumulativeMonths} months)`);
         });
         client.onBits((message) => {
-            console.log(`${message.userName} cheered ${message.bits} Bits`);
+            nodecg.log.info(`${message.userName} cheered ${message.bits} Bits`);
         });
         client.onBitsBadgeUnlock((message) => {
-            console.log(`${message.userName} just unlocked the ${message.badgeTier} Badge`);
+            nodecg.log.info(`${message.userName} just unlocked the ${message.badgeTier} Badge`);
         });
         client.onRedemption((message) => {
-            console.log(`${message.userDisplayName} redeemed ${message.rewardName} (${message.message})`);
+            nodecg.log.info(`${message.userDisplayName} redeemed ${message.rewardName} (${message.message})`);
         });
     });
 


### PR DESCRIPTION
NodeCG bundles should use the integrated nodecg logger and while developing you easily forget it and use `console.log`/`console.error` which may be forgotten and left in the code.
This also introduces a inconsistency because sometimes the nodecg logger and sometimes the `console.log` is used.
To deal with this, this PR adds a eslint rule to treat `console.log` as a warning to ensure that the nodecg logger is used before code is merged. While developing and trying things out you should be still able to use `console.log` if you wish to, that's why only a warning and not an error.