### PR TITLE
Feature: Update nodecg-io-streamelements to include test events

### DIFF
--- a/samples/streamelements-events/extension/index.ts
+++ b/samples/streamelements-events/extension/index.ts
@@ -58,6 +58,10 @@ module.exports = function (nodecg: NodeCG) {
                 );
             }
         });
+
+        client.onTest((data) => {
+            nodecg.log.info(JSON.stringify(data));
+        });
     });
 
     streamElements?.onUnavailable(() => nodecg.log.info("SE client has been unset."));

--- a/samples/streamelements-events/package.json
+++ b/samples/streamelements-events/package.json
@@ -1,6 +1,6 @@
 {
     "name": "streamelements-events",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
@@ -13,7 +13,7 @@
         "@types/node": "^16.11.6",
         "nodecg-types": "^1.8.3",
         "nodecg-io-core": "^0.2.0",
-        "nodecg-io-streamelements": "^0.2.0",
+        "nodecg-io-streamelements": "^0.2.1",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/streamelements-events/package.json
+++ b/samples/streamelements-events/package.json
@@ -1,6 +1,6 @@
 {
     "name": "streamelements-events",
-    "version": "0.2.1",
+    "version": "0.2.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
@@ -13,7 +13,7 @@
         "@types/node": "^16.11.6",
         "nodecg-types": "^1.8.3",
         "nodecg-io-core": "^0.2.0",
-        "nodecg-io-streamelements": "^0.2.1",
+        "nodecg-io-streamelements": "^0.2.0",
         "typescript": "^4.4.4"
     }
 }

--- a/services/nodecg-io-streamelements/extension/StreamElements.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElements.ts
@@ -6,7 +6,7 @@ import { EventEmitter } from "events";
 export class StreamElementsServiceClient extends EventEmitter {
     private socket: SocketIOClient.Socket;
 
-    constructor(private jwtToken: string) {
+    constructor(private jwtToken: string, private handleTestEvents: boolean) {
         super();
     }
 
@@ -29,6 +29,11 @@ export class StreamElementsServiceClient extends EventEmitter {
                 }
             }
             this.emit(data.type, data);
+        });
+        this.onTestEvent((data: StreamElementsEvent) => {
+            if (data.listener) {
+                this.emit("test", data);
+            }
         });
     }
 
@@ -77,7 +82,7 @@ export class StreamElementsServiceClient extends EventEmitter {
         this.socket.on("connect_error", handler);
     }
 
