### PR TITLE
Move nodecg-types to normal dependencies for debug and nanoleaf service

### DIFF
--- a/services/nodecg-io-debug/package.json
+++ b/services/nodecg-io-debug/package.json
@@ -46,7 +46,6 @@
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^16.11.7",
-        "nodecg-types": "^1.8.3",
         "typescript": "^4.4.4",
         "webpack": "^5.64.0",
         "webpack-cli": "^4.9.1",
@@ -56,6 +55,7 @@
     },
     "dependencies": {
         "nodecg-io-core": "^0.2.0",
+        "nodecg-types": "^1.8.3",
         "monaco-editor": "^0.30.1"
     }
 }

--- a/services/nodecg-io-nanoleaf/package.json
+++ b/services/nodecg-io-nanoleaf/package.json
@@ -31,12 +31,12 @@
     "license": "MIT",
     "devDependencies": {
         "@types/node": "^16.11.7",
-        "nodecg-types": "^1.8.3",
         "typescript": "^4.4.4"
     },
     "dependencies": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.5",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.2.0",
+        "nodecg-types": "^1.8.3"
     }
 }


### PR DESCRIPTION
The debug service exposes the `NodeCG` type with its constructor and nanoleaf with the `NanoleafUtils.retrieveAuthKey` method.
Because of this the generated `.d.ts` files import `nodecg-types` and we need to make it a production dependency as it is needed to be able to use the typings when e.g. adding it as a dependency to a bundle once it has been released.