### PR TITLE
Load monaco-editor using webpack instead of monacos own loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ coverage
 # Dashboard webpack
 nodecg-io-core/dashboard/dist
 !nodecg-io-core/dashboard/webpack.config.js
+services/nodecg-io-debug/dashboard/dist
+!services/nodecg-io-debug/webpack.config.js
 
 # Editor configuration
 .idea/

--- a/nodecg-io-core/dashboard/main.ts
+++ b/nodecg-io-core/dashboard/main.ts
@@ -1,7 +1,6 @@
 // Re-exports functions that are used in panel.html
 export { loadFramework } from "./authentication";
 export {
-    onMonacoReady,
     onInstanceSelectChange,
     createInstance,
     saveInstanceConfig,

--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -1,6 +1,17 @@
 {
     "name": "nodecg-io-dashboard",
     "version": "0.2.0",
+    "description": "Dashboard that is used to manage your nodecg-io configuration.",
+    "homepage": "https://nodecg.io/RELEASE",
+    "author": {
+        "name": "CodeOverflow team",
+        "url": "https://github.com/codeoverflow-org"
+    },
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/codeoverflow-org/nodecg-io.git",
+        "directory": "nodecg-io-core/dashboard"
+    },
     "scripts": {
         "build": "webpack",
         "watch": "webpack --watch"
@@ -9,7 +20,10 @@
         "clean-webpack-plugin": "^4.0.0",
         "typescript": "^4.4.4",
         "webpack": "^5.64.0",
-        "webpack-cli": "^4.9.1"
+        "webpack-cli": "^4.9.1",
+        "style-loader": "^3.3.1",
+        "css-loader": "^6.5.1",
+        "monaco-editor-webpack-plugin": "^6.0.0"
     },
     "dependencies": {
         "crypto-js": "^4.1.1",

--- a/nodecg-io-core/dashboard/panel.html
+++ b/nodecg-io-core/dashboard/panel.html
@@ -91,12 +91,5 @@
 
         <!-- Scripts -->
         <script src="./dist/main.bundle.js"></script>
-
-        <!-- monaco is manually included because when including it using webpack it created formatting issues. -->
-        <script src="../modules/monaco-editor/min/vs/loader.js"></script>
-        <script>
-            require.config({ paths: { vs: "../modules/monaco-editor/min/vs" } });
-            require(["vs/editor/editor.main"], onMonacoReady);
-        </script>
     </body>
 </html>

--- a/nodecg-io-core/dashboard/serviceInstance.ts
+++ b/nodecg-io-core/dashboard/serviceInstance.ts
@@ -1,4 +1,4 @@
-/// <reference types="monaco-editor/monaco" />
+import * as monaco from "monaco-editor";
 import {
     CreateServiceInstanceMessage,
     DeleteServiceInstanceMessage,
@@ -33,8 +33,10 @@ const instancePreset = document.getElementById("instancePreset");
 const instanceNameField = document.getElementById("instanceNameField");
 const instanceEditButtons = document.getElementById("instanceEditButtons");
 const instanceCreateButton = document.getElementById("instanceCreateButton");
-const instanceMonaco = document.getElementById("instanceMonaco");
-let editor: monaco.editor.IStandaloneCodeEditor | undefined;
+const instanceMonaco = document.getElementById("instanceMonaco")!;
+const editor = monaco.editor.create(instanceMonaco, {
+    theme: "vs-dark",
+});
 
 const spanInstanceNotice = document.getElementById("spanInstanceNotice");
 const buttonSave = document.getElementById("buttonSave");
@@ -46,18 +48,6 @@ window.addEventListener("resize", () => {
 });
 export function updateMonacoLayout(): void {
     editor?.layout();
-}
-
-export function onMonacoReady(): void {
-    if (instanceMonaco) {
-        editor = monaco.editor.create(instanceMonaco, {
-            theme: "vs-dark",
-        });
-
-        // Virtually selects the same instance option again to show the json/text in the editor.
-        const selected = selectInstance.options[selectInstance.selectedIndex]?.value || "select";
-        selectServiceInstance(selected);
-    }
 }
 
 // Instance drop-down

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -32,12 +32,6 @@
     ],
     "nodecg": {
         "compatibleRange": "^1.1.1",
-        "mount": [
-            {
-                "directory": "../node_modules",
-                "endpoint": "modules"
-            }
-        ],
         "dashboardPanels": [
             {
                 "name": "nodecg-io",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3395,6 +3395,15 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/big.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "dev": true,
+            "engines": {
+                "node": "*"
+            }
+        },
         "node_modules/bignumber.js": {
             "version": "9.0.1",
             "license": "MIT",
@@ -4427,6 +4436,44 @@
                 "node": ">=8"
             }
         },
+        "node_modules/css-loader": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.5.1.tgz",
+            "integrity": "sha512-gEy2w9AnJNnD9Kuo4XAP9VflW/ujKoS9c/syO+uWMlm5igc7LysKzPXaDoR2vroROkSwsTS2tGr1yGGEbZOYZQ==",
+            "dev": true,
+            "dependencies": {
+                "icss-utils": "^5.1.0",
+                "postcss": "^8.2.15",
+                "postcss-modules-extract-imports": "^3.0.0",
+                "postcss-modules-local-by-default": "^4.0.0",
+                "postcss-modules-scope": "^3.0.0",
+                "postcss-modules-values": "^4.0.0",
+                "postcss-value-parser": "^4.1.0",
+                "semver": "^7.3.5"
+            },
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
+            }
+        },
+        "node_modules/cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true,
+            "bin": {
+                "cssesc": "bin/cssesc"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
         "node_modules/cssom": {
             "version": "0.4.4",
             "dev": true,
@@ -4897,6 +4944,15 @@
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "license": "MIT"
+        },
+        "node_modules/emojis-list": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+            "dev": true,
+            "engines": {
+                "node": ">= 4"
+            }
         },
         "node_modules/encodeurl": {
             "version": "1.0.2",
@@ -6541,6 +6597,18 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/icss-utils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+            "dev": true,
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "funding": [
@@ -8171,6 +8239,20 @@
                 "node": ">=6.11.5"
             }
         },
+        "node_modules/loader-utils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+            "dev": true,
+            "dependencies": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            },
+            "engines": {
+                "node": ">=8.9.0"
+            }
+        },
         "node_modules/locate-path": {
             "version": "5.0.0",
             "dev": true,
@@ -8475,6 +8557,19 @@
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
             "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg=="
         },
