### PR TITLE
Fix usage of irc retry limit

### DIFF
--- a/nodecg-io-irc/extension/index.ts
+++ b/nodecg-io-irc/extension/index.ts
@@ -12,7 +12,12 @@ interface IRCServiceConfig {
 
 export class IRCServiceClient extends IRCClient {
     constructor(config: IRCServiceConfig) {
-        super(config.host, config.nick, { password: config.password });
+        super(config.host, config.nick, {
+            password: config.password,
+            autoConnect: false,
+            retryCount: config.reconnectTries ?? 1,
+            retryDelay: 500,
+        });
     }
 
     sendMessage(target: string, message: string): void {
@@ -25,30 +30,17 @@ module.exports = (nodecg: NodeCG) => {
 };
 
 class IRCService extends ServiceBundle<IRCServiceConfig, IRCServiceClient> {
-    async validateConfig(config: IRCServiceConfig): Promise<Result<void>> {
-        const irc = new IRCServiceClient(config);
-
-        // We need one error handler or node will exit the process on an error.
-        irc.on("error", (_err) => {});
-
-        await new Promise((res) => {
-            irc.connect(config.reconnectTries || 5, res);
-        });
-        await new Promise((res) => {
-            irc.disconnect("", () => res(undefined));
-        });
+    async validateConfig(_config: IRCServiceConfig): Promise<Result<void>> {
+        // no checks are currently done here. Server and password are checked in createClient()
+        // We could check whether the port is valid and the host/ip is valid here in the future.
         return emptySuccess();
     }
 
     async createClient(config: IRCServiceConfig): Promise<Result<IRCServiceClient>> {
         const irc = new IRCServiceClient(config);
 
-        // We need one error handler or node will exit the process on an error.
-        irc.on("error", (_err) => {});
-
-        await new Promise((res) => {
-            irc.connect(config.reconnectTries || 5, res);
-        });
+        this.nodecg.log.info("Connecting to IRC...");
+        await this.connect(irc);
         this.nodecg.log.info("Successfully connected to the IRC server.");
 
         return success(irc);
@@ -62,5 +54,17 @@ class IRCService extends ServiceBundle<IRCServiceConfig, IRCServiceClient> {
 
     removeHandlers(client: IRCServiceClient): void {
         client.removeAllListeners();
+    }
+
+    private connect(client: IRCServiceClient): Promise<void> {
+        return new Promise<void>((resolve, reject) => {
+            // We need one error handler or node will exit the process on an error.
+            client.on("error", (err) => reject(err));
+            client.on("abort", () => {
+                reject("Couldn't connect to IRC server! Maximum retry count reached.");
+            });
+
+            client.connect(0, () => resolve(undefined));
+        });
     }
 }

--- a/nodecg-io-irc/extension/index.ts
+++ b/nodecg-io-irc/extension/index.ts
@@ -15,7 +15,7 @@ export class IRCServiceClient extends IRCClient {
         super(config.host, config.nick, {
             password: config.password,
             autoConnect: false,
-            retryCount: config.reconnectTries ?? 1,
+            retryCount: config.reconnectTries ?? 3,
             retryDelay: 500,
         });
     }

--- a/nodecg-io-irc/package.json
+++ b/nodecg-io-irc/package.json
@@ -35,7 +35,7 @@
         "typescript": "^4.1.3"
     },
     "dependencies": {
-        "@types/irc": "^0.3.33",
+        "@types/irc": "^0.5.0",
         "irc": "^0.5.2",
         "nodecg-io-core": "^0.1.0"
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
                 "@slack/web-api": "^5.14.0",
                 "@types/crypto-js": "^4.0.1",
                 "@types/gapi": "0.0.39",
-                "@types/irc": "^0.3.33",
+                "@types/irc": "^0.5.0",
                 "@types/node": "^14.14.13",
                 "@types/node-fetch": "^2.5.8",
                 "@types/node-telegram-bot-api": "^0.51.0",
@@ -3494,9 +3494,9 @@
             }
         },
         "node_modules/@types/irc": {
-            "version": "0.3.33",
-            "resolved": "https://registry.npmjs.org/@types/irc/-/irc-0.3.33.tgz",
-            "integrity": "sha512-5lFVTJw20+bPcDjDePgbOZCIFHXBcjstyXCM9oK1xtHg90rvUMsrY55RydC0hkwlU3omsWEULj59+0rbp++Gkw==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@types/irc/-/irc-0.5.0.tgz",
+            "integrity": "sha512-e/WG2hfVUqzarXcls5Ixh+fACm68l1JfHJfkAjrCpviFj20r1LthI3FjCeXgFVTbzMmh/Lv9aDac8LV8VPhwGg==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -20721,9 +20721,9 @@
             }
         },
         "@types/irc": {
-            "version": "0.3.33",
-            "resolved": "https://registry.npmjs.org/@types/irc/-/irc-0.3.33.tgz",
-            "integrity": "sha512-5lFVTJw20+bPcDjDePgbOZCIFHXBcjstyXCM9oK1xtHg90rvUMsrY55RydC0hkwlU3omsWEULj59+0rbp++Gkw==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/@types/irc/-/irc-0.5.0.tgz",
+            "integrity": "sha512-e/WG2hfVUqzarXcls5Ixh+fACm68l1JfHJfkAjrCpviFj20r1LthI3FjCeXgFVTbzMmh/Lv9aDac8LV8VPhwGg==",
             "requires": {
                 "@types/node": "*"
             }


### PR DESCRIPTION
Fixes IRC Client hangs when using a wrong password #120. Now retries work as intented and it therefore also fails on wrong passwords.
Also removes irc connection check from `validateConfig` because it is the complete same check that `createClient` would do.