### PR TITLE
Verify auth token in pubsub service and add way to stop it

### DIFF
--- a/nodecg-io-twitch-pubsub/extension/index.ts
+++ b/nodecg-io-twitch-pubsub/extension/index.ts
@@ -24,12 +24,14 @@ class TwitchPubSubService extends ServiceBundle<TwitchPubSubServiceConfig, Twitc
         return success(client);
     }
 
-    stopClient(_: TwitchPubSubServiceClient): void {
-        // Not possible
+    stopClient(client: TwitchPubSubServiceClient): void {
+        client
+            .disconnect()
+            .then(() => this.nodecg.log.info("Stopped pubsub client successfully."))
+            .catch((err) => this.nodecg.log.error(`Couldn't stop pubsub client: ${err}`));
     }
 
-    // Pubsub has no methods to close the connection or remove the handler.
-    // It has no way to access the underlying client too, so handlers that are setup once will currently live forever.
-    // TODO: implement a way to at least stop the client, removing handlers would be nice too
+    // Pubsub has no methods to remove the handlers.
+    // At least we can disconnect the client so we must do that on any configuration change and reconnect.
     recreateClientToRemoveHandlers = true;
 }

--- a/nodecg-io-twitch-pubsub/extension/pubSubClient.ts
+++ b/nodecg-io-twitch-pubsub/extension/pubSubClient.ts
@@ -1,11 +1,13 @@
 import { getTokenInfo, StaticAuthProvider, TokenInfo } from "twitch-auth";
 import { TwitchPubSubServiceConfig } from "./index";
-import { SingleUserPubSubClient } from "twitch-pubsub-client";
+import { BasicPubSubClient, SingleUserPubSubClient } from "twitch-pubsub-client";
 import { ApiClient } from "twitch";
 
 export class TwitchPubSubServiceClient extends SingleUserPubSubClient {
-    constructor(apiClient: ApiClient, private readonly userId: string) {
-        super({ twitchClient: apiClient });
+    private basicClient: BasicPubSubClient;
+    constructor(apiClient: ApiClient, basicClient: BasicPubSubClient, private readonly userId: string) {
+        super({ twitchClient: apiClient, pubSubClient: basicClient });
+        this.basicClient = basicClient;
     }
 
     /**
@@ -16,10 +18,27 @@ export class TwitchPubSubServiceClient extends SingleUserPubSubClient {
         const tokenInfo = await TwitchPubSubServiceClient.getTokenInfo(cfg);
         const authProvider = new StaticAuthProvider(tokenInfo.clientId, this.normalizeToken(cfg), tokenInfo.scopes);
 
-        // Create the actual chat client and connect
+        // Create the actual pubsub client and connect
         const apiClient = new ApiClient({ authProvider });
         const user = await apiClient.helix.users.getMe();
-        return new TwitchPubSubServiceClient(apiClient, user.id);
+        const basicClient = new BasicPubSubClient();
+        const pubSubClient = new TwitchPubSubServiceClient(apiClient, basicClient, user.id);
+
+        // Checks whether the provided token is valid and has required scopes.
+        // We do this so that the framework can say that the token is wrong instead of letting it through
+        // till it will result in a exception in the bundle.
+        await basicClient.connect();
+        try {
+            await basicClient.listen([], authProvider); // listen for nothing still checks token
+        } catch (err) {
+            if (err.toString().includes("http status 400")) {
+                throw "Token is invalid or has not all required scopes. (channel_subscriptions, bits:read and channel:read:redemptions)";
+            } else {
+                throw err;
+            }
+        }
+
+        return pubSubClient;
     }
 
     /**
@@ -38,5 +57,9 @@ export class TwitchPubSubServiceClient extends SingleUserPubSubClient {
 
     getUserID(): string {
         return this.userId;
+    }
+
+    async disconnect(): Promise<void> {
+        this.basicClient.disconnect();
     }
 }

--- a/nodecg-io-twitch-pubsub/extension/pubSubClient.ts
+++ b/nodecg-io-twitch-pubsub/extension/pubSubClient.ts
@@ -59,7 +59,7 @@ export class TwitchPubSubServiceClient extends SingleUserPubSubClient {
         return this.userId;
     }
 
-    async disconnect(): Promise<void> {
-        this.basicClient.disconnect();
+    disconnect(): Promise<void> {
+        return this.basicClient.disconnect();
     }
 }


### PR DESCRIPTION
Previously the scopes of the auth token was not really checked and resulted in a crash once the service instance was assigned to a bundle. This was because only the add handler functions that were used by the bundle caused a api call with the credential and this may fail because of missing scopes on the token. This adds a check which will make sure that the token has sufficient scopes and will show an error in the UI if not.
Also adds the possibility to stop the pubsub client, which was previosly not given.