### PR TITLE
elgato-light service for Keylights and light stripes.

### DIFF
--- a/nodecg-io-elgato-light/extension/elgatoLight.ts
+++ b/nodecg-io-elgato-light/extension/elgatoLight.ts
@@ -1,0 +1,91 @@
+import fetch from "node-fetch";
+import { LightData } from "./lightData";
+
+export type LightType = "KeyLight" | "LightStrip";
+
+export class ElgatoLight {
+    constructor(public readonly ipAddress: string, public readonly name?: string) {}
+
+    public async validate(): Promise<boolean> {
+        const response = await this.callGET();
+        return response.status === 200;
+    }
+
+    private buildPath(): string {
+        return `http://${this.ipAddress}:9123/elgato/lights`;
+    }
+
+    private async callGET() {
+        return fetch(this.buildPath(), {
+            method: "GET",
+        });
+    }
+
+    private async callPUT(body: LightData) {
+        return fetch(this.buildPath(), {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+        });
+    }
+
+    async isLightOn(): Promise<boolean> {
+        const response = await this.callGET();
+
+        if (response.status !== 200) {
+            return false;
+        }
+
+        const json = (await response.json()) as LightData;
+        return json.lights[0]?.on === 1;
+    }
+
+    async turnLightOn(): Promise<void> {
+        const lightData = ElgatoLight.createLightData(1);
+        await this.callPUT(lightData);
+    }
+
+    async turnLightOff(): Promise<void> {
+        const lightData = ElgatoLight.createLightData(0);
+        await this.callPUT(lightData);
+    }
+
+    async toggleLight(): Promise<void> {
+        const state = await this.isLightOn();
+        const lightData = ElgatoLight.createLightData(state ? 0 : 1);
+        await this.callPUT(lightData);
+    }
+
+    // TODO: Implement brightness getter and setter
+
+    protected static createLightData(
+        on?: number,
+        hue?: number,
+        saturation?: number,
+        brightness?: number,
+        temperature?: number,
+    ): LightData {
+        return {
+            numberOfLights: 1,
+            lights: [
+                {
+                    on: on,
+                    hue: hue,
+                    saturation: saturation,
+                    brightness: brightness,
+                    temperature: temperature,
+                },
+            ],
+        };
+    }
+}
+
+export class ElgatoKeyLight extends ElgatoLight {
+    // TODO: Implement temperature getter and setter
+}
+
+export class ElgatoLightStrip extends ElgatoLight {
+    // TODO: Implement hue and saturation getter and setter
+}

--- a/nodecg-io-elgato-light/extension/elgatoLight.ts
+++ b/nodecg-io-elgato-light/extension/elgatoLight.ts
@@ -1,5 +1,6 @@
 import fetch from "node-fetch";
 import { LightData } from "./lightData";
+import { Response } from "node-fetch";
 
 export type LightType = "KeyLight" | "LightStrip";
 
@@ -21,7 +22,7 @@ export class ElgatoLight {
         });
     }
 
