### PR TITLE
Don't run docs update action for events caused by dependabot

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,7 +9,9 @@ on:
 jobs:
     build:
         runs-on: ubuntu-latest
-        if: startsWith(github.repository, 'codeoverflow-org') # don't run this in forks
+        # don't run this in forks, because contributors maybe don't have forked the docs repository
+        # also don't run when this run is caused by dependabot because then we won't have access to the ssh key secret
+        if: startsWith(github.repository, 'codeoverflow-org') && github.actor != 'dependabot[bot]'
         steps:
             - name: Setup Python
               uses: actions/setup-python@v2


### PR DESCRIPTION
All GitHub Actions runs triggered by dependabot have no access to secrets for security reasons.
Because of this our documentation update action is failing when dependabot merges a pull request.
This pr adds a check to the action. Now it will only run if it was not triggered by dependabot.
