### PR TITLE
Fix export of NanoleafUtils through index.ts file

### DIFF
--- a/nodecg-io-nanoleaf/extension/index.ts
+++ b/nodecg-io-nanoleaf/extension/index.ts
@@ -8,11 +8,8 @@ export interface NanoleafServiceConfig {
     ipAddress: string;
 }
 
-// Reexporting all important classes
-export { NanoleafClient as NanoleafServiceClient } from "./nanoleafClient";
-export { NanoleafUtils } from "./nanoleafUtils";
-export { Color, ColoredPanel, PanelEffect } from "./interfaces";
-export { NanoleafQueue } from "./nanoleafQueue";
+// Reexportation of important classes and types is done in ../index.ts because we need to
+// export NanoleafUtils which is a class and this file already has a default export for nodecg.
 
 module.exports = (nodecg: NodeCG) => {
     new NanoleafService(nodecg, "nanoleaf", __dirname, "../nanoleaf-schema.json").register();

--- a/nodecg-io-nanoleaf/index.ts
+++ b/nodecg-io-nanoleaf/index.ts
@@ -1,0 +1,6 @@
+// Reexporting all important classes for ease of use
+
+export { NanoleafClient as NanoleafServiceClient } from "./extension//nanoleafClient";
+export { NanoleafUtils } from "./extension/nanoleafUtils";
+export { Color, ColoredPanel, PanelEffect } from "./extension/interfaces";
+export { NanoleafQueue } from "./extension/nanoleafQueue";

--- a/nodecg-io-nanoleaf/package.json
+++ b/nodecg-io-nanoleaf/package.json
@@ -12,7 +12,6 @@
         "url": "https://github.com/codeoverflow-org/nodecg-io.git",
         "directory": "nodecg-io-nanoleaf"
     },
-    "main": "extension",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",


### PR DESCRIPTION
Does a similar thing to the core index.ts to export classes and function which is not possible through extenstion/index.ts because it already has a default export for the nodecg function.
Allows `import {NanoleafUtils} from "nodecg-io-nanoleaf"` to work as intented.