### PR TITLE
Move monaco-editor to `devDependencies`

### DIFF
--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -23,12 +23,12 @@
         "webpack-cli": "^4.9.1",
         "style-loader": "^3.3.1",
         "css-loader": "^6.5.1",
-        "monaco-editor-webpack-plugin": "^6.0.0"
+        "monaco-editor-webpack-plugin": "^6.0.0",
+        "nodecg-types": "^1.8.3"
     },
     "dependencies": {
         "crypto-js": "^4.1.1",
         "monaco-editor": "^0.30.1",
-        "nodecg-types": "^1.8.3",
         "nodecg-io-core": "^0.2.0"
     },
     "license": "MIT"

--- a/services/nodecg-io-debug/package.json
+++ b/services/nodecg-io-debug/package.json
@@ -51,11 +51,11 @@
         "webpack-cli": "^4.9.1",
         "style-loader": "^3.3.1",
         "css-loader": "^6.5.1",
-        "monaco-editor-webpack-plugin": "^6.0.0"
+        "monaco-editor-webpack-plugin": "^6.0.0",
+        "monaco-editor": "^0.30.1"
     },
     "dependencies": {
         "nodecg-io-core": "^0.2.0",
-        "nodecg-types": "^1.8.3",
-        "monaco-editor": "^0.30.1"
+        "nodecg-types": "^1.8.3"
     }
 }


### PR DESCRIPTION
Starting with #312 monaco is included in the javascript bundles that are generated by webpack and does not get loaded out of the `node_modules` directory anymore. This means we can move it to `devDepencencies` as it is only needed during build time and save about 80 MiB of space in a production install, reducing its size (with all services installed) from 328 MiB to 248 MiB.