-    onEvent(handler: (data: StreamElementsEvent) => void): void {
+    private onEvent(handler: (data: StreamElementsEvent) => void): void {
         this.socket.on("event", (data: StreamElementsEvent) => {
             if (data) {
                 handler(data);
@@ -85,31 +90,43 @@ export class StreamElementsServiceClient extends EventEmitter {
         });
     }
 
-    onSubscriber(handler: (data: StreamElementsEvent) => void): void {
+    private onTestEvent(handler: (data: StreamElementsEvent) => void): void {
+        this.socket.on("event:test", (data: StreamElementsEvent) => {
+            if (data) {
+                handler(data);
+            }
+        });
+    }
+
+    public onSubscriber(handler: (data: StreamElementsEvent) => void): void {
         this.on("subscriber", handler);
     }
 
-    onTip(handler: (data: StreamElementsEvent) => void): void {
+    public onTip(handler: (data: StreamElementsEvent) => void): void {
         this.on("tip", handler);
     }
 
-    onCheer(handler: (data: StreamElementsEvent) => void): void {
+    public onCheer(handler: (data: StreamElementsEvent) => void): void {
         this.on("cheer", handler);
     }
 
-    onGift(handler: (data: StreamElementsEvent) => void): void {
+    public onGift(handler: (data: StreamElementsEvent) => void): void {
         this.on("gift", handler);
     }
 
-    onFollow(handler: (data: StreamElementsEvent) => void): void {
+    public onFollow(handler: (data: StreamElementsEvent) => void): void {
         this.on("follow", handler);
     }
 
-    onRaid(handler: (data: StreamElementsEvent) => void): void {
+    public onRaid(handler: (data: StreamElementsEvent) => void): void {
         this.on("raid", handler);
     }
 
-    onHost(handler: (data: StreamElementsEvent) => void): void {
+    public onHost(handler: (data: StreamElementsEvent) => void): void {
         this.on("host", handler);
+    }
+
+    public onTest(handler: (data: StreamElementsEvent) => void): void {
+        this.on("test", handler);
     }
 }

--- a/services/nodecg-io-streamelements/extension/StreamElements.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElements.ts
@@ -30,11 +30,13 @@ export class StreamElementsServiceClient extends EventEmitter {
             }
             this.emit(data.type, data);
         });
-        this.onTestEvent((data: StreamElementsEvent) => {
-            if (data.listener) {
-                this.emit("test", data);
-            }
-        });
+        if (this.handleTestEvents) {
+            this.onTestEvent((data: StreamElementsEvent) => {
+                if (data.listener) {
+                    this.emit("test", data);
+                }
+            });
+        }
     }
 
     async connect(): Promise<void> {

--- a/services/nodecg-io-streamelements/extension/StreamElementsEvent.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElementsEvent.ts
@@ -85,5 +85,15 @@ export interface StreamElementsEvent {
      * Event update date and time
      */
     updatedAt: string;
+    /**
+     * Listener property for test events
+     */
+    listener?: string;
+    /**
+     * Event property for test events
+     */
+    event?: {
+        [k: string]: unknown;
+    };
     [k: string]: unknown;
 }

--- a/services/nodecg-io-streamelements/extension/index.ts
+++ b/services/nodecg-io-streamelements/extension/index.ts
@@ -4,6 +4,7 @@ import { StreamElementsServiceClient } from "./StreamElements";
 
 interface StreamElementsServiceConfig {
     jwtToken: string;
+    handleTestEvents: boolean;
 }
 
 export { StreamElementsServiceClient } from "./StreamElements";
@@ -15,12 +16,12 @@ module.exports = (nodecg: NodeCG) => {
 
 class StreamElementsService extends ServiceBundle<StreamElementsServiceConfig, StreamElementsServiceClient> {
     async validateConfig(config: StreamElementsServiceConfig) {
-        return new StreamElementsServiceClient(config.jwtToken).testConnection();
+        return new StreamElementsServiceClient(config.jwtToken, config.handleTestEvents).testConnection();
     }
 
     async createClient(config: StreamElementsServiceConfig, logger: Logger) {
         logger.info("Connecting to StreamElements socket server...");
-        const client = new StreamElementsServiceClient(config.jwtToken);
+        const client = new StreamElementsServiceClient(config.jwtToken, config.handleTestEvents);
         await client.connect();
         logger.info("Successfully connected to StreamElements socket server.");
 

--- a/services/nodecg-io-streamelements/package.json
+++ b/services/nodecg-io-streamelements/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-streamelements",
-    "version": "0.2.1",
+    "version": "0.2.0",
     "description": "Allows to connect to streamelements to e.g. react to donations.",
     "homepage": "https://nodecg.io/RELEASE",
     "author": {

--- a/services/nodecg-io-streamelements/package.json
+++ b/services/nodecg-io-streamelements/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-streamelements",
-    "version": "0.2.0",
+    "version": "0.2.1",
     "description": "Allows to connect to streamelements to e.g. react to donations.",
     "homepage": "https://nodecg.io/RELEASE",
     "author": {
@@ -43,6 +43,6 @@
     "dependencies": {
         "@types/socket.io-client": "^1.4.36",
         "nodecg-io-core": "^0.2.0",
-        "socket.io-client": "^4.3.2"
+        "socket.io-client": "^2.4.0"
     }
 }

--- a/services/nodecg-io-streamelements/streamelements-schema.json
+++ b/services/nodecg-io-streamelements/streamelements-schema.json
@@ -9,8 +9,9 @@
         },
         "handleTestEvents": {
             "type": "boolean",
+            "default": false,
             "description": "Whether test events should be handled."
         }
     },
-    "required": ["jwtToken", "handleTestEvents"]
+    "required": ["jwtToken"]
 }

--- a/services/nodecg-io-streamelements/streamelements-schema.json
+++ b/services/nodecg-io-streamelements/streamelements-schema.json
@@ -6,7 +6,11 @@
         "jwtToken": {
             "type": "string",
             "description": "Your JWT token for streamelments."
+        },
+        "handleTestEvents": {
+            "type": "boolean",
+            "description": "Whether test events should be handled."
         }
     },
-    "required": ["jwtToken"]
+    "required": ["jwtToken", "handleTestEvents"]
 }


### PR DESCRIPTION
This PR adds a new field ``handleTestEvents`` to the SE config which controls whether it should also fire test events.

Also bumps the version to ``0.2.1`` for the sample and nodecg-io-streamelements