### PR TITLE
Refactor ServiceClientWrapper

### DIFF
--- a/nodecg-io-core/extension/serviceProvider.ts
+++ b/nodecg-io-core/extension/serviceProvider.ts
@@ -11,6 +11,14 @@ export class ServiceProvider<C> {
     private currentClient: C | undefined;
     private em = new EventEmitter();
 
+    constructor() {
+        // Make service client non enumerable, that way it won't be serialized, which would cause problems.
+        Object.defineProperty(this, "currentClient", {
+            enumerable: false,
+            writable: true,
+        });
+    }
+
     /**
      * Returns the current client from the assigned service instance or undefined if it failed to create one or
      * the current bundle has no service instance assigned to it.

--- a/nodecg-io-core/extension/types.d.ts
+++ b/nodecg-io-core/extension/types.d.ts
@@ -1,6 +1,7 @@
 // Holds generic types for the whole project
 
 import { Result } from "./utils/result";
+import { ServiceProvider } from "./serviceProvider";
 
 /**
  * Models a map using a object, instead of a iterator like the javascript es6 map.
@@ -122,10 +123,8 @@ export interface ServiceDependency<C> {
     serviceInstance?: string;
 
     /**
-     * Callback that will give the client of the service to the bundle.
-     * Called on initial set of the service instance or if the config of the service instance has changed.
-     *
-     * @param client the client of the service or undefined if there is currently no service instance set.
+     * The provider that will provide the service client to the bundle that expressed this service dependency.
+     * Will also be used to inform bundle about client updates and unsets.
      */
-    readonly clientUpdateCallback(client?: C): void;
+    readonly provider: ServiceProvider<C>;
 }

--- a/nodecg-io-core/index.ts
+++ b/nodecg-io-core/index.ts
@@ -5,4 +5,4 @@
 export type { ObjectMap, Service, ServiceDependency, ServiceInstance } from "./extension/types";
 export * from "./extension/utils/result";
 export { ServiceBundle } from "./extension/serviceBundle";
-export { requireService } from "./extension/serviceProvider";
+export { requireService, ServiceProvider } from "./extension/serviceProvider";

--- a/nodecg-io-core/index.ts
+++ b/nodecg-io-core/index.ts
@@ -5,4 +5,4 @@
 export type { ObjectMap, Service, ServiceDependency, ServiceInstance } from "./extension/types";
 export * from "./extension/utils/result";
 export { ServiceBundle } from "./extension/serviceBundle";
-export { requireService } from "./extension/serviceClientWrapper";
+export { requireService } from "./extension/serviceProvider";


### PR DESCRIPTION
At the initial creation of the framework it was intented for bundles to provide a callback which would be called with undefined or the client if the client changed. On top of this `ServiceClientWrapper` was built which allowed bundles to have a separate callback for when a client is available or unavailable. `ServiceClientWrapper` used the previously used callback which in retrospect was just an ugly addition.
This PR refactors it to be more integrated with the framework by completely removing the old callback with it and renaming it to `ServiceProvider` which imo is a way better name.
Also now the `EventEmitter` is now in a variable so that it doesn't feel so bloated with all the `EventEmitter` functions when using InteliSense on it.
EDIT: there still seems to be a big in this it seems...