+        "node_modules/monaco-editor-webpack-plugin": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-6.0.0.tgz",
+            "integrity": "sha512-vC886Mzpd2AkSM35XLkfQMjH+Ohz6RISVwhAejDUzZDheJAiz6G34lky1vyO8fZ702v7IrcKmsGwL1rRFnwvUA==",
+            "dev": true,
+            "dependencies": {
+                "loader-utils": "^2.0.0"
+            },
+            "peerDependencies": {
+                "monaco-editor": "0.30.x",
+                "webpack": "^4.5.0 || 5.x"
+            }
+        },
         "node_modules/mqtt": {
             "version": "4.2.8",
             "license": "MIT",
@@ -8620,6 +8715,18 @@
         "node_modules/nan": {
             "version": "2.15.0",
             "license": "MIT"
+        },
+        "node_modules/nanoid": {
+            "version": "3.1.30",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+            "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+            "dev": true,
+            "bin": {
+                "nanoid": "bin/nanoid.cjs"
+            },
+            "engines": {
+                "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+            }
         },
         "node_modules/nanoleaf": {
             "resolved": "samples/nanoleaf",
@@ -9599,6 +9706,102 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/postcss": {
+            "version": "8.3.11",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
+            "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+            "dev": true,
+            "dependencies": {
+                "nanoid": "^3.1.30",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^0.6.2"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >=14"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/postcss/"
+            }
+        },
+        "node_modules/postcss-modules-extract-imports": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+            "dev": true,
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/postcss-modules-local-by-default": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+            "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+            "dev": true,
+            "dependencies": {
+                "icss-utils": "^5.0.0",
+                "postcss-selector-parser": "^6.0.2",
+                "postcss-value-parser": "^4.1.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/postcss-modules-scope": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+            "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+            "dev": true,
+            "dependencies": {
+                "postcss-selector-parser": "^6.0.4"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/postcss-modules-values": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+            "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+            "dev": true,
+            "dependencies": {
+                "icss-utils": "^5.0.0"
+            },
+            "engines": {
+                "node": "^10 || ^12 || >= 14"
+            },
+            "peerDependencies": {
+                "postcss": "^8.1.0"
+            }
+        },
+        "node_modules/postcss-selector-parser": {
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+            "dev": true,
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/postcss-value-parser": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+            "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+            "dev": true
         },
         "node_modules/prebuild-install": {
             "version": "6.1.4",
@@ -10661,6 +10864,15 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/source-map-js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+            "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+            "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/source-map-support": {
             "version": "0.5.20",
             "dev": true,
@@ -10911,6 +11123,22 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/style-loader": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
+            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+            "dev": true,
+            "engines": {
+                "node": ">= 12.13.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/webpack"
+            },
+            "peerDependencies": {
+                "webpack": "^5.0.0"
             }
         },
         "node_modules/superagent": {
@@ -12256,6 +12484,9 @@
             },
             "devDependencies": {
                 "clean-webpack-plugin": "^4.0.0",
+                "css-loader": "^6.5.1",
+                "monaco-editor-webpack-plugin": "^6.0.0",
+                "style-loader": "^3.3.1",
                 "typescript": "^4.4.4",
                 "webpack": "^5.64.0",
                 "webpack-cli": "^4.9.1"
@@ -12856,8 +13087,13 @@
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
+                "css-loader": "^6.5.1",
+                "monaco-editor-webpack-plugin": "^6.0.0",
                 "nodecg-types": "^1.8.3",
-                "typescript": "^4.4.4"
+                "style-loader": "^3.3.1",
+                "typescript": "^4.4.4",
+                "webpack": "^5.64.0",
+                "webpack-cli": "^4.9.1"
             }
         },
         "services/nodecg-io-discord": {
@@ -13083,7 +13319,7 @@
             "license": "MIT",
             "dependencies": {
                 "nodecg-io-core": "^0.2.0",
-                "reddit-ts": "git+ssh://git@github.com/noeppi-noeppi/npm-reddit-ts.git#a776adfa960a73e5d6897b8bfe54ee3b6249b7bf"
+                "reddit-ts": "noeppi-noeppi/npm-reddit-ts#build"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -15929,6 +16165,12 @@
             "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
             "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ=="
         },
+        "big.js": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+            "dev": true
+        },
         "bignumber.js": {
             "version": "9.0.1"
         },
@@ -16670,6 +16912,28 @@
             "version": "2.0.0",
             "dev": true
         },
+        "css-loader": {
+            "version": "6.5.1",
+            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.5.1.tgz",
+            "integrity": "sha512-gEy2w9AnJNnD9Kuo4XAP9VflW/ujKoS9c/syO+uWMlm5igc7LysKzPXaDoR2vroROkSwsTS2tGr1yGGEbZOYZQ==",
+            "dev": true,
+            "requires": {
+                "icss-utils": "^5.1.0",
+                "postcss": "^8.2.15",
+                "postcss-modules-extract-imports": "^3.0.0",
+                "postcss-modules-local-by-default": "^4.0.0",
+                "postcss-modules-scope": "^3.0.0",
+                "postcss-modules-values": "^4.0.0",
+                "postcss-value-parser": "^4.1.0",
+                "semver": "^7.3.5"
+            }
+        },
+        "cssesc": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+            "dev": true
+        },
         "cssom": {
             "version": "0.4.4",
             "dev": true
@@ -17043,6 +17307,12 @@
         },
         "emoji-regex": {
             "version": "8.0.0"
+        },
+        "emojis-list": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
+            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
+            "dev": true
         },
         "encodeurl": {
             "version": "1.0.2"
@@ -18159,6 +18429,13 @@
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
+        "icss-utils": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+            "dev": true,
+            "requires": {}
+        },
         "ieee754": {
             "version": "1.2.1"
         },
