### PR TITLE
Add config presets to core and dashboard. Add presets for midi-input

### DIFF
--- a/nodecg-io-core/dashboard/crypto.ts
+++ b/nodecg-io-core/dashboard/crypto.ts
@@ -39,11 +39,11 @@ class Config extends EventEmitter {
 export const config = new Config();
 
 // Update the decrypted copy of the data once the encrypted version changes (if pw available).
-// This ensures that the decrypted data is kept uptodate.
+// This ensures that the decrypted data is kept up-to-date.
 encryptedData.on("change", updateDecryptedData);
 
 /**
- * Sets the passed passwort to be used by the crypto module.
+ * Sets the passed password to be used by the crypto module.
  * Will try to decrypt decrypted data to tell whether the password is correct,
  * if it is wrong the internal password will be set to undefined.
  * Returns whether the password is correct.

--- a/nodecg-io-core/dashboard/main.ts
+++ b/nodecg-io-core/dashboard/main.ts
@@ -6,6 +6,7 @@ export {
     createInstance,
     saveInstanceConfig,
     deleteInstance,
+    selectInstanceConfigPreset,
 } from "./serviceInstance";
 export {
     renderBundleDeps,

--- a/nodecg-io-core/dashboard/panel.html
+++ b/nodecg-io-core/dashboard/panel.html
@@ -42,6 +42,11 @@
                         <select id="selectService" class="flex-fill"></select>
                     </div>
 
+                    <div id="instancePreset" class="margins flex hidden">
+                        <label for="selectPreset">Load config preset: </label>
+                        <select id="selectPreset" class="flex-fill" onchange="selectInstanceConfigPreset();"></select>
+                    </div>
+
                     <div id="instanceNameField" class="margins flex hidden">
                         <label for="inputInstanceName">Instance Name: </label>
                         <input id="inputInstanceName" class="flex-fill" type="text" />

--- a/nodecg-io-core/dashboard/styles.css
+++ b/nodecg-io-core/dashboard/styles.css
@@ -6,6 +6,7 @@
 #bundleControlDiv {
     display: grid;
     grid-template-columns: auto 1fr;
+    width: 96.5%;
 }
 
 .flex {
@@ -14,6 +15,7 @@
 
 .flex-fill {
     flex: 1;
+    width: 100%;
 }
 
 .flex-column {
@@ -31,4 +33,8 @@
 .hidden {
     display: none;
     visibility: hidden;
+}
+
+select {
+    text-overflow: ellipsis;
 }

--- a/nodecg-io-core/extension/service.ts
+++ b/nodecg-io-core/extension/service.ts
@@ -38,6 +38,13 @@ export interface Service<R, C> {
     readonly defaultConfig?: R;
 
     /**
+     * Config presets that the user can choose to load as their config.
+     * Useful for e.g. detected devices with everything already filled in for that specific device.
+     * Can also be used to show the user multiple different authentication methods or similar.
+     */
+    presets?: ObjectMap<R>;
+
+    /**
      * This function validates the passed config after it has been validated against the json schema (if applicable).
      * Should make deeper checks like checking validity of auth tokens.
      * @param config the config which should be validated.

--- a/nodecg-io-core/extension/serviceBundle.ts
+++ b/nodecg-io-core/extension/serviceBundle.ts
@@ -26,6 +26,13 @@ export abstract class ServiceBundle<R, C> implements Service<R, C> {
     public defaultConfig?: R;
 
     /**
+     * Config presets that the user can choose to load as their config.
+     * Useful for e.g. detected devices with everything already filled in for that specific device.
+     * Can also be used to show the user multiple different authentication methods or similar.
+     */
+    public presets?: ObjectMap<R>;
+
+    /**
      * This constructor creates the service and gets the nodecg-io-core
      * @param nodecg the current NodeCG instance
      * @param serviceName the name of the service in all-lowercase-and-with-hyphen

--- a/nodecg-io-midi-input/extension/index.ts
+++ b/nodecg-io-midi-input/extension/index.ts
@@ -13,6 +13,8 @@ module.exports = (nodecg: NodeCG) => {
 };
 
 class MidiService extends ServiceBundle<MidiInputServiceConfig, MidiInputServiceClient> {
+    presets = Object.fromEntries(easymidi.getInputs().map((device) => [device, { device }]));
+
     async validateConfig(config: MidiInputServiceConfig): Promise<Result<void>> {
         const devices: Array<string> = new Array<string>();
 

--- a/tsconfig.common.json
+++ b/tsconfig.common.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         // Output related
-        "target": "es2017",
+        "target": "es2019",
         "importHelpers": true,
         "sourceMap": true,
         "declaration": true,
@@ -10,7 +10,7 @@
         "moduleResolution": "node",
 
         // Type checking
-        "lib": ["es2017"],
+        "lib": ["es2019"],
         "alwaysStrict": true,
         "forceConsistentCasingInFileNames": true,
         "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Closes #109 

Currently only `midi-input` has presets. Other services still need to be done before this PR is merged.

How it works:

https://user-images.githubusercontent.com/30466471/131215363-a680621f-1835-46e8-888f-fdfcf40f0047.mp4

The preset drop-down is only visible if the service provides presets and is hidden for services that don't provide any otherwise the UI would be too cluttered.