### PR TITLE
Fix youtube token refreshing by always prompting user for consent

### DIFF
--- a/nodecg-io-youtube/extension/index.ts
+++ b/nodecg-io-youtube/extension/index.ts
@@ -29,6 +29,7 @@ class YoutubeService extends ServiceBundle<YoutubeServiceConfig, YoutubeServiceC
         const authUrl = auth.generateAuthUrl({
             access_type: "offline",
             scope: "https://www.googleapis.com/auth/youtube",
+            prompt: "consent",
         });
 
         return new Promise((resolve, reject) => {


### PR DESCRIPTION
Fixes #212. The problem is that the google oauth2 api only returns a refresh token if a confirmation prompt was displayed to the user. Previously if you logged in once it would use the session and automatically authenticate you. But then you don't have a refresh token and it fails because of that after about an hour.
This creates the problem that everytime you need to select your Google account and click "OK" but I will create a followup PR to save the refresh token so you don't need to login each time and also it doesn't create a browser tab each time.