### PR TITLE
Fix twitch-addons sample bundle dependency

### DIFF
--- a/samples/twitch-addons/package.json
+++ b/samples/twitch-addons/package.json
@@ -5,7 +5,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-template": "^0.2.0"
+            "nodecg-io-twitch-addons": "^0.2.0"
         }
     },
     "license": "MIT",


### PR DESCRIPTION
The bundle dependency on the `nodecg-io-twitch-addons` bundle in the sample bundle was still referencing the template service.
Because of this in some instances the `twitch-addons` sample bundle failed to load because it was loaded before the service.