-    private async callPUT(body: LightData) {
+    protected async callPUT(body: LightData): Promise<Response> {
         return fetch(this.buildPath(), {
             method: "PUT",
             headers: {
@@ -31,15 +32,27 @@ export class ElgatoLight {
         });
     }
 
-    async isLightOn(): Promise<boolean> {
+    protected async getLightData(): Promise<
+        | {
+              on?: number | undefined;
+              hue?: number | undefined;
+              saturation?: number | undefined;
+              brightness?: number | undefined;
+              temperature?: number | undefined;
+          }
+        | undefined
+    > {
         const response = await this.callGET();
 
         if (response.status !== 200) {
-            return false;
+            return undefined;
         }
 
-        const json = (await response.json()) as LightData;
-        return json.lights[0]?.on === 1;
+        return ((await response.json()) as LightData).lights[0];
+    }
+
+    async isLightOn(): Promise<boolean> {
+        return (await this.getLightData())?.on === 1;
     }
 
     async turnLightOn(): Promise<void> {
@@ -58,7 +71,15 @@ export class ElgatoLight {
         await this.callPUT(lightData);
     }
 
-    // TODO: Implement brightness getter and setter
+    async setBrightness(brightness: number): Promise<void> {
+        const sanitizedValue = Math.max(0, Math.min(100, brightness));
+        const lightData = ElgatoLight.createLightData(undefined, undefined, undefined, sanitizedValue);
+        await this.callPUT(lightData);
+    }
+
+    async getBrightness(): Promise<number> {
+        return (await this.getLightData())?.brightness || -1;
+    }
 
     protected static createLightData(
         on?: number,
@@ -83,9 +104,41 @@ export class ElgatoLight {
 }
 
 export class ElgatoKeyLight extends ElgatoLight {
-    // TODO: Implement temperature getter and setter
+    async setTemperature(temperature: number): Promise<void> {
+        const sanitizedValue = Math.max(143, Math.min(344, 487 - temperature));
+        const lightData = ElgatoLight.createLightData(undefined, undefined, undefined, undefined, sanitizedValue);
+        await this.callPUT(lightData);
+    }
+
+    async getTemperature(): Promise<number> {
+        const temperature = (await this.getLightData())?.temperature;
+
+        if (temperature) {
+            return 487 - temperature;
+        } else {
+            return -1;
+        }
+    }
 }
 
 export class ElgatoLightStrip extends ElgatoLight {
-    // TODO: Implement hue and saturation getter and setter
+    async setHue(hue: number): Promise<void> {
+        const sanitizedValue = Math.max(0, Math.min(360, hue));
+        const lightData = ElgatoLight.createLightData(undefined, sanitizedValue);
+        await this.callPUT(lightData);
+    }
+
+    async getHue(): Promise<number> {
+        return (await this.getLightData())?.hue || -1;
+    }
+
+    async setSaturation(saturation: number): Promise<void> {
+        const sanitizedValue = Math.max(0, Math.min(100, saturation));
+        const lightData = ElgatoLight.createLightData(undefined, undefined, sanitizedValue);
+        await this.callPUT(lightData);
+    }
+
+    async getSaturation(): Promise<number> {
+        return (await this.getLightData())?.saturation || -1;
+    }
 }

--- a/nodecg-io-elgato-light/extension/elgatoLight.ts
+++ b/nodecg-io-elgato-light/extension/elgatoLight.ts
@@ -1,5 +1,5 @@
 import fetch from "node-fetch";
-import { LightData } from "./lightData";
+import { LightData, LightValues } from "./lightData";
 import { Response } from "node-fetch";
 
 export type LightType = "KeyLight" | "LightStrip";
@@ -48,16 +48,7 @@ export abstract class ElgatoLight {
      * Helper method to call HTTP GET on the elgato light and ease the interpretation of the response.
      * @returns the response of the elgato light or undefined
      */
-    protected async getLightData(): Promise<
-        | {
-              on?: number | undefined;
-              hue?: number | undefined;
-              saturation?: number | undefined;
-              brightness?: number | undefined;
-              temperature?: number | undefined;
-          }
-        | undefined
-    > {
+    protected async getLightData(): Promise<LightValues | undefined> {
         const response = await this.callGET();
 
         if (response.status !== 200) {
@@ -79,7 +70,7 @@ export abstract class ElgatoLight {
      * Switches the elgato light on.
      */
     async turnLightOn(): Promise<void> {
-        const lightData = ElgatoLight.createLightData(1);
+        const lightData = ElgatoLight.createLightData({ on: 1 });
         await this.callPUT(lightData);
     }
 
@@ -87,7 +78,7 @@ export abstract class ElgatoLight {
      * Switches the elgato light off.
      */
     async turnLightOff(): Promise<void> {
-        const lightData = ElgatoLight.createLightData(0);
+        const lightData = ElgatoLight.createLightData({ on: 0 });
         await this.callPUT(lightData);
     }
 
@@ -96,7 +87,7 @@ export abstract class ElgatoLight {
      */
     async toggleLight(): Promise<void> {
         const state = await this.isLightOn();
-        const lightData = ElgatoLight.createLightData(state ? 0 : 1);
+        const lightData = ElgatoLight.createLightData({ on: state ? 0 : 1 });
         await this.callPUT(lightData);
     }
 
@@ -106,7 +97,7 @@ export abstract class ElgatoLight {
      */
     async setBrightness(brightness: number): Promise<void> {
         const sanitizedValue = Math.max(0, Math.min(100, brightness));
-        const lightData = ElgatoLight.createLightData(undefined, undefined, undefined, sanitizedValue);
+        const lightData = ElgatoLight.createLightData({ brightness: sanitizedValue });
         await this.callPUT(lightData);
     }
 
@@ -118,24 +109,10 @@ export abstract class ElgatoLight {
         return (await this.getLightData())?.brightness ?? -1;
     }
 
-    protected static createLightData(
-        on?: number,
-        hue?: number,
-        saturation?: number,
-        brightness?: number,
-        temperature?: number,
-    ): LightData {
+    protected static createLightData(data: LightValues): LightData {
         return {
             numberOfLights: 1,
-            lights: [
-                {
-                    on: on,
-                    hue: hue,
-                    saturation: saturation,
-                    brightness: brightness,
-                    temperature: temperature,
-                },
-            ],
+            lights: [data],
         };
     }
 }
@@ -152,7 +129,7 @@ export class ElgatoKeyLight extends ElgatoLight {
      */
     async setTemperature(temperature: number): Promise<void> {
         const sanitizedValue = Math.max(143, Math.min(344, ElgatoKeyLight.temperatureFactor / temperature));
-        const lightData = ElgatoLight.createLightData(undefined, undefined, undefined, undefined, sanitizedValue);
+        const lightData = ElgatoLight.createLightData({ temperature: sanitizedValue });
         await this.callPUT(lightData);
     }
 
@@ -181,7 +158,7 @@ export class ElgatoLightStrip extends ElgatoLight {
      */
     async setHue(hue: number): Promise<void> {
         const sanitizedValue = Math.max(0, Math.min(360, hue));
-        const lightData = ElgatoLight.createLightData(undefined, sanitizedValue);
+        const lightData = ElgatoLight.createLightData({ hue: sanitizedValue });
         await this.callPUT(lightData);
     }
 
@@ -199,7 +176,7 @@ export class ElgatoLightStrip extends ElgatoLight {
      */
     async setSaturation(saturation: number): Promise<void> {
         const sanitizedValue = Math.max(0, Math.min(100, saturation));
-        const lightData = ElgatoLight.createLightData(undefined, undefined, sanitizedValue);
+        const lightData = ElgatoLight.createLightData({ saturation: sanitizedValue });
         await this.callPUT(lightData);
     }
 

--- a/nodecg-io-elgato-light/extension/elgatoLight.ts
+++ b/nodecg-io-elgato-light/extension/elgatoLight.ts
@@ -4,9 +4,16 @@ import { Response } from "node-fetch";
 
 export type LightType = "KeyLight" | "LightStrip";
 
-export class ElgatoLight {
+/**
+ * Represents an elgato light. Is never directly created but has subclasses for the different light types.
+ */
+export abstract class ElgatoLight {
     constructor(public readonly ipAddress: string, public readonly name?: string) {}
 
+    /**
+     * Tests if the elgato light is reachable.
+     * @returns true if the test call returned success. false, otherwise
+     */
     public async validate(): Promise<boolean> {
         const response = await this.callGET();
         return response.status === 200;
@@ -22,6 +29,11 @@ export class ElgatoLight {
         });
     }
 
+    /**
+     * Helper method to call HTTP PUT on the elgato light.
+     * @param body json data to send to the elgato light
+     * @returns the response of the elgato light
+     */
     protected async callPUT(body: LightData): Promise<Response> {
         return fetch(this.buildPath(), {
             method: "PUT",
@@ -32,6 +44,10 @@ export class ElgatoLight {
         });
     }
 
+    /**
+     * Helper method to call HTTP GET on the elgato light and ease the interpretation of the response.
+     * @returns the response of the elgato light or undefined
+     */
     protected async getLightData(): Promise<
         | {
               on?: number | undefined;
@@ -51,34 +67,55 @@ export class ElgatoLight {
         return ((await response.json()) as LightData).lights[0];
     }
 
+    /**
+     *
+     * @returns Returns true if the light is switched on.
+     */
     async isLightOn(): Promise<boolean> {
         return (await this.getLightData())?.on === 1;
     }
 
+    /**
+     * Switches the elgato light on.
+     */
     async turnLightOn(): Promise<void> {
         const lightData = ElgatoLight.createLightData(1);
         await this.callPUT(lightData);
     }
 
+    /**
+     * Switches the elgato light off.
+     */
     async turnLightOff(): Promise<void> {
         const lightData = ElgatoLight.createLightData(0);
         await this.callPUT(lightData);
     }
 
+    /**
+     * Toggles the on/off state of the elgato light.
+     */
     async toggleLight(): Promise<void> {
         const state = await this.isLightOn();
         const lightData = ElgatoLight.createLightData(state ? 0 : 1);
         await this.callPUT(lightData);
     }
 
+    /**
+     * Sets the brightness of the elgato light.
+     * @param brightness a value between 0.0 and 100.0
+     */
     async setBrightness(brightness: number): Promise<void> {
         const sanitizedValue = Math.max(0, Math.min(100, brightness));
         const lightData = ElgatoLight.createLightData(undefined, undefined, undefined, sanitizedValue);
         await this.callPUT(lightData);
     }
 
+    /**
+     * Returns the brightness of the elgato light.
+     * @returns a value between 0.0 and 100.0 or -1 if an error occurred
+     */
     async getBrightness(): Promise<number> {
-        return (await this.getLightData())?.brightness || -1;
+        return (await this.getLightData())?.brightness ?? -1;
     }
 
     protected static createLightData(
@@ -103,42 +140,74 @@ export class ElgatoLight {
     }
 }
 
+/**
+ * Represents an elgato key light, e.g., the key light or key light air.
+ */
 export class ElgatoKeyLight extends ElgatoLight {
+    private static readonly temperatureFactor = 1000000;
+
+    /**
+     * Sets the temperature of the elgato key light.
+     * @param temperature a value between 2900 and 7000 kelvin
+     */
     async setTemperature(temperature: number): Promise<void> {
-        const sanitizedValue = Math.max(143, Math.min(344, 487 - temperature));
+        const sanitizedValue = Math.max(143, Math.min(344, ElgatoKeyLight.temperatureFactor / temperature));
         const lightData = ElgatoLight.createLightData(undefined, undefined, undefined, undefined, sanitizedValue);
         await this.callPUT(lightData);
     }
 
+    /**
+     * Returns the temperature of the elgato key light.
+     * @returns a value between 2900 and 7000 or -1 if an error occurred
+     */
     async getTemperature(): Promise<number> {
         const temperature = (await this.getLightData())?.temperature;
 
-        if (temperature) {
-            return 487 - temperature;
+        if (temperature !== undefined) {
+            return ElgatoKeyLight.temperatureFactor / temperature;
         } else {
             return -1;
         }
     }
 }
 
+/**
+ * Represents an elgato light stripe of any length.
+ */
 export class ElgatoLightStrip extends ElgatoLight {
+    /**
+     * Sets the hue of the elgato light stripe.
+     * @param hue a value between 0.0 and 360.0
+     */
     async setHue(hue: number): Promise<void> {
         const sanitizedValue = Math.max(0, Math.min(360, hue));
         const lightData = ElgatoLight.createLightData(undefined, sanitizedValue);
         await this.callPUT(lightData);
     }
 
+    /**
+     * Returns the hue of the elgato light stripe.
+     * @returns a value between 0.0 and 360.0 or -1 if an error occurred
+     */
     async getHue(): Promise<number> {
-        return (await this.getLightData())?.hue || -1;
+        return (await this.getLightData())?.hue ?? -1;
     }
 
+    /**
+     * Sets the saturation of the elgato light stripe.
+     * @param saturation a value between 0.0 and 100.0
+     */
     async setSaturation(saturation: number): Promise<void> {
         const sanitizedValue = Math.max(0, Math.min(100, saturation));
         const lightData = ElgatoLight.createLightData(undefined, undefined, sanitizedValue);
         await this.callPUT(lightData);
     }
 
+    /**
+     * Returns the saturation of the elgato light stripe.
+     * @returns a value between 0.0 and 100.0 or -1 if an error occurred
+     */
     async getSaturation(): Promise<number> {
-        return (await this.getLightData())?.saturation || -1;
+        return (await this.getLightData())?.saturation ?? -1;
     }
 }

--- a/nodecg-io-elgato-light/extension/elgatoLightClient.ts
+++ b/nodecg-io-elgato-light/extension/elgatoLightClient.ts
@@ -11,6 +11,9 @@ export interface ElgatoLightConfig {
     ];
 }
 
+/**
+ * The elgato light client is used to access all configured elgato lights. Just use the get methods.
+ */
 export class ElgatoLightClient {
     private lights: ElgatoLight[] = [];
 
@@ -26,6 +29,10 @@ export class ElgatoLightClient {
         }
     }
 
+    /**
+     * Tries to reach all elgato lights contained in the config provided in the constructor.
+     * @returns  an array of IP addresses of elgato lights that where configured but not reachable
+     */
     async identifyNotReachableLights(): Promise<Array<string>> {
         const notReachableLights = [];
 
@@ -38,14 +45,28 @@ export class ElgatoLightClient {
         return notReachableLights;
     }
 
+    /**
+     * Returns all configured elgato lights.
+     * @returns an array of elgato lights (elgato key lights or light stripes)
+     */
     getAllLights(): ElgatoLight[] {
         return [...this.lights];
     }
 
+    /**
+     * Returns the specified elgato light (elgato key light or light stripe)
+     * @param name the name of the elgato light specified in the nodecg-io config
+     * @returns the specified elgato light instance or undefined if the name was not found
+     */
     getLightByName(name: string): ElgatoLight | undefined {
         return this.lights.find((light) => light.name === name);
     }
 
+    /**
+     * Returns the specified elgato light (elgato key light or light stripe)
+     * @param ipAddress the ip address of the elgato light as specified in the nodecg-io config
+     * @returns the specified elgato light instance or undefined if the address was not found
+     */
     getLightByAddress(ipAddress: string): ElgatoLight | undefined {
         return this.lights.find((light) => light.ipAddress === ipAddress);
     }

--- a/nodecg-io-elgato-light/extension/elgatoLightClient.ts
+++ b/nodecg-io-elgato-light/extension/elgatoLightClient.ts
@@ -15,14 +15,14 @@ export class ElgatoLightClient {
     private lights: ElgatoLight[] = [];
 
     constructor(private config: ElgatoLightConfig) {
-        this.lights = this.config.lights.map((light) => this.createLight(light.ipAddress, light.lightType));
+        this.lights = this.config.lights.map((light) => this.createLight(light.ipAddress, light.lightType, light.name));
     }
 
-    private createLight(ipAddress: string, lightType: LightType) {
+    private createLight(ipAddress: string, lightType: LightType, name?: string) {
         if (lightType === "KeyLight") {
-            return new ElgatoKeyLight(ipAddress);
+            return new ElgatoKeyLight(ipAddress, name);
         } else {
-            return new ElgatoLightStrip(ipAddress);
+            return new ElgatoLightStrip(ipAddress, name);
         }
     }
 

--- a/nodecg-io-elgato-light/extension/elgatoLightClient.ts
+++ b/nodecg-io-elgato-light/extension/elgatoLightClient.ts
@@ -1,12 +1,91 @@
-import { ElgatoLightConfig } from "./index";
+import fetch from "node-fetch";
+import { LightData } from "./lightData";
+
+export type LightType = "KeyLight" | "LightStrip";
 
 export class ElgatoLightClient {
-    constructor(_: ElgatoLightConfig) {
-        // TODO: Implement
+    constructor(private ipAddress: string) {}
+
+    public async validate(): Promise<boolean> {
+        const response = await this.callGET();
+        return response.status === 200;
     }
 
-    static createClient(config: ElgatoLightConfig): ElgatoLightClient {
-        // TODO: Implement
-        return new ElgatoLightClient(config);
+    private buildPath(): string {
+        return `http://${this.ipAddress}:9123/elgato/lights`;
     }
+
+    private async callGET() {
+        return fetch(this.buildPath(), {
+            method: "GET",
+        });
+    }
+
+    private async callPUT(body: LightData) {
+        return fetch(this.buildPath(), {
+            method: "PUT",
+            headers: {
+                "Content-Type": "application/json",
+            },
+            body: JSON.stringify(body),
+        });
+    }
+
+    async isLightOn(): Promise<boolean> {
+        const response = await this.callGET();
+
+        if (response.status !== 200) {
+            return false;
+        }
+
+        const json = (await response.json()) as LightData;
+        return json.lights[0]?.on === 1;
+    }
+
+    async turnLightOn(): Promise<void> {
+        const lightData = ElgatoLightClient.createLightData(1);
+        await this.callPUT(lightData);
+    }
+
+    async turnLightOff(): Promise<void> {
+        const lightData = ElgatoLightClient.createLightData(0);
+        await this.callPUT(lightData);
+    }
+
+    async toggleLight(): Promise<void> {
+        const state = await this.isLightOn();
+        const lightData = ElgatoLightClient.createLightData(state ? 0 : 1);
+        await this.callPUT(lightData);
+    }
+
+    // TODO: Implement brightness getter and setter
+
+    protected static createLightData(
+        on?: number,
+        hue?: number,
+        saturation?: number,
+        brightness?: number,
+        temperature?: number,
+    ): LightData {
+        return {
+            numberOfLights: 1,
+            lights: [
+                {
+                    on: on,
+                    hue: hue,
+                    saturation: saturation,
+                    brightness: brightness,
+                    temperature: temperature,
+                },
+            ],
+        };
+    }
+}
+
+export class ElgatoKeyLightClient extends ElgatoLightClient {
+    // TODO: Implement temperature getter and setter
+}
+
+export class ElgatoLightStripClient extends ElgatoLightClient {
+    // TODO: Implement hue and saturation getter and setter
 }

--- a/nodecg-io-elgato-light/extension/elgatoLightClient.ts
+++ b/nodecg-io-elgato-light/extension/elgatoLightClient.ts
@@ -31,7 +31,7 @@ export class ElgatoLightClient {
 
     /**
      * Tries to reach all elgato lights contained in the config provided in the constructor.
-     * @returns  an array of IP addresses of elgato lights that where configured but not reachable
+     * @returns an array of IP addresses of elgato lights that where configured but not reachable
      */
     async identifyNotReachableLights(): Promise<Array<string>> {
         const notReachableLights = [];

--- a/nodecg-io-elgato-light/extension/elgatoLightClient.ts
+++ b/nodecg-io-elgato-light/extension/elgatoLightClient.ts
@@ -1,0 +1,12 @@
+import { ElgatoLightConfig } from "./index";
+
+export class ElgatoLightClient {
+    constructor(_: ElgatoLightConfig) {
+        // TODO: Implement
+    }
+
+    static createClient(config: ElgatoLightConfig): ElgatoLightClient {
+        // TODO: Implement
+        return new ElgatoLightClient(config);
+    }
+}

--- a/nodecg-io-elgato-light/extension/index.ts
+++ b/nodecg-io-elgato-light/extension/index.ts
@@ -1,0 +1,31 @@
+import { NodeCG } from "nodecg/types/server";
+import { Result, emptySuccess, success, ServiceBundle } from "nodecg-io-core";
+import { ElgatoLightClient } from "./elgatoLightClient";
+
+export interface ElgatoLightConfig {
+    placeholder: string; // TODO: Change (IP and type)
+}
+
+export { ElgatoLightClient } from "./elgatoLightClient";
+
+module.exports = (nodecg: NodeCG) => {
+    new TemplateService(nodecg, "elgato-light", __dirname, "../schema.json").register();
+};
+
+class TemplateService extends ServiceBundle<ElgatoLightConfig, ElgatoLightClient> {
+    async validateConfig(_: ElgatoLightConfig): Promise<Result<void>> {
+        // TODO: Implement by calling the registered IPs
+        return emptySuccess();
+    }
+
+    async createClient(config: ElgatoLightConfig): Promise<Result<ElgatoLightClient>> {
+        // TODO: Implement
+        const client = ElgatoLightClient.createClient(config);
+        this.nodecg.log.info("Successfully created Elgato light client.");
+        return success(client);
+    }
+
+    stopClient(_: ElgatoLightClient): void {
+        this.nodecg.log.info("Successfully stopped Elgato light client.");
+    }
+}

--- a/nodecg-io-elgato-light/extension/index.ts
+++ b/nodecg-io-elgato-light/extension/index.ts
@@ -15,9 +15,8 @@ class ElgatoLightService extends ServiceBundle<ElgatoLightConfig, ElgatoLightCli
         if (notReachableLights.length === 0) {
             return emptySuccess();
         }
-        {
-            return error(`Unable to connect to the lights with the following IPs: ${notReachableLights.join(", ")}`);
-        }
+
+        return error(`Unable to connect to the lights with the following IPs: ${notReachableLights.join(", ")}`);
     }
 
     async createClient(config: ElgatoLightConfig): Promise<Result<ElgatoLightClient>> {

--- a/nodecg-io-elgato-light/extension/lightData.ts
+++ b/nodecg-io-elgato-light/extension/lightData.ts
@@ -3,13 +3,13 @@
  */
 export interface LightData {
     numberOfLights: 1;
-    lights: [
-        {
-            on?: number;
-            hue?: number;
-            saturation?: number;
-            brightness?: number;
-            temperature?: number;
-        },
-    ];
+    lights: LightValues[];
+}
+
+export interface LightValues {
+    on?: number;
+    hue?: number;
+    saturation?: number;
+    brightness?: number;
+    temperature?: number;
 }

--- a/nodecg-io-elgato-light/extension/lightData.ts
+++ b/nodecg-io-elgato-light/extension/lightData.ts
@@ -1,0 +1,15 @@
+/**
+ * DTO for elgato light http communication.
+ */
+export interface LightData {
+    numberOfLights: 1;
+    lights: [
+        {
+            on?: number;
+            hue?: number;
+            saturation?: number;
+            brightness?: number;
+            temperature?: number;
+        },
+    ];
+}

--- a/nodecg-io-elgato-light/package.json
+++ b/nodecg-io-elgato-light/package.json
@@ -1,0 +1,46 @@
+{
+    "name": "nodecg-io-elgato-light",
+    "version": "0.2.0",
+    "description": "Control your Elgato lights, e.g., key lights and light stripes.",
+    "homepage": "https://nodecg.io/RELEASE/samples/elgato-light",
+    "author": {
+        "name": "CodeOverflow team",
+        "url": "https://github.com/codeoverflow-org"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-elgato-light"
+    },
+    "files": [
+        "**/*.js",
+        "**/*.js.map",
+        "**/*.d.ts",
+        "*.json"
+    ],
+    "main": "extension/index",
+    "scripts": {
+        "build": "tsc -b",
+        "watch": "tsc -b -w",
+        "clean": "tsc -b --clean"
+    },
+    "keywords": [
+        "nodecg-io",
+        "nodecg-bundle"
+    ],
+    "nodecg": {
+        "compatibleRange": "^1.1.1",
+        "bundleDependencies": {
+            "nodecg-io-core": "^0.2.0"
+        }
+    },
+    "license": "MIT",
+    "devDependencies": {
+        "@types/node": "^15.0.2",
+        "nodecg": "^1.8.1",
+        "typescript": "^4.2.4"
+    },
+    "dependencies": {
+        "nodecg-io-core": "^0.2.0"
+    }
+}

--- a/nodecg-io-elgato-light/package.json
+++ b/nodecg-io-elgato-light/package.json
@@ -41,6 +41,8 @@
         "typescript": "^4.2.4"
     },
     "dependencies": {
+        "@types/node-fetch": "^2.5.10",
+        "node-fetch": "^2.6.1",
         "nodecg-io-core": "^0.2.0"
     }
 }

--- a/nodecg-io-elgato-light/package.json
+++ b/nodecg-io-elgato-light/package.json
@@ -1,7 +1,7 @@
 {
     "name": "nodecg-io-elgato-light",
     "version": "0.2.0",
-    "description": "Control your Elgato lights, e.g., key lights and light stripes.",
+    "description": "Control your Elgato lights, e.g. key lights and light stripes.",
     "homepage": "https://nodecg.io/RELEASE/samples/elgato-light",
     "author": {
         "name": "CodeOverflow team",

--- a/nodecg-io-elgato-light/schema.json
+++ b/nodecg-io-elgato-light/schema.json
@@ -17,6 +17,10 @@
                         "type": "string",
                         "enum": ["KeyLight", "LightStrip"],
                         "description": "The type of light. Available types: 'KeyLight', 'LightStrip'."
+                    },
+                    "name": {
+                        "type": "string",
+                        "description": "An optional name for the light that can be used to identify it."
                     }
                 },
                 "required": ["ipAddress", "lightType"]

--- a/nodecg-io-elgato-light/schema.json
+++ b/nodecg-io-elgato-light/schema.json
@@ -3,10 +3,25 @@
     "type": "object",
     "additionalProperties": false,
     "properties": {
-        "placeholder": {
-            "type": "string",
-            "description": "A template placeholder."
+        "lights": {
+            "type": "array",
+            "description": "A list of elgato lights you want to control.",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "ipAddress": {
+                        "type": "string",
+                        "description": "The IP-Address of a elgato light in your local network."
+                    },
+                    "lightType": {
+                        "type": "string",
+                        "enum": ["KeyLight", "LightStrip"],
+                        "description": "The type of light. Available types: 'KeyLight', 'LightStrip'."
+                    }
+                },
+                "required": ["ipAddress", "lightType"]
+            }
         }
     },
-    "required": ["placeholder"]
+    "required": ["lights"]
 }

--- a/nodecg-io-elgato-light/schema.json
+++ b/nodecg-io-elgato-light/schema.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+        "placeholder": {
+            "type": "string",
+            "description": "A template placeholder."
+        }
+    },
+    "required": ["placeholder"]
+}

--- a/nodecg-io-elgato-light/tsconfig.json
+++ b/nodecg-io-elgato-light/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../tsconfig.common.json"
+}

--- a/samples/elgato-light/extension/index.ts
+++ b/samples/elgato-light/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ElgatoLightClient } from "nodecg-io-elgato-light";
+import { ElgatoKeyLight, ElgatoLightClient, ElgatoLightStrip } from "nodecg-io-elgato-light";
 import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
@@ -7,11 +7,19 @@ module.exports = function (nodecg: NodeCG) {
 
     const elgatoLightClient = requireService<ElgatoLightClient>(nodecg, "elgato-light");
 
-    elgatoLightClient?.onAvailable((client) => {
+    elgatoLightClient?.onAvailable(async (client) => {
         nodecg.log.info("Elgato light service available.");
 
+        //client.getAllLights().forEach((light) => light.toggleLight());
+        //const brightness = await((client.getLightByName("ShelfStrip")) as ElgatoLightStrip).getHue();
+        //nodecg.log.info(brightness);
+
+        //(client.getLightByName("ShelfStrip") as ElgatoLightStrip).setHue(69);
+        //(client.getLightByName("ShelfStrip") as ElgatoLightStrip).setSaturation(50);
+
+        // TODO: Add 10^6/kelvin calculation
+        // TODO: Add typescript doc
         // TODO: Create a more comprehensive example
-        client.getAllLights().forEach((light) => light.toggleLight());
     });
 
     elgatoLightClient?.onUnavailable(() => {

--- a/samples/elgato-light/extension/index.ts
+++ b/samples/elgato-light/extension/index.ts
@@ -5,15 +5,16 @@ import { requireService } from "nodecg-io-core";
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for the Elgato light service started.");
 
-    const elgatoLightClient = requireService<ElgatoLightClient>(nodecg, "elgato-light");
+    const elgatoLightClient = requireService<Array<ElgatoLightClient>>(nodecg, "elgato-light");
 
-    elgatoLightClient?.onAvailable((_) => {
+    elgatoLightClient?.onAvailable((clients) => {
         nodecg.log.info("Elgato light service available.");
-        // TODO: Implement
+
+        // TODO: Create a more comprehensive example
+        clients.forEach((client) => client.toggleLight());
     });
 
     elgatoLightClient?.onUnavailable(() => {
         nodecg.log.info("Elgato light service unavailable.");
-        // TODO: Implement
     });
 };

--- a/samples/elgato-light/extension/index.ts
+++ b/samples/elgato-light/extension/index.ts
@@ -1,5 +1,5 @@
 import { NodeCG } from "nodecg/types/server";
-import { ElgatoKeyLight, ElgatoLightClient, ElgatoLightStrip } from "nodecg-io-elgato-light";
+import { ElgatoLightClient } from "nodecg-io-elgato-light";
 import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
@@ -10,16 +10,15 @@ module.exports = function (nodecg: NodeCG) {
     elgatoLightClient?.onAvailable(async (client) => {
         nodecg.log.info("Elgato light service available.");
 
-        //client.getAllLights().forEach((light) => light.toggleLight());
-        //const brightness = await((client.getLightByName("ShelfStrip")) as ElgatoLightStrip).getHue();
-        //nodecg.log.info(brightness);
+        // Blinky Blinky
+        const interval = setInterval(() => client.getAllLights().forEach((light) => light.toggleLight()), 500);
+        setTimeout(() => clearInterval(interval), 3100);
 
-        //(client.getLightByName("ShelfStrip") as ElgatoLightStrip).setHue(69);
-        //(client.getLightByName("ShelfStrip") as ElgatoLightStrip).setSaturation(50);
-
-        // TODO: Add 10^6/kelvin calculation
-        // TODO: Add typescript doc
-        // TODO: Create a more comprehensive example
+        // Get some data
+        client.getAllLights().forEach(async (light) => {
+            const brightness = await light.getBrightness();
+            nodecg.log.info(`Elgato light (${light.ipAddress}), brightness: ${brightness}`);
+        });
     });
 
     elgatoLightClient?.onUnavailable(() => {

--- a/samples/elgato-light/extension/index.ts
+++ b/samples/elgato-light/extension/index.ts
@@ -1,0 +1,19 @@
+import { NodeCG } from "nodecg/types/server";
+import { ElgatoLightClient } from "nodecg-io-elgato-light";
+import { requireService } from "nodecg-io-core";
+
+module.exports = function (nodecg: NodeCG) {
+    nodecg.log.info("Sample bundle for the Elgato light service started.");
+
+    const elgatoLightClient = requireService<ElgatoLightClient>(nodecg, "elgato-light");
+
+    elgatoLightClient?.onAvailable((_) => {
+        nodecg.log.info("Elgato light service available.");
+        // TODO: Implement
+    });
+
+    elgatoLightClient?.onUnavailable(() => {
+        nodecg.log.info("Elgato light service unavailable.");
+        // TODO: Implement
+    });
+};

--- a/samples/elgato-light/extension/index.ts
+++ b/samples/elgato-light/extension/index.ts
@@ -5,13 +5,13 @@ import { requireService } from "nodecg-io-core";
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for the Elgato light service started.");
 
-    const elgatoLightClient = requireService<Array<ElgatoLightClient>>(nodecg, "elgato-light");
+    const elgatoLightClient = requireService<ElgatoLightClient>(nodecg, "elgato-light");
 
-    elgatoLightClient?.onAvailable((clients) => {
+    elgatoLightClient?.onAvailable((client) => {
         nodecg.log.info("Elgato light service available.");
 
         // TODO: Create a more comprehensive example
-        clients.forEach((client) => client.toggleLight());
+        client.getAllLights().forEach((light) => light.toggleLight());
     });
 
     elgatoLightClient?.onUnavailable(() => {

--- a/samples/elgato-light/package.json
+++ b/samples/elgato-light/package.json
@@ -1,0 +1,24 @@
+{
+    "name": "elgato-light",
+    "version": "0.2.0",
+    "private": true,
+    "nodecg": {
+        "compatibleRange": "^1.1.1",
+        "bundleDependencies": {
+            "nodecg-io-elgato-light": "^0.2.0"
+        }
+    },
+    "scripts": {
+        "build": "tsc -b",
+        "watch": "tsc -b -w",
+        "clean": "tsc -b --clean"
+    },
+    "license": "MIT",
+    "dependencies": {
+        "@types/node": "^15.0.2",
+        "nodecg": "^1.8.1",
+        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-elgato-light": "^0.2.0",
+        "typescript": "^4.2.4"
+    }
+}

--- a/samples/elgato-light/tsconfig.json
+++ b/samples/elgato-light/tsconfig.json
@@ -1,0 +1,3 @@
+{
+    "extends": "../../tsconfig.common.json"
+}


### PR DESCRIPTION
Closes #118. Does not use any external elgato light npm library because the're are all not up to date and we only need two HTTP requests...