@@ -19215,6 +19492,17 @@
             "version": "4.2.0",
             "dev": true
         },
+        "loader-utils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
+            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
+            "dev": true,
+            "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^3.0.0",
+                "json5": "^2.1.2"
+            }
+        },
         "locate-path": {
             "version": "5.0.0",
             "dev": true,
@@ -19447,6 +19735,15 @@
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
             "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg=="
         },
+        "monaco-editor-webpack-plugin": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-6.0.0.tgz",
+            "integrity": "sha512-vC886Mzpd2AkSM35XLkfQMjH+Ohz6RISVwhAejDUzZDheJAiz6G34lky1vyO8fZ702v7IrcKmsGwL1rRFnwvUA==",
+            "dev": true,
+            "requires": {
+                "loader-utils": "^2.0.0"
+            }
+        },
         "mqtt": {
             "version": "4.2.8",
             "requires": {
@@ -19555,6 +19852,12 @@
         },
         "nan": {
             "version": "2.15.0"
+        },
+        "nanoid": {
+            "version": "3.1.30",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
+            "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
+            "dev": true
         },
         "nanoleaf": {
             "version": "file:samples/nanoleaf",
@@ -19828,9 +20131,12 @@
             "requires": {
                 "clean-webpack-plugin": "^4.0.0",
                 "crypto-js": "^4.1.1",
+                "css-loader": "^6.5.1",
                 "monaco-editor": "^0.30.1",
+                "monaco-editor-webpack-plugin": "^6.0.0",
                 "nodecg-io-core": "^0.2.0",
                 "nodecg-types": "^1.8.3",
+                "style-loader": "^3.3.1",
                 "typescript": "^4.4.4",
                 "webpack": "^5.64.0",
                 "webpack-cli": "^4.9.1"
@@ -19850,10 +20156,15 @@
             "version": "file:services/nodecg-io-debug",
             "requires": {
                 "@types/node": "^16.11.7",
+                "css-loader": "^6.5.1",
                 "monaco-editor": "^0.30.1",
+                "monaco-editor-webpack-plugin": "^6.0.0",
                 "nodecg-io-core": "^0.2.0",
                 "nodecg-types": "^1.8.3",
-                "typescript": "^4.4.4"
+                "style-loader": "^3.3.1",
+                "typescript": "^4.4.4",
+                "webpack": "^5.64.0",
+                "webpack-cli": "^4.9.1"
             }
         },
         "nodecg-io-discord": {
@@ -20033,7 +20344,7 @@
                 "@types/node": "^16.11.7",
                 "nodecg-io-core": "^0.2.0",
                 "nodecg-types": "^1.8.3",
-                "reddit-ts": "git+ssh://git@github.com/noeppi-noeppi/npm-reddit-ts.git#a776adfa960a73e5d6897b8bfe54ee3b6249b7bf",
+                "reddit-ts": "noeppi-noeppi/npm-reddit-ts#build",
                 "typescript": "^4.4.4"
             }
         },
@@ -20738,6 +21049,69 @@
             "requires": {
                 "find-up": "^4.0.0"
             }
+        },
+        "postcss": {
+            "version": "8.3.11",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
+            "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
+            "dev": true,
+            "requires": {
+                "nanoid": "^3.1.30",
+                "picocolors": "^1.0.0",
+                "source-map-js": "^0.6.2"
+            }
+        },
+        "postcss-modules-extract-imports": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+            "dev": true,
+            "requires": {}
+        },
+        "postcss-modules-local-by-default": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+            "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+            "dev": true,
+            "requires": {
+                "icss-utils": "^5.0.0",
+                "postcss-selector-parser": "^6.0.2",
+                "postcss-value-parser": "^4.1.0"
+            }
+        },
+        "postcss-modules-scope": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+            "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+            "dev": true,
+            "requires": {
+                "postcss-selector-parser": "^6.0.4"
+            }
+        },
+        "postcss-modules-values": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+            "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+            "dev": true,
+            "requires": {
+                "icss-utils": "^5.0.0"
+            }
+        },
+        "postcss-selector-parser": {
+            "version": "6.0.6",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
+            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
+            "dev": true,
+            "requires": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            }
+        },
+        "postcss-value-parser": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+            "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
+            "dev": true
         },
         "prebuild-install": {
             "version": "6.1.4",
@@ -21451,6 +21825,12 @@
             "version": "0.6.1",
             "dev": true
         },
