### PR TITLE
Update Action workflows and docs script for master to main renaming

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,7 @@ name: Update docs
 on:
     push:
         branches:
-            - master
+            - main
             - "release/**"
 
 jobs:

--- a/.scripts/build-docs.py
+++ b/.scripts/build-docs.py
@@ -58,7 +58,7 @@ def appendBundle(out, dir, reldir, baseDepDir, baseDocDir, outGraph, depList, re
     with open(dir + os.path.sep + 'package.json') as r:
         data = json.load(r)
         if (data['name'] != 'nodecg-io-core' or is_core) and 'keywords' in data and 'nodecg-bundle' in data['keywords']:
-            out.write(f'## [{data["name"]}](https://github.com/codeoverflow-org/nodecg-io/tree/master/{reldir})\n')
+            out.write(f'## [{data["name"]}](https://github.com/codeoverflow-org/nodecg-io/tree/main/{reldir})\n')
             out.write('\n')
 
             if 'description' in data and data['description'].strip() != '':
@@ -82,14 +82,14 @@ def appendBundle(out, dir, reldir, baseDepDir, baseDocDir, outGraph, depList, re
             if 'dependencies' in data:
                 if not data['name'] in depList:
                     if data['name'] == 'nodecg-io-core':
-                        outGraph.write(f'[<u>{data["name"]}] as {reldir.replace(os.path.sep, "_").replace(".", "_").replace("-", "_").replace("/", "_").replace("@", "")} <<core>> [[https://github.com/codeoverflow-org/nodecg-io/tree/master/{reldir}]]\n')
+                        outGraph.write(f'[<u>{data["name"]}] as {reldir.replace(os.path.sep, "_").replace(".", "_").replace("-", "_").replace("/", "_").replace("@", "")} <<core>> [[https://github.com/codeoverflow-org/nodecg-io/tree/main/{reldir}]]\n')
                     else:
-                        outGraph.write(f'[<u>{data["name"]}] as {reldir.replace(os.path.sep, "_").replace(".", "_").replace("-", "_").replace("/", "_").replace("@", "")} <<service>> [[https://github.com/codeoverflow-org/nodecg-io/tree/master/{reldir}]]\n')
+                        outGraph.write(f'[<u>{data["name"]}] as {reldir.replace(os.path.sep, "_").replace(".", "_").replace("-", "_").replace("/", "_").replace("@", "")} <<service>> [[https://github.com/codeoverflow-org/nodecg-io/tree/main/{reldir}]]\n')
                 depList.append(data['name'])
 
                 for dependency in data['dependencies']:
                     if os.path.exists(baseDepDir + os.path.sep + dependency):
-                        depurl = f'https://github.com/codeoverflow-org/nodecg-io/tree/master/{dependency.replace(os.path.sep, "/")}'
+                        depurl = f'https://github.com/codeoverflow-org/nodecg-io/tree/main/{dependency.replace(os.path.sep, "/")}'
                         lineStyle = '-->'
                     else:
                         depurl = f'https://www.npmjs.com/package/{dependency.replace(os.path.sep, "/")}'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Bugs](https://img.shields.io/github/issues/codeoverflow-org/nodecg-io/bug?label=Bugs&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/labels/bug)
 [![Pull Requests](https://img.shields.io/github/issues-pr/codeoverflow-org/nodecg-io?label=Pull%20Requests&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/pulls)
 [![Services](https://img.shields.io/static/v1?label=Services%20implemented&message=39&color=blue&style=flat-square)](https://nodecg.io/RELEASE/services/)
-[![License](https://img.shields.io/github/license/codeoverflow-org/nodecg-io?label=License&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/blob/master/LICENSE)
+[![License](https://img.shields.io/github/license/codeoverflow-org/nodecg-io?label=License&style=flat-square)](https://github.com/codeoverflow-org/nodecg-io/blob/main/LICENSE)
 [![Discord](https://img.shields.io/badge/discord-join-7289DA.svg?logo=discord&style=flat-square)](https://discord.gg/GEJzxBGRu6)
 
 **A NodeCG-bundle which implements Social Media API's in the NodeCG framework**

--- a/nodecg-io-core/extension/__tests__/mocks.ts
+++ b/nodecg-io-core/extension/__tests__/mocks.ts
@@ -16,7 +16,7 @@ export class MockNodeCG implements NodeCG {
     ) {}
 
     bundleGit = {
-        branch: "master",
+        branch: "main",
         hash: "e3dbf8d7233ca3fdb895e7b2be934cebc7494173",
         shortHash: "e3dbf8d",
     };


### PR DESCRIPTION
Check https://github.com/codeoverflow-org/nodecg-io/issues/266 for more details.
Replaces `master` with `main` in GitHub Action workflows, our documentation script and the readme.