### PR TITLE
Remove JSON schemas from configuration-less services

### DIFF
--- a/nodecg-io-core/extension/serviceBundle.ts
+++ b/nodecg-io-core/extension/serviceBundle.ts
@@ -108,6 +108,8 @@ export abstract class ServiceBundle<R, C> implements Service<R, C> {
     requiresNoConfig = false;
 
     private readSchema(pathSegments: string[]): ObjectMap<unknown> | undefined {
+        if (pathSegments.length === 0) return undefined;
+
         const joinedPath = path.resolve(...pathSegments);
         try {
             const fileContent = fs.readFileSync(joinedPath, "utf8");

--- a/nodecg-io-curseforge/extension/index.ts
+++ b/nodecg-io-curseforge/extension/index.ts
@@ -36,11 +36,11 @@ export {
 } from "./curseforgeClient";
 
 module.exports = (nodecg: NodeCG) => {
-    new CurseforgeService(nodecg, "curseforge", __dirname, "../schema.json").register();
+    new CurseforgeService(nodecg, "curseforge").register();
 };
 
 class CurseforgeService extends ServiceBundle<never, CurseForgeClient> {
-    async validateConfig(_: never): Promise<Result<void>> {
+    async validateConfig(): Promise<Result<void>> {
         return emptySuccess();
     }
 

--- a/nodecg-io-curseforge/schema.json
+++ b/nodecg-io-curseforge/schema.json
@@ -1,7 +1,0 @@
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {},
-    "required": []
-}

--- a/nodecg-io-debug/extension/index.ts
+++ b/nodecg-io-debug/extension/index.ts
@@ -2,22 +2,18 @@ import { NodeCG } from "nodecg-types/types/server";
 import { Result, emptySuccess, success, ServiceBundle } from "nodecg-io-core";
 import { DebugHelper } from "./debugHelper";
 
-export type DebugConfig = {
-    // Nothing to configure
-};
-
 export { DebugHelper } from "./debugHelper";
 
 module.exports = (nodecg: NodeCG) => {
-    new DebugService(nodecg, "debug", __dirname, "../schema.json").register();
+    new DebugService(nodecg, "debug").register();
 };
 
-class DebugService extends ServiceBundle<DebugConfig, DebugHelper> {
-    async validateConfig(_: DebugConfig): Promise<Result<void>> {
+class DebugService extends ServiceBundle<never, DebugHelper> {
+    async validateConfig(): Promise<Result<void>> {
         return emptySuccess();
     }
 
-    async createClient(_: DebugConfig): Promise<Result<DebugHelper>> {
+    async createClient(): Promise<Result<DebugHelper>> {
         const client = DebugHelper.createClient(this.nodecg);
         this.nodecg.log.info("Successfully created debug helper.");
         return success(client);

--- a/nodecg-io-debug/schema.json
+++ b/nodecg-io-debug/schema.json
@@ -1,7 +1,0 @@
-{
-    "$schema": "http://json-schema.org/draft-07/schema#",
-    "type": "object",
-    "additionalProperties": false,
-    "properties": {},
-    "required": []
-}


### PR DESCRIPTION
The curseforge and debug service don't require any configuration and therefore the current JSON schema is empty.
This is unneeded because the schema isn't used to validate the config as there is no config.
To make these services easier we can safely remove the schemas as they are optional anyway.