### PR TITLE
Update nodecg.io links to point to latest release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
         node-version: "15"
 
     - name: Install system dependencies
-      run: sudo apt-get -y install libusb-1.0-0-dev libasound2-dev libudev-dev
+      run: sudo apt update && sudo apt-get -y install libusb-1.0-0-dev libasound2-dev libudev-dev
 
     - name: Install nodejs dependencies
       run: npm ci && npm run bootstrap

--- a/.scripts/create-service.py
+++ b/.scripts/create-service.py
@@ -28,7 +28,7 @@ if __name__ == '__main__':
     # Replace some entries from the template package.json
     package['name'] = f'nodecg-io-{service_name}'
     package['description'] = description
-    package['homepage'] = f'https://nodecg.io/samples/{sample_name}'
+    package['homepage'] = f'https://nodecg.io/RELEASE/samples/{sample_name}'
     package['author'] = {
         'name': author_name,
         'url': author_url

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Feature Requests](https://img.shields.io/github/issues/codeoverflow-org/nodecg-io/enhancement?label=Feature%20Requests&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/labels/enhancement)
 [![Bugs](https://img.shields.io/github/issues/codeoverflow-org/nodecg-io/bug?label=Bugs&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/labels/bug)
 [![Pull Requests](https://img.shields.io/github/issues-pr/codeoverflow-org/nodecg-io?label=Pull%20Requests&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/pulls)
-[![Services](https://img.shields.io/static/v1?label=Services%20implemented&message=21&color=blue&style=flat-square)](https://nodecg.io/services/)
+[![Services](https://img.shields.io/static/v1?label=Services%20implemented&message=21&color=blue&style=flat-square)](https://nodecg.io/RELEASE/services/)
 [![License](https://img.shields.io/github/license/codeoverflow-org/nodecg-io?label=License&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/blob/master/LICENSE)
 [![Discord](https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&style=flat-square)](https://discord.gg/GEJzxBGRu6)
 
@@ -52,11 +52,11 @@ nodecg-io is the successor of [ChatOverflow](https://github.com/codeoverflow-org
 ## How to use nodecg-io
 
 If you want to use nodecg-io, you should note that it is only a framework for your bundle, so you need at least a basic knowledge of the programming language JavaScript or any other language that compiles to JavaScript like TypeScript.
-If that's no problem you can head over to the [installation guide](https://nodecg.io/getting_started/install/) and take a look at the [available nodecg-io services](https://nodecg.io/services/).
+If that's no problem you can head over to the [installation guide](https://nodecg.io/RELEASE/getting_started/install/) and take a look at the [available nodecg-io services](https://nodecg.io/RELEASE/services/).
 
 ## How to contribute
 
-If you want to contribute to this bundle you can implement one of those services or fix an [issue](https://github.com/codeoverflow-org/nodecg-io/issues). Before contributing head over to the [How to contribute](https://nodecg.io/contribute/contribute/) guide.
+If you want to contribute to this bundle you can implement one of those services or fix an [issue](https://github.com/codeoverflow-org/nodecg-io/issues). Before contributing head over to the [How to contribute](https://nodecg.io/RELEASE/contribute/contribute/) guide.
 
 ## Code Overflow Team
 

--- a/nodecg-io-ahk/package.json
+++ b/nodecg-io-ahk/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-ahk",
     "version": "0.2.0",
     "description": "Allows you to send commands to AutoHotkey.",
-    "homepage": "https://nodecg.io/samples/ahk",
+    "homepage": "https://nodecg.io/RELEASE/samples/ahk",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"

--- a/nodecg-io-android/package.json
+++ b/nodecg-io-android/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-android",
     "version": "0.2.0",
     "description": "Allows to connect to an android device via adb.",
-    "homepage": "https://nodecg.io/samples/android",
+    "homepage": "https://nodecg.io/RELEASE/samples/android",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-core",
     "version": "0.2.0",
     "description": "The core of nodecg-io. Connects everything up.",
-    "homepage": "https://nodecg.io",
+    "homepage": "https://nodecg.io/RELEASE",
     "author": {
         "name": "CodeOverflow team",
         "url": "https://github.com/codeoverflow-org"

--- a/nodecg-io-curseforge/package.json
+++ b/nodecg-io-curseforge/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-curseforge",
     "version": "0.2.0",
     "description": "A service to communicate with the CurseForge API.",
-    "homepage": "https://nodecg.io/samples/curseforge",
+    "homepage": "https://nodecg.io/RELEASE/samples/curseforge",
     "author": {
         "name": "MelanX",
         "url": "https://www.github.com/MelanX"

--- a/nodecg-io-debug/package.json
+++ b/nodecg-io-debug/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-debug",
     "version": "0.2.0",
     "description": "Debug helper service that helps to easily trigger your code for debugging purposes.",
-    "homepage": "https://nodecg.io/samples/debug",
+    "homepage": "https://nodecg.io/RELEASE/samples/debug",
     "author": {
         "name": "CodeOverflow team",
         "url": "https://github.com/codeoverflow-org"

--- a/nodecg-io-discord/package.json
+++ b/nodecg-io-discord/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-discord",
     "version": "0.2.0",
     "description": "Allows to connect to discord via a discord-bot.",
-    "homepage": "https://nodecg.io/samples/discord",
+    "homepage": "https://nodecg.io/RELEASE/samples/discord",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-gsheets/package.json
+++ b/nodecg-io-gsheets/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-gsheets",
     "version": "0.2.0",
     "description": "Allow to control Google Sheets.",
-    "homepage": "https://nodecg.io",
+    "homepage": "https://nodecg.io/RELEASE",
     "author": {
         "name": "ExtremTechniker",
         "url": "https://github.com/ExtremTechniker"

--- a/nodecg-io-intellij/package.json
+++ b/nodecg-io-intellij/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-intellij",
     "version": "0.2.0",
     "description": "Allows to control JetBrains IDEs via nodecg-io",
-    "homepage": "https://nodecg.io/samples/intellij",
+    "homepage": "https://nodecg.io/RELEASE/samples/intellij",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-irc/package.json
+++ b/nodecg-io-irc/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-irc",
     "version": "0.2.0",
     "description": "Allow to connect to IRC Servers.",
-    "homepage": "https://nodecg.io",
+    "homepage": "https://nodecg.io/RELEASE",
     "author": {
         "name": "ExtremTechniker",
         "url": "https://github.com/ExtremTechniker"

--- a/nodecg-io-midi-input/package.json
+++ b/nodecg-io-midi-input/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-midi-input",
     "version": "0.2.0",
     "description": "Connect to MIDI devices and control the volume of your voice or music with a fader.",
-    "homepage": "https://nodecg.io/samples/midi-input",
+    "homepage": "https://nodecg.io/RELEASE/samples/midi-input",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-midi-output/package.json
+++ b/nodecg-io-midi-output/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-midi-output",
     "version": "0.2.0",
     "description": "Connect to MIDI devices and control the volume of your voice or music with a fader.",
-    "homepage": "https://nodecg.io/samples/midi-output",
+    "homepage": "https://nodecg.io/RELEASE/samples/midi-output",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-nanoleaf/package.json
+++ b/nodecg-io-nanoleaf/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-nanoleaf",
     "version": "0.2.0",
     "description": "Allows to connect to a nanoleaf controller and trigger custom lighting effects.",
-    "homepage": "https://nodecg.io/samples/nanoleaf",
+    "homepage": "https://nodecg.io/RELEASE/samples/nanoleaf",
     "author": {
         "name": "sebinside",
         "url": "https://github.com/sebinside"

--- a/nodecg-io-obs/package.json
+++ b/nodecg-io-obs/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-obs",
     "version": "0.2.0",
     "description": "Allows to control your obs instance to e.g. switch scenes.",
-    "homepage": "https://nodecg.io",
+    "homepage": "https://nodecg.io/RELEASE",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"

--- a/nodecg-io-philipshue/package.json
+++ b/nodecg-io-philipshue/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-philipshue",
     "version": "0.2.0",
     "description": "Allows you to connect with your Philips Hue bridge. This allows you to control your lights etc.",
-    "homepage": "https://nodecg.io",
+    "homepage": "https://nodecg.io/RELEASE",
     "author": {
         "name": "TheCrether",
         "url": "https://thecrether.at"

--- a/nodecg-io-rcon/package.json
+++ b/nodecg-io-rcon/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-rcon",
     "version": "0.2.0",
     "description": "Allows you to send commands to a minecraft server via RCON.",
-    "homepage": "https://nodecg.io/samples/rcon",
+    "homepage": "https://nodecg.io/RELEASE/samples/rcon",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"

--- a/nodecg-io-reddit/package.json
+++ b/nodecg-io-reddit/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-reddit",
     "version": "0.2.0",
     "description": "Provides an interface to the Reddit-API.",
-    "homepage": "https://nodecg.io/samples/reddit",
+    "homepage": "https://nodecg.io/RELEASE/samples/reddit",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-sacn-receiver/package.json
+++ b/nodecg-io-sacn-receiver/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-sacn-receiver",
     "version": "0.2.0",
     "description": "Allows you to receive data via sACN from e.g professional lighting consoles.",
-    "homepage": "https://nodecg.io/samples/sacn-receiver",
+    "homepage": "https://nodecg.io/RELEASE/samples/sacn-receiver",
     "author": {
         "name": "Tim-Tech-Dev",
         "url": "https://github.com/Tim-Tech-Dev"

--- a/nodecg-io-sacn-sender/package.json
+++ b/nodecg-io-sacn-sender/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-sacn-sender",
     "version": "0.2.0",
     "description": "Allows you to send data via sACN to e.g professional lights.",
-    "homepage": "https://nodecg.io/samples/sacn-sender",
+    "homepage": "https://nodecg.io/RELEASE/samples/sacn-sender",
     "author": {
         "name": "Tim-Tech-Dev",
         "url": "https://github.com/Tim-Tech-Dev"

--- a/nodecg-io-serial/package.json
+++ b/nodecg-io-serial/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-serial",
     "version": "0.2.0",
     "description": "Exposes serial deivces to nodecg-io",
-    "homepage": "https://nodecg.io/samples/serial",
+    "homepage": "https://nodecg.io/RELEASE/samples/serial",
     "author": {
         "name": "Stefan Schmelz",
         "url": "https://github.com/StefanSchmelz"

--- a/nodecg-io-slack/package.json
+++ b/nodecg-io-slack/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-slack",
     "version": "0.2.0",
     "description": "Allows to connect to your slack. This enables you to e.g. send messages and list all channel. Visit https://api.slack.com/methods to see all methods ",
-    "homepage": "https://nodecg.io/samples/slack",
+    "homepage": "https://nodecg.io/RELEASE/samples/slack",
     "author": {
         "name": "ExtremTechniker",
         "url": "https://github.com/ExtremTechniker"

--- a/nodecg-io-spotify/package.json
+++ b/nodecg-io-spotify/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-spotify",
     "version": "0.2.0",
     "description": "Allows to connect to your personal Spotify account. This enables you to e.g. control music playback or get current song information. ",
-    "homepage": "https://nodecg.io",
+    "homepage": "https://nodecg.io/RELEASE",
     "author": {
         "name": "CodeOverflow team",
         "url": "http://codeoverflow.org"

--- a/nodecg-io-streamdeck/package.json
+++ b/nodecg-io-streamdeck/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-streamdeck",
     "version": "0.2.0",
     "description": "Allows to interface with the elgato streamdeck.",
-    "homepage": "https://nodecg.io/samples/streamdeck",
+    "homepage": "https://nodecg.io/RELEASE/samples/streamdeck",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-streamelements/package.json
+++ b/nodecg-io-streamelements/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-streamelements",
     "version": "0.2.0",
     "description": "Allows to connect to streamelements to e.g. react to donations.",
-    "homepage": "https://nodecg.io",
+    "homepage": "https://nodecg.io/RELEASE",
     "author": {
         "name": "CodeOverflow team",
         "url": "https://github.com/codeoverflow-org"

--- a/nodecg-io-telegram/package.json
+++ b/nodecg-io-telegram/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-telegram",
     "version": "0.2.0",
     "description": "Allows you to control a telegram bot.",
-    "homepage": "https://nodecg.io/samples/telegram",
+    "homepage": "https://nodecg.io/RELEASE/samples/telegram",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"

--- a/nodecg-io-template/package.json
+++ b/nodecg-io-template/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-template",
     "version": "0.2.0",
     "description": "Template package.",
-    "homepage": "https://nodecg.io/samples/template",
+    "homepage": "https://nodecg.io/RELEASE/samples/template",
     "author": {
         "name": "CodeOverflow team",
         "url": "https://github.com/codeoverflow-org"

--- a/nodecg-io-tiane/package.json
+++ b/nodecg-io-tiane/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-tiane",
     "version": "0.2.0",
     "description": "Connect to TIANE and make her for example a discord bot. https://github.com/FerdiKr/TIANE",
-    "homepage": "https://nodecg.io/samples/tiane",
+    "homepage": "https://nodecg.io/RELEASE/samples/tiane",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-twitch-addons/package.json
+++ b/nodecg-io-twitch-addons/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-twitch-addons",
     "version": "0.2.0",
     "description": "Support for the API's of BetterTTV and FrankerFaceZ",
-    "homepage": "https://nodecg.io/samples/twitch-addons",
+    "homepage": "https://nodecg.io/RELEASE/samples/twitch-addons",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-twitch-api/package.json
+++ b/nodecg-io-twitch-api/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-twitch-api",
     "version": "0.2.0",
     "description": "Allows talking to twitch APIs like helix.",
-    "homepage": "https://nodecg.io/samples/twitch-api",
+    "homepage": "https://nodecg.io/RELEASE/samples/twitch-api",
     "author": {
         "name": "CodeOverflow team",
         "url": "https://github.com/codeoverflow-org"

--- a/nodecg-io-twitch-chat/package.json
+++ b/nodecg-io-twitch-chat/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-twitch-chat",
     "version": "0.2.0",
     "description": "Allows to connect to the twitch chat with your account, send and receive messages and much more. It can be used to create Twitch-Bots.",
-    "homepage": "https://nodecg.io/samples/twitch-chat",
+    "homepage": "https://nodecg.io/RELEASE/samples/twitch-chat",
     "author": {
         "name": "CodeOverflow team",
         "url": "https://github.com/codeoverflow-org"

--- a/nodecg-io-twitch-pubsub/package.json
+++ b/nodecg-io-twitch-pubsub/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-twitch-pubsub",
     "version": "0.2.0",
     "description": "Allows access to the Twitch PubSub API.",
-    "homepage": "https://nodecg.io/samples/twitch-pubsub",
+    "homepage": "https://nodecg.io/RELEASE/samples/twitch-pubsub",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"

--- a/nodecg-io-twitter/package.json
+++ b/nodecg-io-twitter/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-twitter",
     "version": "0.2.0",
     "description": "Allows to connect to twitter, send, retweet or like messages.",
-    "homepage": "https://nodecg.io/samples/twitter",
+    "homepage": "https://nodecg.io/RELEASE/samples/twitter",
     "author": {
         "name": "CodeOverflow team",
         "url": "http://codeoverflow.org"

--- a/nodecg-io-websocket-client/package.json
+++ b/nodecg-io-websocket-client/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-websocket-client",
     "version": "0.2.0",
     "description": "Allows to connect to a external WebSocket server.",
-    "homepage": "https://nodecg.io/samples/websocket-client/",
+    "homepage": "https://nodecg.io/RELEASE/samples/websocket-client/",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"

--- a/nodecg-io-websocket-server/package.json
+++ b/nodecg-io-websocket-server/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-websocket-server",
     "version": "0.2.0",
     "description": "Allows to create a custom WebSocket server.",
-    "homepage": "https://nodecg.io/samples/websocket-server/",
+    "homepage": "https://nodecg.io/RELEASE/samples/websocket-server/",
     "author": {
         "name": "derNiklaas",
         "url": "https://github.com/derNiklaas"

--- a/nodecg-io-xdotool/package.json
+++ b/nodecg-io-xdotool/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-xdotool",
     "version": "0.2.0",
     "description": "Allows you to send commands to xdotool.",
-    "homepage": "https://nodecg.io/samples/xdotool",
+    "homepage": "https://nodecg.io/RELEASE/samples/xdotool",
     "author": {
         "name": "noeppi_noeppi",
         "url": "https://github.com/noeppi-noeppi"

--- a/nodecg-io-youtube/package.json
+++ b/nodecg-io-youtube/package.json
@@ -2,7 +2,7 @@
     "name": "nodecg-io-youtube",
     "version": "0.2.0",
     "description": "Allows to connect and interact to youtube",
-    "homepage": "https://nodecg.io/samples/youtube",
+    "homepage": "https://nodecg.io/RELEASE/samples/youtube",
     "author": {
         "name": "CodeOverflow team",
         "url": "http://codeoverflow.org"


### PR DESCRIPTION
Because the docs are now versioned we need to provide a version in the url, otherwise we get a 404. So this PR updates them to always target the latest release using the alias.