### PR TITLE
Only stop client on exit when it is defined

### DIFF
--- a/nodecg-io-core/extension/index.ts
+++ b/nodecg-io-core/extension/index.ts
@@ -85,7 +85,7 @@ function onExit(
         if (instances[key] !== undefined) {
             const client = instances[key]?.client;
             const service = serviceManager.getService(instances[key]?.serviceType as string);
-            if (!service.failed) {
+            if (!service.failed && client) {
                 nodecg.log.info(`Stopping service ${key} of type ${service.result.serviceType}.`);
                 try {
                     service.result.stopClient(client);


### PR DESCRIPTION
Fixes all the errors about not being able to stop clients and "... is not defined on value undefined" for all services that aren't configured properly