### PR TITLE
Implement `localhost` default address for IntelliJ service config

### DIFF
--- a/nodecg-io-intellij/extension/index.ts
+++ b/nodecg-io-intellij/extension/index.ts
@@ -3,7 +3,7 @@ import { Result, emptySuccess, success, ServiceBundle } from "nodecg-io-core";
 import { IntelliJ } from "./intellij";
 
 interface IntelliJServiceConfig {
-    address: string;
+    address?: string;
 }
 
 export type IntelliJServiceClient = IntelliJ;
@@ -14,8 +14,7 @@ module.exports = (nodecg: NodeCG) => {
 
 class IntellijService extends ServiceBundle<IntelliJServiceConfig, IntelliJServiceClient> {
     async validateConfig(config: IntelliJServiceConfig): Promise<Result<void>> {
-        const address = config.address;
-        const ij = new IntelliJ(address);
+        const ij = new IntelliJ(config.address);
         await ij.rawRequest("available_methods", {});
         return emptySuccess();
     }

--- a/nodecg-io-intellij/extension/index.ts
+++ b/nodecg-io-intellij/extension/index.ts
@@ -22,7 +22,7 @@ class IntellijService extends ServiceBundle<IntelliJServiceConfig, IntelliJServi
     async createClient(config: IntelliJServiceConfig): Promise<Result<IntelliJServiceClient>> {
         const ij = new IntelliJ(config.address);
         await ij.rawRequest("available_methods", {});
-        this.nodecg.log.info(`Successfully connected to IntelliJ at ${config.address}.`);
+        this.nodecg.log.info(`Successfully connected to IntelliJ at ${ij.address}.`);
         return success(ij);
     }
 

--- a/nodecg-io-intellij/extension/intellij.ts
+++ b/nodecg-io-intellij/extension/intellij.ts
@@ -1,7 +1,7 @@
 import fetch from "node-fetch";
 
 export class IntelliJ {
-    private readonly address: string;
+    readonly address: string;
 
     readonly pluginManager: PluginManager;
     readonly localHistory: LocalHistory;

--- a/nodecg-io-intellij/extension/intellij.ts
+++ b/nodecg-io-intellij/extension/intellij.ts
@@ -6,12 +6,12 @@ export class IntelliJ {
     readonly pluginManager: PluginManager;
     readonly localHistory: LocalHistory;
 
-    public constructor(address: string) {
-        this.address = address;
-        if (address.includes("://")) {
+    constructor(address?: string) {
+        // Check if protocol is defined and default to http if missing
+        if (address?.includes("://")) {
             this.address = address;
         } else {
-            this.address = "http://" + address;
+            this.address = `http://${address ?? "127.0.0.1:19524"}`;
         }
 
         this.pluginManager = new PluginManager(this);

--- a/nodecg-io-intellij/intellij-schema.json
+++ b/nodecg-io-intellij/intellij-schema.json
@@ -8,5 +8,5 @@
             "description": "The address where the nodecg-io-intellij server runs. This defaults to 127.0.0.1:19524"
         }
     },
-    "required": ["address"]
+    "required": []
 }


### PR DESCRIPTION
The IntelliJ schema mentions that it defaults to `127.0.0.1:19524` if no address is given.
This makes sense as most will connect the service to the IntelliJ instance running on the same host.
However the schema requires a value and also the code doesn't check for `undefined` and thus doesn't provide the default if the value is missing.
This PR implements the default value by using it if no value is provided and removing `address` from the required fields list of the JSON schema.