+        "source-map-js": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
+            "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
+            "dev": true
+        },
         "source-map-support": {
             "version": "0.5.20",
             "dev": true,
@@ -21642,6 +22022,13 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
+        },
+        "style-loader": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
+            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+            "dev": true,
+            "requires": {}
         },
         "superagent": {
             "version": "6.1.0",

--- a/services/nodecg-io-debug/dashboard/debug-helper.html
+++ b/services/nodecg-io-debug/dashboard/debug-helper.html
@@ -165,26 +165,9 @@
                 <div>
                     <button id="json_send">Send</button>
                 </div>
-
-                <script src="../modules/monaco-editor/min/vs/loader.js"></script>
-                <script>
-                    require.config({ paths: { vs: "../modules/monaco-editor/min/vs" } });
-                    require(["vs/editor/editor.main"], onMonacoReady);
-
-                    function onMonacoReady() {
-                        var jsonCode = ["{", '    "data": 42', "}"].join("\n");
-
-                        var model = monaco.editor.createModel(jsonCode, "json");
-
-                        window.debugMonacoEditor = monaco.editor.create(document.getElementById("instanceMonaco"), {
-                            model: model,
-                            theme: "vs-dark",
-                        });
-                    }
-                </script>
             </div>
         </div>
 
-        <script src="debug-helper.js"></script>
+        <script src="dist/main.bundle.js"></script>
     </body>
 </html>

--- a/services/nodecg-io-debug/dashboard/debug-helper.ts
+++ b/services/nodecg-io-debug/dashboard/debug-helper.ts
@@ -1,5 +1,5 @@
 /// <reference types="nodecg-types/types/browser" />
-/// <reference types="monaco-editor/monaco" />
+import * as monaco from "monaco-editor";
 
 // Buttons
 for (let i = 1; i <= 5; i++) {
@@ -71,8 +71,13 @@ setHandler("#list_list_send", "onclick", () => {
 });
 
 // JSON
-// defined in debug-helper.html
-declare const debugMonacoEditor: monaco.editor.IStandaloneCodeEditor;
+const jsonCode = JSON.stringify({ data: 42 }, null, 4);
+const model = monaco.editor.createModel(jsonCode, "json");
+const debugMonacoEditor = monaco.editor.create(document.getElementById("instanceMonaco")!, {
+    model: model,
+    theme: "vs-dark",
+});
+
 setHandler("#json_send", "onclick", () => {
     const jsonString = debugMonacoEditor.getValue();
     try {

--- a/services/nodecg-io-debug/package.json
+++ b/services/nodecg-io-debug/package.json
@@ -12,6 +12,10 @@
         "url": "https://github.com/codeoverflow-org/nodecg-io.git",
         "directory": "services/nodecg-io-debug"
     },
+    "scripts": {
+        "build": "webpack",
+        "watch": "webpack --watch"
+    },
     "files": [
         "dashboard",
         "**/*.js",
@@ -37,19 +41,18 @@
                 "fullbleed": true,
                 "headerColor": "#527878"
             }
-        ],
-        "mount": [
-            {
-                "directory": "../../node_modules",
-                "endpoint": "modules"
-            }
         ]
     },
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "typescript": "^4.4.4"
+        "typescript": "^4.4.4",
+        "webpack": "^5.64.0",
+        "webpack-cli": "^4.9.1",
+        "style-loader": "^3.3.1",
+        "css-loader": "^6.5.1",
+        "monaco-editor-webpack-plugin": "^6.0.0"
     },
     "dependencies": {
         "nodecg-io-core": "^0.2.0",

--- a/services/nodecg-io-debug/webpack.config.js
+++ b/services/nodecg-io-debug/webpack.config.js
@@ -3,14 +3,14 @@ const { CleanWebpackPlugin } = require('clean-webpack-plugin')
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 const ROOT = path.resolve(__dirname);
-const DESTINATION = path.resolve(__dirname, 'dist');
+const DESTINATION = path.resolve(__dirname, 'dashboard', 'dist');
 
 module.exports = {
     context: ROOT,
 
     mode: "none",
     entry: {
-        'main': './main.ts'
+        'main': 'dashboard/debug-helper.js'
     },
 
     output: {
@@ -32,7 +32,7 @@ module.exports = {
     plugins: [
         new CleanWebpackPlugin(),
         new MonacoWebpackPlugin({
-            languages: ['text', 'json']
+            languages: ['json']
         })
     ],
 


### PR DESCRIPTION
Closes #311.
Monaco uses some newer browser features that are not available on old chromium versions like the one embedded in OBS. To fix this (and also fix our kinda hacky loading of monaco through a relative fs mount to the root  `node_modules`) we can load monaco through webpack.
I've activated webpack caching because webpack is now actually processing more than 5 files and using it the build time can be reduced from ~6s to 1.5s per webpack project. The caches take up about 12MB per project, so 24MB in total, which is okay I think.