### PR TITLE
Automatically set instances with no required config

### DIFF
--- a/nodecg-io-core/extension/index.ts
+++ b/nodecg-io-core/extension/index.ts
@@ -22,7 +22,7 @@ module.exports = (nodecg: NodeCG): NodeCGIOCore => {
     const serviceManager = new ServiceManager(nodecg);
     const bundleManager = new BundleManager(nodecg);
     const instanceManager = new InstanceManager(nodecg, serviceManager, bundleManager);
-    const persistenceManager = new PersistenceManager(nodecg, instanceManager, bundleManager);
+    const persistenceManager = new PersistenceManager(nodecg, serviceManager, instanceManager, bundleManager);
 
     new MessageManager(
         nodecg,

--- a/nodecg-io-core/extension/persistenceManager.ts
+++ b/nodecg-io-core/extension/persistenceManager.ts
@@ -4,6 +4,7 @@ import { BundleManager } from "./bundleManager";
 import * as crypto from "crypto-js";
 import { emptySuccess, error, Result, success } from "./utils/result";
 import { ObjectMap, ServiceDependency, ServiceInstance } from "./types";
+import { ServiceManager } from "./serviceManager";
 
 /**
  * Models all the data that needs to be persistent in a plain manner.
@@ -58,6 +59,7 @@ export class PersistenceManager {
 
     constructor(
         private readonly nodecg: NodeCG,
+        private readonly services: ServiceManager,
         private readonly instances: InstanceManager,
         private readonly bundles: BundleManager,
     ) {
@@ -155,6 +157,11 @@ export class PersistenceManager {
                 this.nodecg.log.info(
                     `Couldn't load instance "${instanceName}" from saved configuration: ${result.errorMessage}`,
                 );
+                continue;
+            }
+
+            const svc = this.services.getService(inst.serviceType);
+            if (!svc.failed && svc.result.requiresNoConfig) {
                 continue;
             }
 

--- a/nodecg-io-core/extension/serviceBundle.ts
+++ b/nodecg-io-core/extension/serviceBundle.ts
@@ -96,9 +96,16 @@ export abstract class ServiceBundle<R, C> implements Service<R, C> {
      * It gets rid of the handlers by stopping the client and creating a new one, to which then only the
      * now wanted handlers get registered (e.g. if a bundle doesn't uses this service anymore but another still does).
      * Not ideal, but if your service can't implement removeHandlers for some reason it is still better than
-     * having dangling handlers that still fire eventho they shouldn't.
+     * having dangling handlers that still fire events eventho they shouldn't.
      */
     reCreateClientToRemoveHandlers = false;
+
+    /**
+     * This flag says that this service cannot be configured and doesn't need any config passed to {@link createClient}.
+     * If this is set {@link validateConfig} will never be called.
+     * @default false
+     */
+    requiresNoConfig = false;
 
     private readSchema(pathSegments: string[]): unknown {
         const joinedPath = path.resolve(...pathSegments);

--- a/nodecg-io-core/extension/types.d.ts
+++ b/nodecg-io-core/extension/types.d.ts
@@ -75,14 +75,22 @@ export interface Service<R, C extends ServiceClient<unknown>> {
     readonly removeHandlers?(client: C): void;
 
     /**
-     * This flag can be enabled by services if they can't implement removeHandlers but also have some handlers that
+     * This flag can be enabled by services if they can't implement {@link removeHandlers} but also have some handlers that
      * should be reset if a bundleDependency has been changed.
      * It gets rid of the handlers by stopping the client and creating a new one, to which then only the
      * now wanted handlers get registered (e.g. if a bundle doesn't uses this service anymore but another still does).
      * Not ideal, but if your service can't implement removeHandlers for some reason it is still better than
      * having dangling handlers that still fire eventho they shouldn't.
+     * @default false
      */
     reCreateClientToRemoveHandlers: boolean;
+
+    /**
+     * This flag says that this service cannot be configured and doesn't need any config passed to {@link createClient}.
+     * If this is set {@link validateConfig} will never be called.
+     * @default false
+     */
+    requiresNoConfig: boolean;
 }
 
 /**

--- a/nodecg-io-curseforge/extension/index.ts
+++ b/nodecg-io-curseforge/extension/index.ts
@@ -53,4 +53,6 @@ class CurseforgeService extends ServiceBundle<never, CurseForgeClient> {
     stopClient(_: CurseForgeClient): void {
         this.nodecg.log.info("Successfully stopped CurseForge client.");
     }
+
+    requiresNoConfig = true;
 }


### PR DESCRIPTION
With this services that don't require a config like curseforge or the debug service (#205) will be automatically set and created.
That way you don't need to manually click "save" which can be forgotten.
Also shows in the UI that these services don't need any configuration.
