### PR TITLE
Disable deprecated automatic promise cancellation in telegram

### DIFF
--- a/services/nodecg-io-telegram/extension/index.ts
+++ b/services/nodecg-io-telegram/extension/index.ts
@@ -1,5 +1,9 @@
 import { NodeCG } from "nodecg-types/types/server";
 import { Result, emptySuccess, success, ServiceBundle, Logger } from "nodecg-io-core";
+
+// Disable automatic promise cancellation
+// Check https://github.com/yagop/node-telegram-bot-api/issues/319 for more information about this
+process.env.NTBA_FIX_319 = "1";
 import TelegramBot = require("node-telegram-bot-api");
 
 interface TelegramServiceConfig {


### PR DESCRIPTION
Closes #267
Previously the telegram library automatically would enable bluebird promise cancellation. It is recommended to set the `NTBA_FIX_319` environment variable to disable automatic activation and only enable it if needed. We don't use promise cancellation arround here and anyone using our telegram service propably doesn't either. If this is the case they should enable it themselfs.
