### PR TITLE
Add install.json from nodecg-io-cli to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,8 @@ package.json.lerna_backup
 # Documentation
 docs/
 
-#lerna debug
+# lerna debug
 lerna-debug.log
+
+# nodecg-io-cli install details. Created when installing development version using nodecg-io install.
+install.json


### PR DESCRIPTION
This file is created by the nodecg-io cli when you create a install and saves what you have selected there. In case you create a development install git will say that this file is untracked because it is not checked in and not gitignored.
This file should not be commited so this PR adds it to the `.gitignore` file.