### PR TITLE
Remove main entry from twitch-auth package.json

### DIFF
--- a/utils/nodecg-io-twitch-auth/package.json
+++ b/utils/nodecg-io-twitch-auth/package.json
@@ -11,7 +11,6 @@
         "url": "https://github.com/codeoverflow-org/nodecg-io.git",
         "directory": "utils/nodecg-io-twitch-chat"
     },
-    "main": "extension/index",
     "scripts": {
         "build": "tsc -b",
         "watch": "tsc -b -w",


### PR DESCRIPTION
`nodecg-io-twitch-auth` has its main file directly in `index.{ts,js}`, which is the default. But it was set to `extension/index` which does not exist and is incorrect. This happend because we I've copied `package.json` from some other package and didn't notice this.
Previous node.js versions simply ignored this but v16 and newer report this as a [runtime deprecation](https://nodejs.org/api/deprecations.html#DEP0128).