### PR TITLE
Use dependabot to automatically update gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+###   Issues with lerna stop us from auto-updating npm dependencies
+###   See: https://github.com/codeoverflow-org/nodecg-io/issues/263
+# - package-ecosystem: "npm"
+#   directory: "/"
+#   schedule:
+#     interval: "daily"


### PR DESCRIPTION
See: #263 for information on why npm packages can't be auto-updated.