### PR TITLE
Save config after all service instances have been loaded at startup

### DIFF
--- a/nodecg-io-core/dashboard/crypto.ts
+++ b/nodecg-io-core/dashboard/crypto.ts
@@ -4,7 +4,7 @@ import { ObjectMap, ServiceInstance, ServiceDependency, Service } from "nodecg-i
 import { isLoaded } from "./authentication";
 import { PasswordMessage } from "nodecg-io-core/extension/messageManager";
 
-export const encryptedData = nodecg.Replicant<EncryptedData>("encryptedConfig");
+const encryptedData = nodecg.Replicant<EncryptedData>("encryptedConfig");
 let services: Service<unknown, never>[] | undefined;
 let password: string | undefined;
 


### PR DESCRIPTION
Could be a solution for #231, was definitly not intented the way it was.

If you added a bundle you would first need to do an action that saved the config because otherwise it would be still the one from the last start without the new bundle. This was not noticied because usually you first create a new instance for the bundle and then you don't notice this behaviour.