### PR TITLE
Add 7TV emotes to nodecg-io-twitch-addons

### DIFF
--- a/samples/twitch-addons/extension/index.ts
+++ b/samples/twitch-addons/extension/index.ts
@@ -9,12 +9,15 @@ module.exports = function (nodecg: NodeCG) {
 
     twitchAddons?.onAvailable(async (client) => {
         nodecg.log.info("Twitch-addons service available.");
-        const emotes = await client.getEmoteCollection("#derniklaas", false);
+        const emotes = await client.getEmoteCollection("#derniklaas", { includeGlobal: false });
         const emoteNames = client.getEmoteNames(emotes);
-        const global = await client.getEmoteCollection("#derniklaas", true);
+        const global = await client.getEmoteCollection("#derniklaas", { includeGlobal: true });
         const globalNames = client.getEmoteNames(global);
+        const stv = await client.getEmoteCollection("#derniklaas", { includeGlobal: true, include7tv: true });
+        const stvNames = client.getEmoteNames(stv);
         nodecg.log.info(`BTTV & FFZ emotes on the twitch channel #derniklaas (without global emotes): ${emoteNames}`);
         nodecg.log.info(`BTTV & FFZ emotes on the twitch channel #derniklaas (with global emotes): ${globalNames}`);
+        nodecg.log.info(`BTTV, FFZ, & 7TV emotes on the twitch channel #derniklaas (with global emotes): ${stvNames}`);
     });
 
     twitchAddons?.onUnavailable(() => {

--- a/services/nodecg-io-twitch-addons/extension/twitchAddonsClient.ts
+++ b/services/nodecg-io-twitch-addons/extension/twitchAddonsClient.ts
@@ -81,7 +81,7 @@ export class TwitchAddonsClient {
             throw new Error(`Unknown twitch channel: ${channel}`);
         }
         const response = await (await fetch(`https://api.7tv.app/v2/users/${channelId}/emotes`)).json();
-        if (response.status == 404) {
+        if (response.status === 404) {
             if (response.message.startsWith("Unknown User")) {
                 // The user has no room at 7TV (probably never logged in there)
                 return undefined;


### PR DESCRIPTION
### Added [7TV](https://7tv.app) Emotes to the providers in [nodecg-io-twitch-addons](../services/nodecg-io-twitch-addons/extension/twitchAddonsClient.ts)

Sadly, since Javascript variables (and object properties) can't start with numbers, I made 7tv's property on [EmoteCollection](https://github.com/codeoverflow-org/nodecg-io/blob/de1c46d49e10fe29310526f8ec9320a18569495c/services/nodecg-io-twitch-addons/extension/twitchAddonsClient.ts#L436) 'stv' so users can access the collection with **`emotes.stv` instead** of using a string key with access through `emotes["7tv"]`
```ts
var emotes = await client.getEmoteCollection... // Get emotes
// Easier to access:
emotes.stv.find(v => v.name === "docSpin")
// An annoyance to access:
emotes["7tv"].find(v => v.name === "docSpin")
```

Since it's common to make 7TV optional (at least in the chat clients I've looked over), I also modified the second parameter of getEmoteCollection (previously a boolean for 'includeGlobal') to be more of an "options" parameter. It's now an object of type:
`{ includeGlobal: boolean, include7tv: boolean }` and has default values of `{ includeGlobal: true, include7tv: false }` so users can just call `getEmoteCollection(emotes)` without the options.

If I missed anything in my PR then please let me know!

Heres my NodeCG console printing a test of the providers' emote lengths (the '7tv' key is just part of the test object):

![A console log from me testing if all emote sources work.](https://user-images.githubusercontent.com/15599091/141911428-cfa58fc1-c149-402e-bf43-213a8b5758e6.png)

Cheers!
[devJimmyboy](https://twitch.tv/devJimmyboy)