### PR TITLE
Bump version numbers to 0.3.0

### DIFF
--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-dashboard",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Dashboard that is used to manage your nodecg-io configuration.",
     "homepage": "https://nodecg.io/RELEASE",
     "author": {
@@ -29,7 +29,7 @@
     "dependencies": {
         "crypto-js": "^4.1.1",
         "monaco-editor": "^0.30.1",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     },
     "license": "MIT"
 }

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-core",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "The core of nodecg-io. Connects everything up.",
     "homepage": "https://nodecg.io/RELEASE",
     "author": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,19 @@
                 "dayjs": "^1.8.28"
             }
         },
+        "node_modules/@babel/code-frame": {
+            "version": "7.16.0",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/highlight": "^7.16.0"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            }
+        },
         "node_modules/@babel/compat-data": {
-            "version": "7.15.0",
+            "version": "7.16.4",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -40,19 +51,19 @@
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.15.8",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.15.8",
-                "@babel/generator": "^7.15.8",
-                "@babel/helper-compilation-targets": "^7.15.4",
-                "@babel/helper-module-transforms": "^7.15.8",
-                "@babel/helpers": "^7.15.4",
-                "@babel/parser": "^7.15.8",
-                "@babel/template": "^7.15.4",
-                "@babel/traverse": "^7.15.4",
-                "@babel/types": "^7.15.6",
+                "@babel/code-frame": "^7.16.0",
+                "@babel/generator": "^7.16.0",
+                "@babel/helper-compilation-targets": "^7.16.0",
+                "@babel/helper-module-transforms": "^7.16.0",
+                "@babel/helpers": "^7.16.0",
+                "@babel/parser": "^7.16.0",
+                "@babel/template": "^7.16.0",
+                "@babel/traverse": "^7.16.0",
+                "@babel/types": "^7.16.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -66,17 +77,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/babel"
-            }
-        },
-        "node_modules/@babel/core/node_modules/@babel/code-frame": {
-            "version": "7.15.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/highlight": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core/node_modules/debug": {
@@ -112,11 +112,11 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.15.8",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.15.6",
+                "@babel/types": "^7.16.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -133,13 +133,13 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.15.4",
+            "version": "7.16.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.15.0",
+                "@babel/compat-data": "^7.16.0",
                 "@babel/helper-validator-option": "^7.14.5",
-                "browserslist": "^4.16.6",
+                "browserslist": "^4.17.5",
                 "semver": "^6.3.0"
             },
             "engines": {
@@ -158,86 +158,86 @@
             }
         },
         "node_modules/@babel/helper-function-name": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-get-function-arity": "^7.15.4",
-                "@babel/template": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/helper-get-function-arity": "^7.16.0",
+                "@babel/template": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-get-function-arity": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-hoist-variables": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-member-expression-to-functions": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.15.8",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.15.4",
-                "@babel/helper-replace-supers": "^7.15.4",
-                "@babel/helper-simple-access": "^7.15.4",
-                "@babel/helper-split-export-declaration": "^7.15.4",
+                "@babel/helper-module-imports": "^7.16.0",
+                "@babel/helper-replace-supers": "^7.16.0",
+                "@babel/helper-simple-access": "^7.16.0",
+                "@babel/helper-split-export-declaration": "^7.16.0",
                 "@babel/helper-validator-identifier": "^7.15.7",
-                "@babel/template": "^7.15.4",
-                "@babel/traverse": "^7.15.4",
-                "@babel/types": "^7.15.6"
+                "@babel/template": "^7.16.0",
+                "@babel/traverse": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-optimise-call-expression": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -252,36 +252,36 @@
             }
         },
         "node_modules/@babel/helper-replace-supers": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-member-expression-to-functions": "^7.15.4",
-                "@babel/helper-optimise-call-expression": "^7.15.4",
-                "@babel/traverse": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/helper-member-expression-to-functions": "^7.16.0",
+                "@babel/helper-optimise-call-expression": "^7.16.0",
+                "@babel/traverse": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-simple-access": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-split-export-declaration": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -304,24 +304,24 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.15.4",
+            "version": "7.16.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.15.4",
-                "@babel/traverse": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/template": "^7.16.0",
+                "@babel/traverse": "^7.16.3",
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/highlight": {
-            "version": "7.14.5",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -394,7 +394,7 @@
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.15.8",
+            "version": "7.16.4",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -540,7 +540,7 @@
             }
         },
         "node_modules/@babel/plugin-syntax-typescript": {
-            "version": "7.14.5",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -554,54 +554,32 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/template/node_modules/@babel/code-frame": {
-            "version": "7.15.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/highlight": "^7.14.5"
+                "@babel/code-frame": "^7.16.0",
+                "@babel/parser": "^7.16.0",
+                "@babel/types": "^7.16.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.15.4",
+            "version": "7.16.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/generator": "^7.15.4",
-                "@babel/helper-function-name": "^7.15.4",
-                "@babel/helper-hoist-variables": "^7.15.4",
-                "@babel/helper-split-export-declaration": "^7.15.4",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4",
+                "@babel/code-frame": "^7.16.0",
+                "@babel/generator": "^7.16.0",
+                "@babel/helper-function-name": "^7.16.0",
+                "@babel/helper-hoist-variables": "^7.16.0",
+                "@babel/helper-split-export-declaration": "^7.16.0",
+                "@babel/parser": "^7.16.3",
+                "@babel/types": "^7.16.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/traverse/node_modules/@babel/code-frame": {
-            "version": "7.15.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/highlight": "^7.14.5"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -632,11 +610,11 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.15.6",
+            "version": "7.16.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.14.9",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "to-fast-properties": "^2.0.0"
             },
             "engines": {
@@ -647,6 +625,23 @@
             "version": "0.2.3",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@d-fischer/cache-decorators": {
+            "version": "3.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "@d-fischer/shared-utils": "^3.0.1",
+                "@types/node": "^14.14.22",
+                "tslib": "^2.1.0"
+            }
+        },
+        "node_modules/@d-fischer/cache-decorators/node_modules/@types/node": {
+            "version": "14.17.34",
+            "license": "MIT"
+        },
+        "node_modules/@d-fischer/cache-decorators/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/@d-fischer/connection": {
             "version": "6.6.1",
@@ -672,17 +667,9 @@
                 "ws": "^8.2.0"
             }
         },
-        "node_modules/@d-fischer/connection/node_modules/@d-fischer/logger": {
-            "version": "4.1.1",
-            "license": "MIT",
-            "dependencies": {
-                "@d-fischer/shared-utils": "^3.2.0",
-                "detect-node": "^2.0.4",
-                "tslib": "^2.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            }
+        "node_modules/@d-fischer/connection/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/@d-fischer/connection/node_modules/ws": {
             "version": "8.2.3",
@@ -728,6 +715,22 @@
                 "node": ">=10"
             }
         },
+        "node_modules/@d-fischer/logger": {
+            "version": "4.1.1",
+            "license": "MIT",
+            "dependencies": {
+                "@d-fischer/shared-utils": "^3.2.0",
+                "detect-node": "^2.0.4",
+                "tslib": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
+            }
+        },
+        "node_modules/@d-fischer/logger/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
+        },
         "node_modules/@d-fischer/promise.allsettled": {
             "version": "2.0.2",
             "license": "MIT",
@@ -766,21 +769,13 @@
                 "tslib": "^2.0.3"
             }
         },
-        "node_modules/@d-fischer/rate-limiter/node_modules/@d-fischer/logger": {
-            "version": "4.1.1",
-            "license": "MIT",
-            "dependencies": {
-                "@d-fischer/shared-utils": "^3.2.0",
-                "detect-node": "^2.0.4",
-                "tslib": "^2.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            }
-        },
         "node_modules/@d-fischer/rate-limiter/node_modules/@types/node": {
-            "version": "12.20.36",
+            "version": "12.20.37",
             "license": "MIT"
+        },
+        "node_modules/@d-fischer/rate-limiter/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/@d-fischer/shared-utils": {
             "version": "3.2.0",
@@ -794,8 +789,12 @@
             }
         },
         "node_modules/@d-fischer/shared-utils/node_modules/@types/node": {
-            "version": "14.17.32",
+            "version": "14.17.34",
             "license": "MIT"
+        },
+        "node_modules/@d-fischer/shared-utils/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/@d-fischer/typed-event-emitter": {
             "version": "3.2.3",
@@ -809,13 +808,16 @@
             }
         },
         "node_modules/@d-fischer/typed-event-emitter/node_modules/@types/node": {
-            "version": "14.17.32",
+            "version": "14.17.34",
             "license": "MIT"
+        },
+        "node_modules/@d-fischer/typed-event-emitter/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/@discordjs/builders": {
             "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.8.2.tgz",
-            "integrity": "sha512-/YRd11SrcluqXkKppq/FAVzLIPRVlIVmc6X8ZklspzMIHDtJ+A4W37D43SHvLdH//+NnK+SHW/WeOF4Ts54PeQ==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@sindresorhus/is": "^4.2.0",
                 "discord-api-types": "^0.24.0",
@@ -830,8 +832,7 @@
         },
         "node_modules/@discordjs/builders/node_modules/@sindresorhus/is": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-            "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -839,10 +840,13 @@
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
             }
         },
+        "node_modules/@discordjs/builders/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
+        },
         "node_modules/@discordjs/collection": {
             "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.3.2.tgz",
-            "integrity": "sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg==",
+            "license": "Apache-2.0",
             "engines": {
                 "node": ">=16.0.0",
                 "npm": ">=7.0.0"
@@ -870,8 +874,7 @@
         },
         "node_modules/@elgato-stream-deck/core": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@elgato-stream-deck/core/-/core-5.1.1.tgz",
-            "integrity": "sha512-rj2UJThlPSdhY4V87UsxEM81Jte8WQGDJWnOt38VyI6waMZdiqgvzll6Ww9w93f6IFxIKVvPcKOUgCm+qRDofA==",
+            "license": "MIT",
             "dependencies": {
                 "eventemitter3": "^4.0.7"
             },
@@ -879,15 +882,9 @@
                 "node": ">=12.18"
             }
         },
-        "node_modules/@elgato-stream-deck/core/node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-        },
         "node_modules/@elgato-stream-deck/node": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@elgato-stream-deck/node/-/node-5.1.1.tgz",
-            "integrity": "sha512-zaAQWsZhVae/1kP/BK0iscyJ+3wweaNwm8APh1b7r9NyuMMtsDiRYHYcsaUjTnSOAwrnxogzUe0daS0BjmKJ4A==",
+            "license": "MIT",
             "dependencies": {
                 "@elgato-stream-deck/core": "5.1.1",
                 "jpeg-js": "^0.4.2",
@@ -902,9 +899,8 @@
         },
         "node_modules/@eslint/eslintrc": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
-            "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
@@ -920,17 +916,10 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
         "node_modules/@eslint/eslintrc/node_modules/debug": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -945,30 +934,16 @@
         },
         "node_modules/@eslint/eslintrc/node_modules/ignore": {
             "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-            "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
         },
-        "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
-        },
         "node_modules/@humanwhocodes/config-array": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
-            "integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
             "dev": true,
+            "license": "Apache-2.0",
             "dependencies": {
                 "@humanwhocodes/object-schema": "^1.2.0",
                 "debug": "^4.1.1",
@@ -980,9 +955,8 @@
         },
         "node_modules/@humanwhocodes/config-array/node_modules/debug": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -996,10 +970,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
-            "dev": true
+            "version": "1.2.1",
+            "dev": true,
+            "license": "BSD-3-Clause"
         },
         "node_modules/@istanbuljs/load-nyc-config": {
             "version": "1.1.0",
@@ -1014,6 +987,26 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+            "version": "1.0.10",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sprintf-js": "~1.0.2"
+            }
+        },
+        "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+            "version": "3.14.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "argparse": "^1.0.7",
+                "esprima": "^4.0.0"
+            },
+            "bin": {
+                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/@istanbuljs/load-nyc-config/node_modules/resolve-from": {
@@ -1263,9 +1256,8 @@
         },
         "node_modules/@julusian/jpeg-turbo": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@julusian/jpeg-turbo/-/jpeg-turbo-1.1.1.tgz",
-            "integrity": "sha512-IO1KqXbR+Taded0BgAvIj/IPTXvSip8MhkZ0PDpHqxIi2YNGeQ8TodxAAW2MB8DThO4opHKq4Ngx2ybZWzGZQw==",
             "hasInstallScript": true,
+            "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
                 "bindings": "^1.5.0",
@@ -1277,17 +1269,10 @@
                 "node": ">=10"
             }
         },
-        "node_modules/@julusian/jpeg-turbo/node_modules/node-addon-api": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-            "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-            "peer": true
-        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -1298,18 +1283,16 @@
         },
         "node_modules/@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -1445,8 +1428,7 @@
         },
         "node_modules/@sapphire/async-queue": {
             "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
-            "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=v14.0.0",
                 "npm": ">=7.0.0"
@@ -1510,10 +1492,9 @@
             }
         },
         "node_modules/@serialport/bindings": {
-            "version": "9.2.5",
-            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.2.5.tgz",
-            "integrity": "sha512-fyabNg56gWbOMuYJc5c45z94sANC/WzTnGeML7Nr1IYVk0SJ1uksN4ETI8Nea9ZAtr4DhNiIMQ3/IOkyof6Tqg==",
+            "version": "9.2.7",
             "hasInstallScript": true,
+            "license": "MIT",
             "dependencies": {
                 "@serialport/binding-abstract": "9.2.3",
                 "@serialport/parser-readline": "9.2.4",
@@ -1531,8 +1512,7 @@
         },
         "node_modules/@serialport/bindings/node_modules/debug": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -1663,7 +1643,7 @@
             }
         },
         "node_modules/@sinonjs/fake-timers": {
-            "version": "8.0.1",
+            "version": "8.1.0",
             "dev": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -1691,8 +1671,7 @@
         },
         "node_modules/@slack/web-api": {
             "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.5.0.tgz",
-            "integrity": "sha512-yQOipaMZVj2R/CxTQa3CuE1XAmgjxaxQFCY1/GPsdpy1rRGeB8hCQPcQf4WPxsM2b7rSVMicF9qFjKPVP+cYbw==",
+            "license": "MIT",
             "dependencies": {
                 "@slack/logger": "^3.0.0",
                 "@slack/types": "^2.0.0",
@@ -1711,13 +1690,9 @@
                 "npm": ">= 6.12.0"
             }
         },
-        "node_modules/@slack/web-api/node_modules/axios": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-            "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-            "dependencies": {
-                "follow-redirects": "^1.14.4"
-            }
+        "node_modules/@slack/web-api/node_modules/eventemitter3": {
+            "version": "3.1.2",
+            "license": "MIT"
         },
         "node_modules/@slack/web-api/node_modules/form-data": {
             "version": "2.5.1",
@@ -1763,8 +1738,7 @@
         },
         "node_modules/@twurple/api": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/api/-/api-5.0.9.tgz",
-            "integrity": "sha512-LO53jrfrtF1jkss78CC4W+uZ7Q+wQ96hkYjiQ37084c46foHgvwGJwOyfqSgOeSNsAvV603cQbjDJ043pdVu1w==",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/cache-decorators": "^3.0.0",
                 "@d-fischer/logger": "^4.0.0",
@@ -1783,8 +1757,7 @@
         },
         "node_modules/@twurple/api-call": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/api-call/-/api-call-5.0.9.tgz",
-            "integrity": "sha512-ug0t0O+vgyJO3sgp7QPX5GO4k1LbemK5qvdYbKK+VaWl1hdd9XrQ6iMRWG5MHeEObudENkNRCTpuEhr+hSvoIA==",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/cross-fetch": "^4.0.2",
                 "@d-fischer/qs": "^7.0.2",
@@ -1796,38 +1769,17 @@
                 "url": "https://github.com/sponsors/d-fischer"
             }
         },
-        "node_modules/@twurple/api/node_modules/@d-fischer/cache-decorators": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-3.0.0.tgz",
-            "integrity": "sha512-mYUCjrp5hJgimceC5bof3zzmElyxzW4ty+73IjY12wvxLAqsq0CbgLGspnJm6KgwEfGoeRnISZD4EXJidG3FvA==",
-            "dependencies": {
-                "@d-fischer/shared-utils": "^3.0.1",
-                "@types/node": "^14.14.22",
-                "tslib": "^2.1.0"
-            }
+        "node_modules/@twurple/api-call/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
-        "node_modules/@twurple/api/node_modules/@d-fischer/logger": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
-            "integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
-            "dependencies": {
-                "@d-fischer/shared-utils": "^3.2.0",
-                "detect-node": "^2.0.4",
-                "tslib": "^2.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            }
-        },
-        "node_modules/@twurple/api/node_modules/@types/node": {
-            "version": "14.17.32",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-            "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+        "node_modules/@twurple/api/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/@twurple/auth": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-5.0.9.tgz",
-            "integrity": "sha512-dODbqMTiYCiUY3+DRY3Ul+TcQVKdEfKhTv1TfFP6QLLycZbxdNm/lnUl/3wVlmH7FW7rdo/G99CJVr9bYh6JYQ==",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/logger": "^4.0.0",
                 "@d-fischer/shared-utils": "^3.2.0",
@@ -1839,23 +1791,13 @@
                 "url": "https://github.com/sponsors/d-fischer"
             }
         },
-        "node_modules/@twurple/auth/node_modules/@d-fischer/logger": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
-            "integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
-            "dependencies": {
-                "@d-fischer/shared-utils": "^3.2.0",
-                "detect-node": "^2.0.4",
-                "tslib": "^2.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            }
+        "node_modules/@twurple/auth/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/@twurple/chat": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/@twurple/chat/-/chat-5.0.8.tgz",
-            "integrity": "sha512-2xlw1oRLS/ULukzbdf7O1n6qo53hxeRa7QpJDbhh0AhXGOPv+sCd6UTa9YG/O98XaXWyCp+9OPRljQy6SNtTgA==",
+            "version": "5.0.9",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/cache-decorators": "^3.0.0",
                 "@d-fischer/deprecate": "^2.0.2",
@@ -1863,7 +1805,7 @@
                 "@d-fischer/rate-limiter": "^0.4.4",
                 "@d-fischer/shared-utils": "^3.2.0",
                 "@d-fischer/typed-event-emitter": "^3.2.2",
-                "@twurple/common": "^5.0.8",
+                "@twurple/common": "^5.0.9",
                 "ircv3": "^0.28.0",
                 "tslib": "^2.0.3"
             },
@@ -1874,56 +1816,13 @@
                 "@twurple/auth": "^5.0.0"
             }
         },
-        "node_modules/@twurple/chat/node_modules/@d-fischer/cache-decorators": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-3.0.0.tgz",
-            "integrity": "sha512-mYUCjrp5hJgimceC5bof3zzmElyxzW4ty+73IjY12wvxLAqsq0CbgLGspnJm6KgwEfGoeRnISZD4EXJidG3FvA==",
-            "dependencies": {
-                "@d-fischer/shared-utils": "^3.0.1",
-                "@types/node": "^14.14.22",
-                "tslib": "^2.1.0"
-            }
-        },
-        "node_modules/@twurple/chat/node_modules/@d-fischer/logger": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
-            "integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
-            "dependencies": {
-                "@d-fischer/shared-utils": "^3.2.0",
-                "detect-node": "^2.0.4",
-                "tslib": "^2.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            }
-        },
-        "node_modules/@twurple/chat/node_modules/@types/node": {
-            "version": "14.17.32",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-            "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
-        },
-        "node_modules/@twurple/chat/node_modules/ircv3": {
-            "version": "0.28.1",
-            "resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.28.1.tgz",
-            "integrity": "sha512-zYTN7S96evwQrQF7+1024JpGzPrK0enSiabd9uhzik9TZMstsellIUkLcQHYOxdq+P0dfDPqbvGqKrg2OAiaeA==",
-            "dependencies": {
-                "@d-fischer/connection": "^6.6.0",
-                "@d-fischer/escape-string-regexp": "^5.0.0",
-                "@d-fischer/logger": "^4.0.0",
-                "@d-fischer/shared-utils": "^3.0.1",
-                "@d-fischer/typed-event-emitter": "^3.2.2",
-                "@types/node": "^14.14.19",
-                "klona": "^2.0.4",
-                "tslib": "^2.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            }
+        "node_modules/@twurple/chat/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/@twurple/common": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/common/-/common-5.0.9.tgz",
-            "integrity": "sha512-9RUnPjWBn0FvoyFfO7SaV9TZ34J/6OBBZ1+dwHzf/1v1piDuK5dOuvgTR2q+8Qgf2zxZIUdoGe44s1ZjUspKkw==",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/shared-utils": "^3.2.0",
                 "klona": "^2.0.4",
@@ -1933,10 +1832,13 @@
                 "url": "https://github.com/sponsors/d-fischer"
             }
         },
+        "node_modules/@twurple/common/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
+        },
         "node_modules/@twurple/pubsub": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/pubsub/-/pubsub-5.0.9.tgz",
-            "integrity": "sha512-6feaTbG7vDuAiZD4/rqUL26IWOTW7paTJRodg40a9WQnAa4tLLJT3Sh+/ShdS9KMNjF16ouvNRM1dfsa36EBZw==",
+            "license": "MIT",
             "dependencies": {
                 "@d-fischer/connection": "^6.6.0",
                 "@d-fischer/logger": "^4.0.0",
@@ -1952,18 +1854,9 @@
                 "@twurple/auth": "^5.0.0"
             }
         },
-        "node_modules/@twurple/pubsub/node_modules/@d-fischer/logger": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
-            "integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
-            "dependencies": {
-                "@d-fischer/shared-utils": "^3.2.0",
-                "detect-node": "^2.0.4",
-                "tslib": "^2.0.3"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/d-fischer"
-            }
+        "node_modules/@twurple/pubsub/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/@types/babel__core": {
             "version": "7.1.16",
@@ -2003,7 +1896,7 @@
             }
         },
         "node_modules/@types/body-parser": {
-            "version": "1.19.1",
+            "version": "1.19.2",
             "license": "MIT",
             "dependencies": {
                 "@types/connect": "*",
@@ -2042,7 +1935,7 @@
             }
         },
         "node_modules/@types/eslint": {
-            "version": "7.28.2",
+            "version": "8.2.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2075,7 +1968,7 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.24",
+            "version": "4.17.25",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -2140,7 +2033,7 @@
             }
         },
         "node_modules/@types/jest": {
-            "version": "27.0.2",
+            "version": "27.0.3",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2163,9 +2056,8 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "16.11.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-            "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+            "version": "16.11.9",
+            "license": "MIT"
         },
         "node_modules/@types/node-fetch": {
             "version": "2.5.12",
@@ -2176,7 +2068,7 @@
             }
         },
         "node_modules/@types/node-telegram-bot-api": {
-            "version": "0.53.1",
+            "version": "0.53.2",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*",
@@ -2191,7 +2083,7 @@
             }
         },
         "node_modules/@types/prettier": {
-            "version": "2.4.1",
+            "version": "2.4.2",
             "dev": true,
             "license": "MIT"
         },
@@ -2273,11 +2165,11 @@
             }
         },
         "node_modules/@types/spotify-api": {
-            "version": "0.0.11",
+            "version": "0.0.12",
             "license": "MIT"
         },
         "node_modules/@types/spotify-web-api-node": {
-            "version": "5.0.3",
+            "version": "5.0.4",
             "license": "MIT",
             "dependencies": {
                 "@types/spotify-api": "*"
@@ -2321,13 +2213,12 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.3.1.tgz",
-            "integrity": "sha512-cFImaoIr5Ojj358xI/SDhjog57OK2NqlpxwdcgyxDA3bJlZcJq5CPzUXtpD7CxI2Hm6ATU7w5fQnnkVnmwpHqw==",
+            "version": "5.4.0",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/experimental-utils": "5.3.1",
-                "@typescript-eslint/scope-manager": "5.3.1",
+                "@typescript-eslint/experimental-utils": "5.4.0",
+                "@typescript-eslint/scope-manager": "5.4.0",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -2352,53 +2243,6 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.1.tgz",
-            "integrity": "sha512-XksFVBgAq0Y9H40BDbuPOTUIp7dn4u8oOuhcgGq7EoDP50eqcafkMVGrypyVGvDYHzjhdUCUwuwVUK4JhkMAMg==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.3.1",
-                "@typescript-eslint/visitor-keys": "5.3.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/types": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.1.tgz",
-            "integrity": "sha512-bG7HeBLolxKHtdHG54Uac750eXuQQPpdJfCYuw4ZI3bZ7+GgKClMWM8jExBtp7NSP4m8PmLRM8+lhzkYnSmSxQ==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.1.tgz",
-            "integrity": "sha512-3cHUzUuVTuNHx0Gjjt5pEHa87+lzyqOiHXy/Gz+SJOCW1mpw9xQHIIEwnKn+Thph1mgWyZ90nboOcSuZr/jTTQ==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.3.1",
-                "eslint-visitor-keys": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
             "version": "4.3.2",
             "dev": true,
@@ -2415,25 +2259,15 @@
                 }
             }
         },
-        "node_modules/@typescript-eslint/eslint-plugin/node_modules/eslint-visitor-keys": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-            "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
         "node_modules/@typescript-eslint/experimental-utils": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.1.tgz",
-            "integrity": "sha512-RgFn5asjZ5daUhbK5Sp0peq0SSMytqcrkNfU4pnDma2D8P3ElZ6JbYjY8IMSFfZAJ0f3x3tnO3vXHweYg0g59w==",
+            "version": "5.4.0",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.3.1",
-                "@typescript-eslint/types": "5.3.1",
-                "@typescript-eslint/typescript-estree": "5.3.1",
+                "@typescript-eslint/scope-manager": "5.4.0",
+                "@typescript-eslint/types": "5.4.0",
+                "@typescript-eslint/typescript-estree": "5.4.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
             },
@@ -2448,115 +2282,14 @@
                 "eslint": "*"
             }
         },
-        "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.1.tgz",
-            "integrity": "sha512-XksFVBgAq0Y9H40BDbuPOTUIp7dn4u8oOuhcgGq7EoDP50eqcafkMVGrypyVGvDYHzjhdUCUwuwVUK4JhkMAMg==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.3.1",
-                "@typescript-eslint/visitor-keys": "5.3.1"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/types": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.1.tgz",
-            "integrity": "sha512-bG7HeBLolxKHtdHG54Uac750eXuQQPpdJfCYuw4ZI3bZ7+GgKClMWM8jExBtp7NSP4m8PmLRM8+lhzkYnSmSxQ==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.1.tgz",
-            "integrity": "sha512-PwFbh/PKDVo/Wct6N3w+E4rLZxUDgsoII/GrWM2A62ETOzJd4M6s0Mu7w4CWsZraTbaC5UQI+dLeyOIFF1PquQ==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.3.1",
-                "@typescript-eslint/visitor-keys": "5.3.1",
-                "debug": "^4.3.2",
-                "globby": "^11.0.4",
-                "is-glob": "^4.0.3",
-                "semver": "^7.3.5",
-                "tsutils": "^3.21.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/experimental-utils/node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.1.tgz",
-            "integrity": "sha512-3cHUzUuVTuNHx0Gjjt5pEHa87+lzyqOiHXy/Gz+SJOCW1mpw9xQHIIEwnKn+Thph1mgWyZ90nboOcSuZr/jTTQ==",
-            "dev": true,
-            "dependencies": {
-                "@typescript-eslint/types": "5.3.1",
-                "eslint-visitor-keys": "^3.0.0"
-            },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/experimental-utils/node_modules/debug": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-            "dev": true,
-            "dependencies": {
-                "ms": "2.1.2"
-            },
-            "engines": {
-                "node": ">=6.0"
-            },
-            "peerDependenciesMeta": {
-                "supports-color": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-visitor-keys": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-            "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
         "node_modules/@typescript-eslint/parser": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.2.0.tgz",
-            "integrity": "sha512-Uyy4TjJBlh3NuA8/4yIQptyJb95Qz5PX//6p8n7zG0QnN4o3NF9Je3JHbVU7fxf5ncSXTmnvMtd/LDQWDk0YqA==",
+            "version": "5.4.0",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "5.2.0",
-                "@typescript-eslint/types": "5.2.0",
-                "@typescript-eslint/typescript-estree": "5.2.0",
+                "@typescript-eslint/scope-manager": "5.4.0",
+                "@typescript-eslint/types": "5.4.0",
+                "@typescript-eslint/typescript-estree": "5.4.0",
                 "debug": "^4.3.2"
             },
             "engines": {
@@ -2577,9 +2310,8 @@
         },
         "node_modules/@typescript-eslint/parser/node_modules/debug": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -2593,13 +2325,12 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.2.0.tgz",
-            "integrity": "sha512-RW+wowZqPzQw8MUFltfKYZfKXqA2qgyi6oi/31J1zfXJRpOn6tCaZtd9b5u9ubnDG2n/EMvQLeZrsLNPpaUiFQ==",
+            "version": "5.4.0",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "5.2.0",
-                "@typescript-eslint/visitor-keys": "5.2.0"
+                "@typescript-eslint/types": "5.4.0",
+                "@typescript-eslint/visitor-keys": "5.4.0"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2610,10 +2341,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.2.0.tgz",
-            "integrity": "sha512-cTk6x08qqosps6sPyP2j7NxyFPlCNsJwSDasqPNjEQ8JMD5xxj2NHxcLin5AJQ8pAVwpQ8BMI3bTxR0zxmK9qQ==",
+            "version": "5.4.0",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -2623,13 +2353,12 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.2.0.tgz",
-            "integrity": "sha512-RsdXq2XmVgKbm9nLsE3mjNUM7BTr/K4DYR9WfFVMUuozHWtH5gMpiNZmtrMG8GR385EOSQ3kC9HiEMJWimxd/g==",
+            "version": "5.4.0",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
-                "@typescript-eslint/types": "5.2.0",
-                "@typescript-eslint/visitor-keys": "5.2.0",
+                "@typescript-eslint/types": "5.4.0",
+                "@typescript-eslint/visitor-keys": "5.4.0",
                 "debug": "^4.3.2",
                 "globby": "^11.0.4",
                 "is-glob": "^4.0.3",
@@ -2651,9 +2380,8 @@
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.1.2"
             },
@@ -2667,12 +2395,11 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.2.0.tgz",
-            "integrity": "sha512-Nk7HizaXWWCUBfLA/rPNKMzXzWS8Wg9qHMuGtT+v2/YpPij4nVXrVJc24N/r5WrrmqK31jCrZxeHqIgqRzs0Xg==",
+            "version": "5.4.0",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "5.2.0",
+                "@typescript-eslint/types": "5.4.0",
                 "eslint-visitor-keys": "^3.0.0"
             },
             "engines": {
@@ -2681,15 +2408,6 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
-            }
-        },
-        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-            "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@webassemblyjs/ast": {
@@ -2898,7 +2616,7 @@
             }
         },
         "node_modules/acorn": {
-            "version": "7.4.1",
+            "version": "8.6.0",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -2917,11 +2635,29 @@
                 "acorn-walk": "^7.1.1"
             }
         },
+        "node_modules/acorn-globals/node_modules/acorn": {
+            "version": "7.4.1",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "acorn": "bin/acorn"
+            },
+            "engines": {
+                "node": ">=0.4.0"
+            }
+        },
+        "node_modules/acorn-import-assertions": {
+            "version": "1.8.0",
+            "dev": true,
+            "license": "MIT",
+            "peerDependencies": {
+                "acorn": "^8"
+            }
+        },
         "node_modules/acorn-jsx": {
             "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
+            "license": "MIT",
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
@@ -2933,11 +2669,6 @@
             "engines": {
                 "node": ">=0.4.0"
             }
-        },
-        "node_modules/after": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-            "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
         },
         "node_modules/agent-base": {
             "version": "6.0.2",
@@ -2992,8 +2723,7 @@
         },
         "node_modules/alawmulaw": {
             "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/alawmulaw/-/alawmulaw-5.0.2.tgz",
-            "integrity": "sha512-W3bWBB7MwTNGALlAKbOxe+tMNW9DpqGsv1V1idGPzctnBH++eS+Dx3UuucHNe5nk38WvAuy0sgMAbS5idHCArw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -3004,8 +2734,7 @@
         },
         "node_modules/ansi": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-            "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/ansi-align": {
@@ -3087,20 +2816,23 @@
             "license": "ISC"
         },
         "node_modules/are-we-there-yet": {
-            "version": "1.1.7",
+            "version": "1.0.6",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "readable-stream": "^2.0.0 || ^1.1.13"
             }
         },
         "node_modules/are-we-there-yet/node_modules/isarray": {
             "version": "1.0.0",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/are-we-there-yet/node_modules/readable-stream": {
             "version": "2.3.7",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -3114,17 +2846,15 @@
         "node_modules/are-we-there-yet/node_modules/string_decoder": {
             "version": "1.1.1",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
             }
         },
         "node_modules/argparse": {
-            "version": "1.0.10",
+            "version": "2.0.1",
             "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
+            "license": "Python-2.0"
         },
         "node_modules/array-differ": {
             "version": "3.0.0",
@@ -3179,11 +2909,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/arraybuffer.slice": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-            "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
-        },
         "node_modules/arrify": {
             "version": "2.0.1",
             "license": "MIT",
@@ -3203,7 +2928,7 @@
             }
         },
         "node_modules/asn1": {
-            "version": "0.2.4",
+            "version": "0.2.6",
             "license": "MIT",
             "dependencies": {
                 "safer-buffer": "~2.1.0"
@@ -3225,13 +2950,12 @@
             "link": true
         },
         "node_modules/atem-connection": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/atem-connection/-/atem-connection-2.3.1.tgz",
-            "integrity": "sha512-lw0k0uYDt+Ljf/w4zAEdQSI0g4/FZkFKEsohcYaliotH2rtkRMXkbfHbtQ9e/f8SIdZN4VikJBBeAkHqApi0GA==",
+            "version": "2.4.0",
+            "license": "MIT",
             "dependencies": {
-                "big-integer": "^1.6.48",
+                "big-integer": "^1.6.51",
                 "eventemitter3": "^4.0.4",
-                "exit-hook": "^2.0.0",
+                "exit-hook": "^2.2.1",
                 "nanotimer": "^0.3.15",
                 "threadedclass": "^0.8.0",
                 "tslib": "^1.13.0",
@@ -3240,16 +2964,6 @@
             "engines": {
                 "node": ">=8.10"
             }
-        },
-        "node_modules/atem-connection/node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-        },
-        "node_modules/atem-connection/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/aws-sign2": {
             "version": "0.7.0",
@@ -3263,10 +2977,10 @@
             "license": "MIT"
         },
         "node_modules/axios": {
-            "version": "0.21.4",
+            "version": "0.24.0",
             "license": "MIT",
             "dependencies": {
-                "follow-redirects": "^1.14.0"
+                "follow-redirects": "^1.14.4"
             }
         },
         "node_modules/babel-jest": {
@@ -3379,18 +3093,13 @@
                 "@babel/core": "^7.0.0"
             }
         },
-        "node_modules/backo2": {
-            "version": "1.0.2",
-            "license": "MIT"
-        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "license": "MIT"
         },
         "node_modules/base64-arraybuffer-es6": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.3.1.tgz",
-            "integrity": "sha512-TrhBheudYaff9adiTAqjSScjvtmClQ4vF9l4cqkPNkVsA11m4/NRdH4LkZ/tAMmpzzwfI20BXnJ/PTtafECCNA==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.6.0"
             }
@@ -3420,27 +3129,21 @@
                 "tweetnacl": "^0.14.3"
             }
         },
-        "node_modules/bcrypt-pbkdf/node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "license": "Unlicense"
-        },
         "node_modules/before-after-hook": {
             "version": "2.2.2",
             "license": "Apache-2.0"
         },
         "node_modules/big-integer": {
-            "version": "1.6.50",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-            "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ==",
+            "version": "1.6.51",
+            "license": "Unlicense",
             "engines": {
                 "node": ">=0.6"
             }
         },
         "node_modules/big.js": {
             "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "*"
             }
@@ -3454,15 +3157,11 @@
         },
         "node_modules/binary": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-            "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "buffers": "~0.1.1",
                 "chainsaw": "~0.1.0"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/binary-extensions": {
@@ -3482,8 +3181,7 @@
         },
         "node_modules/bitdepth": {
             "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/bitdepth/-/bitdepth-7.0.2.tgz",
-            "integrity": "sha512-Ed11TL4IIWyUEoQTfkbRBDCgDNurxYzFgmk30ZU6SgNCsysoEx7UMm+g7SDFHxA2lhLbWyjV8T1ab3z0BtYOAw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -3497,10 +3195,42 @@
                 "readable-stream": "^3.4.0"
             }
         },
-        "node_modules/blob": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-            "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
+        "node_modules/bl/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/bl/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/bl/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
         },
         "node_modules/bluebird": {
             "version": "3.7.2",
@@ -3562,7 +3292,7 @@
             }
         },
         "node_modules/boxen/node_modules/camelcase": {
-            "version": "6.2.0",
+            "version": "6.2.1",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -3597,12 +3327,12 @@
             "license": "BSD-2-Clause"
         },
         "node_modules/browserslist": {
-            "version": "4.17.5",
+            "version": "4.18.1",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "caniuse-lite": "^1.0.30001271",
-                "electron-to-chromium": "^1.3.878",
+                "caniuse-lite": "^1.0.30001280",
+                "electron-to-chromium": "^1.3.896",
                 "escalade": "^3.1.1",
                 "node-releases": "^2.0.1",
                 "picocolors": "^1.0.0"
@@ -3669,8 +3399,7 @@
         },
         "node_modules/buffer-indexof-polyfill": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
+            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10"
@@ -3678,14 +3407,11 @@
         },
         "node_modules/buffer-shims": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/buffers": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
             "peer": true,
             "engines": {
                 "node": ">=0.2.0"
@@ -3693,8 +3419,7 @@
         },
         "node_modules/byte-data": {
             "version": "16.0.3",
-            "resolved": "https://registry.npmjs.org/byte-data/-/byte-data-16.0.3.tgz",
-            "integrity": "sha512-IzV3mzv8OnnzPdb9CoESQr2ikPX/gkHUesRu+vff9XB7KwMxyflPDewtPFWXPvF+Xukl52ceor2IRLbnQZf3PQ==",
+            "license": "MIT",
             "dependencies": {
                 "endianness": "^8.0.2",
                 "ieee754-buffer": "^0.2.1",
@@ -3728,20 +3453,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/cacheable-request/node_modules/get-stream": {
-            "version": "5.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/cacheable-request/node_modules/lowercase-keys": {
@@ -3779,7 +3490,7 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001271",
+            "version": "1.0.30001282",
             "dev": true,
             "license": "CC-BY-4.0",
             "funding": {
@@ -3793,14 +3504,10 @@
         },
         "node_modules/chainsaw": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-            "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+            "license": "MIT/X11",
             "peer": true,
             "dependencies": {
                 "traverse": ">=0.3.0 <0.4"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/chalk": {
@@ -3855,6 +3562,17 @@
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
+            }
+        },
+        "node_modules/chokidar/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/chownr": {
@@ -3948,8 +3666,7 @@
         },
         "node_modules/cmake-js": {
             "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.2.1.tgz",
-            "integrity": "sha512-wEpg0Z8SY6ihXTe+xosadh4PbASdWSM/locbLacWRYJCZfAjWLyOrd4RoVIeirLkfPxmG8GdNQA9tW/Rz5SfJA==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "axios": "^0.21.1",
@@ -3977,27 +3694,23 @@
         },
         "node_modules/cmake-js/node_modules/ansi-regex": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/cmake-js/node_modules/are-we-there-yet": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-            "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+        "node_modules/cmake-js/node_modules/axios": {
+            "version": "0.21.4",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.0 || ^1.1.13"
+                "follow-redirects": "^1.14.0"
             }
         },
         "node_modules/cmake-js/node_modules/camelcase": {
             "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-            "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
+            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -4005,8 +3718,7 @@
         },
         "node_modules/cmake-js/node_modules/cliui": {
             "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-            "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "string-width": "^1.0.1",
@@ -4016,8 +3728,7 @@
         },
         "node_modules/cmake-js/node_modules/debug": {
             "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-            "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "ms": "2.1.2"
@@ -4031,32 +3742,9 @@
                 }
             }
         },
-        "node_modules/cmake-js/node_modules/fs-minipass": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-            "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-            "peer": true,
-            "dependencies": {
-                "minipass": "^2.6.0"
-            }
-        },
-        "node_modules/cmake-js/node_modules/gauge": {
-            "version": "1.2.7",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-            "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-            "peer": true,
-            "dependencies": {
-                "ansi": "^0.3.0",
-                "has-unicode": "^2.0.0",
-                "lodash.pad": "^4.1.0",
-                "lodash.padend": "^4.1.0",
-                "lodash.padstart": "^4.1.0"
-            }
-        },
         "node_modules/cmake-js/node_modules/is-fullwidth-code-point": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "number-is-nan": "^1.0.0"
@@ -4065,91 +3753,17 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/cmake-js/node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-            "peer": true
-        },
-        "node_modules/cmake-js/node_modules/minipass": {
-            "version": "2.9.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-            "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-            "peer": true,
-            "dependencies": {
-                "safe-buffer": "^5.1.2",
-                "yallist": "^3.0.0"
-            }
-        },
-        "node_modules/cmake-js/node_modules/minizlib": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-            "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-            "peer": true,
-            "dependencies": {
-                "minipass": "^2.9.0"
-            }
-        },
-        "node_modules/cmake-js/node_modules/mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "peer": true,
-            "dependencies": {
-                "minimist": "^1.2.5"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
-        "node_modules/cmake-js/node_modules/npmlog": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-            "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
-            "peer": true,
-            "dependencies": {
-                "ansi": "~0.3.0",
-                "are-we-there-yet": "~1.0.0",
-                "gauge": "~1.2.0"
-            }
-        },
-        "node_modules/cmake-js/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "peer": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
         "node_modules/cmake-js/node_modules/semver": {
             "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+            "license": "ISC",
             "peer": true,
             "bin": {
                 "semver": "bin/semver"
             }
         },
-        "node_modules/cmake-js/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "peer": true,
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
-        },
         "node_modules/cmake-js/node_modules/string-width": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "code-point-at": "^1.0.0",
@@ -4162,8 +3776,7 @@
         },
         "node_modules/cmake-js/node_modules/strip-ansi": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "ansi-regex": "^2.0.0"
@@ -4172,48 +3785,9 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/cmake-js/node_modules/tar": {
-            "version": "4.4.19",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-            "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
-            "peer": true,
-            "dependencies": {
-                "chownr": "^1.1.4",
-                "fs-minipass": "^1.2.7",
-                "minipass": "^2.9.0",
-                "minizlib": "^1.3.3",
-                "mkdirp": "^0.5.5",
-                "safe-buffer": "^5.2.1",
-                "yallist": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=4.5"
-            }
-        },
-        "node_modules/cmake-js/node_modules/tar/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "peer": true
-        },
         "node_modules/cmake-js/node_modules/which": {
             "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
@@ -4224,8 +3798,7 @@
         },
         "node_modules/cmake-js/node_modules/wrap-ansi": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-            "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "string-width": "^1.0.1",
@@ -4237,20 +3810,12 @@
         },
         "node_modules/cmake-js/node_modules/y18n": {
             "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-            "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-            "peer": true
-        },
-        "node_modules/cmake-js/node_modules/yallist": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-            "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+            "license": "ISC",
             "peer": true
         },
         "node_modules/cmake-js/node_modules/yargs": {
             "version": "3.32.0",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-            "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "camelcase": "^2.0.1",
@@ -4301,8 +3866,7 @@
         },
         "node_modules/colorette": {
             "version": "2.0.16",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-            "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+            "license": "MIT"
         },
         "node_modules/combined-stream": {
             "version": "1.0.8",
@@ -4336,19 +3900,9 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/component-bind": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-            "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-        },
         "node_modules/component-emitter": {
             "version": "1.3.0",
             "license": "MIT"
-        },
-        "node_modules/component-inherit": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-            "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -4367,8 +3921,45 @@
                 "typedarray": "^0.0.6"
             }
         },
+        "node_modules/concat-stream/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/concat-stream/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/concat-stream/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
         "node_modules/concurrently": {
-            "version": "6.3.0",
+            "version": "6.4.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4449,7 +4040,7 @@
             "license": "MIT"
         },
         "node_modules/core-util-is": {
-            "version": "1.0.2",
+            "version": "1.0.3",
             "license": "MIT"
         },
         "node_modules/cross-spawn": {
@@ -4479,9 +4070,8 @@
         },
         "node_modules/css-loader": {
             "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.5.1.tgz",
-            "integrity": "sha512-gEy2w9AnJNnD9Kuo4XAP9VflW/ujKoS9c/syO+uWMlm5igc7LysKzPXaDoR2vroROkSwsTS2tGr1yGGEbZOYZQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "icss-utils": "^5.1.0",
                 "postcss": "^8.2.15",
@@ -4505,9 +4095,8 @@
         },
         "node_modules/cssesc": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "cssesc": "bin/cssesc"
             },
@@ -4564,7 +4153,7 @@
             }
         },
         "node_modules/date-fns": {
-            "version": "2.25.0",
+            "version": "2.26.0",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -4605,8 +4194,7 @@
         },
         "node_modules/decamelize": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -4795,9 +4383,8 @@
         },
         "node_modules/dir-glob": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "path-type": "^4.0.0"
             },
@@ -4807,8 +4394,7 @@
         },
         "node_modules/discord-api-types": {
             "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.24.0.tgz",
-            "integrity": "sha512-X0uA2a92cRjowUEXpLZIHWl4jiX1NsUpDhcEOpa1/hpO1vkaokgZ8kkPtPih9hHth5UVQ3mHBu/PpB4qjyfJ4A==",
+            "license": "MIT",
             "engines": {
                 "node": ">=12"
             }
@@ -4823,8 +4409,7 @@
         },
         "node_modules/discord.js": {
             "version": "13.3.1",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.3.1.tgz",
-            "integrity": "sha512-zn4G8tL5+tMV00+0aSsVYNYcIfMSdT2g0nudKny+Ikd+XKv7m6bqI7n3Vji0GIRqXDr5ArPaw+iYFM2I1Iw3vg==",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@discordjs/builders": "^0.8.1",
                 "@discordjs/collection": "^0.3.2",
@@ -4843,8 +4428,7 @@
         },
         "node_modules/discord.js/node_modules/ws": {
             "version": "8.2.3",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-            "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -4915,8 +4499,7 @@
         },
         "node_modules/duplexer2": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+            "license": "BSD-3-Clause",
             "peer": true,
             "dependencies": {
                 "readable-stream": "^2.0.2"
@@ -4924,14 +4507,12 @@
         },
         "node_modules/duplexer2/node_modules/isarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/duplexer2/node_modules/readable-stream": {
             "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "core-util-is": "~1.0.0",
@@ -4945,8 +4526,7 @@
         },
         "node_modules/duplexer2/node_modules/string_decoder": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "safe-buffer": "~5.1.0"
@@ -4965,6 +4545,43 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^3.1.1",
                 "stream-shift": "^1.0.0"
+            }
+        },
+        "node_modules/duplexify/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/duplexify/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/duplexify/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/easymidi": {
@@ -4994,7 +4611,7 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.3.880",
+            "version": "1.3.903",
             "dev": true,
             "license": "ISC"
         },
@@ -5019,9 +4636,8 @@
         },
         "node_modules/emojis-list": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
@@ -5042,8 +4658,7 @@
         },
         "node_modules/endianness": {
             "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/endianness/-/endianness-8.0.2.tgz",
-            "integrity": "sha512-IU+77+jJ7lpw2qZ3NUuqBZFy3GuioNgXUdsL1L9tooDNTaw0TgOnwNuc+8Ns+haDaTifK97QLzmOANJtI/rGvw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -5270,9 +4885,8 @@
         },
         "node_modules/eslint": {
             "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
-            "integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@eslint/eslintrc": "^1.0.4",
                 "@humanwhocodes/config-array": "^0.6.0",
@@ -5337,9 +4951,8 @@
         },
         "node_modules/eslint-utils": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "eslint-visitor-keys": "^2.0.0"
             },
@@ -5353,7 +4966,7 @@
                 "eslint": ">=5"
             }
         },
-        "node_modules/eslint-visitor-keys": {
+        "node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
             "version": "2.1.0",
             "dev": true,
             "license": "Apache-2.0",
@@ -5361,11 +4974,13 @@
                 "node": ">=10"
             }
         },
-        "node_modules/eslint/node_modules/argparse": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-            "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
+        "node_modules/eslint-visitor-keys": {
+            "version": "3.1.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            }
         },
         "node_modules/eslint/node_modules/debug": {
             "version": "4.3.2",
@@ -5385,9 +5000,8 @@
         },
         "node_modules/eslint/node_modules/eslint-scope": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
-            "integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
@@ -5396,34 +5010,12 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
-        "node_modules/eslint/node_modules/eslint-visitor-keys": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-            "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
-            "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
         "node_modules/eslint/node_modules/estraverse": {
             "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-            "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "engines": {
                 "node": ">=4.0"
-            }
-        },
-        "node_modules/eslint/node_modules/glob-parent": {
-            "version": "6.0.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-            "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-            "dev": true,
-            "dependencies": {
-                "is-glob": "^4.0.3"
-            },
-            "engines": {
-                "node": ">=10.13.0"
             }
         },
         "node_modules/eslint/node_modules/ignore": {
@@ -5432,18 +5024,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 4"
-            }
-        },
-        "node_modules/eslint/node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-            "dev": true,
-            "dependencies": {
-                "argparse": "^2.0.1"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
             }
         },
         "node_modules/esm": {
@@ -5455,35 +5035,13 @@
         },
         "node_modules/espree": {
             "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
-            "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "acorn": "^8.5.0",
                 "acorn-jsx": "^5.3.1",
                 "eslint-visitor-keys": "^3.0.0"
             },
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-            }
-        },
-        "node_modules/espree/node_modules/acorn": {
-            "version": "8.5.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-            "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-            "dev": true,
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/espree/node_modules/eslint-visitor-keys": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-            "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-            "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
@@ -5582,7 +5140,7 @@
             }
         },
         "node_modules/eventemitter3": {
-            "version": "3.1.2",
+            "version": "4.0.7",
             "license": "MIT"
         },
         "node_modules/events": {
@@ -5594,18 +5152,18 @@
             }
         },
         "node_modules/execa": {
-            "version": "5.1.1",
+            "version": "4.1.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
                 "is-stream": "^2.0.0",
                 "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2",
                 "strip-final-newline": "^2.0.0"
             },
             "engines": {
@@ -5624,8 +5182,7 @@
         },
         "node_modules/exit-hook": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
-            "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             },
@@ -5734,9 +5291,8 @@
         },
         "node_modules/fast-glob": {
             "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-            "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -5746,6 +5302,17 @@
             },
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/fast-glob/node_modules/glob-parent": {
+            "version": "5.1.2",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "is-glob": "^4.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
             }
         },
         "node_modules/fast-json-stable-stringify": {
@@ -5772,9 +5339,8 @@
         },
         "node_modules/fastq": {
             "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
             }
@@ -5872,12 +5438,12 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.2",
+            "version": "3.2.4",
             "dev": true,
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.14.4",
+            "version": "1.14.5",
             "funding": [
                 {
                     "type": "individual",
@@ -5914,7 +5480,7 @@
             }
         },
         "node_modules/formidable": {
-            "version": "1.2.2",
+            "version": "1.2.6",
             "license": "MIT",
             "funding": {
                 "url": "https://ko-fi.com/tunnckoCore/commissions"
@@ -5944,8 +5510,7 @@
         },
         "node_modules/fs-extra": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-            "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
@@ -5954,14 +5519,11 @@
             }
         },
         "node_modules/fs-minipass": {
-            "version": "2.1.0",
+            "version": "1.2.7",
             "license": "ISC",
-            "optional": true,
+            "peer": true,
             "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
+                "minipass": "^2.6.0"
             }
         },
         "node_modules/fs.realpath": {
@@ -5970,8 +5532,7 @@
         },
         "node_modules/fstream": {
             "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
+            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
@@ -5983,22 +5544,9 @@
                 "node": ">=0.6"
             }
         },
-        "node_modules/fstream/node_modules/mkdirp": {
-            "version": "0.5.5",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-            "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-            "peer": true,
-            "dependencies": {
-                "minimist": "^1.2.5"
-            },
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            }
-        },
         "node_modules/fstream/node_modules/rimraf": {
             "version": "2.7.1",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-            "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+            "license": "ISC",
             "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
@@ -6017,56 +5565,15 @@
             "license": "MIT"
         },
         "node_modules/gauge": {
-            "version": "2.7.4",
+            "version": "1.2.7",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
+                "ansi": "^0.3.0",
                 "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
-        },
-        "node_modules/gauge/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gauge/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "license": "MIT",
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gauge/node_modules/string-width": {
-            "version": "1.0.2",
-            "license": "MIT",
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gauge/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "license": "MIT",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
+                "lodash.pad": "^4.1.0",
+                "lodash.padend": "^4.1.0",
+                "lodash.padstart": "^4.1.0"
             }
         },
         "node_modules/gaxios": {
@@ -6135,10 +5642,14 @@
             "license": "MIT"
         },
         "node_modules/get-stream": {
-            "version": "6.0.1",
+            "version": "5.2.0",
+            "dev": true,
             "license": "MIT",
+            "dependencies": {
+                "pump": "^3.0.0"
+            },
             "engines": {
-                "node": ">=10"
+                "node": ">=8"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -6196,14 +5707,14 @@
             }
         },
         "node_modules/glob-parent": {
-            "version": "5.1.2",
+            "version": "6.0.2",
             "dev": true,
             "license": "ISC",
             "dependencies": {
-                "is-glob": "^4.0.1"
+                "is-glob": "^4.0.3"
             },
             "engines": {
-                "node": ">= 6"
+                "node": ">=10.13.0"
             }
         },
         "node_modules/glob-to-regexp": {
@@ -6227,9 +5738,8 @@
         },
         "node_modules/globals": {
             "version": "13.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-            "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "type-fest": "^0.20.2"
             },
@@ -6242,9 +5752,8 @@
         },
         "node_modules/globby": {
             "version": "11.0.4",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "array-union": "^2.1.0",
                 "dir-glob": "^3.0.1",
@@ -6261,7 +5770,7 @@
             }
         },
         "node_modules/google-auth-library": {
-            "version": "7.10.1",
+            "version": "7.10.2",
             "license": "Apache-2.0",
             "dependencies": {
                 "arrify": "^2.0.0",
@@ -6404,23 +5913,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/has-binary2": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-            "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-            "dependencies": {
-                "isarray": "2.0.1"
-            }
-        },
-        "node_modules/has-binary2/node_modules/isarray": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-            "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-        },
-        "node_modules/has-cors": {
-            "version": "1.1.0",
-            "license": "MIT"
-        },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "dev": true,
@@ -6470,6 +5962,43 @@
             "dependencies": {
                 "glob": "^7.1.6",
                 "readable-stream": "^3.6.0"
+            }
+        },
+        "node_modules/help-me/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/help-me/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/help-me/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/hexy": {
@@ -6637,18 +6166,17 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "node_modules/human-signals": {
-            "version": "2.1.0",
+            "version": "1.1.1",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
-                "node": ">=10.17.0"
+                "node": ">=8.12.0"
             }
         },
         "node_modules/husky": {
             "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-            "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "husky": "lib/bin.js"
             },
@@ -6671,9 +6199,8 @@
         },
         "node_modules/icss-utils": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": "^10 || ^12 || >= 14"
             },
@@ -6701,14 +6228,13 @@
         },
         "node_modules/ieee754-buffer": {
             "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754-buffer/-/ieee754-buffer-0.2.1.tgz",
-            "integrity": "sha512-dDlJhYk8BAmH1HDncTjCt6xOm2+kT+MxGhRKB+mUoF8nocDzPAgZPEWTRI9QgkGvbDkbJgCqyxweGlIV0yhbUQ==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/ignore": {
-            "version": "5.1.8",
+            "version": "5.1.9",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -6722,17 +6248,15 @@
         },
         "node_modules/imaadpcm": {
             "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/imaadpcm/-/imaadpcm-4.1.2.tgz",
-            "integrity": "sha512-7gwxe6lKCGitmkMtGbm1ecnt0Q59KcWwo7AVi2RAd3lQ9VghVN5zX5x3oK6xNhfD9KUMbaYzku43UBn3Ix3RIA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/import-fresh": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -6774,11 +6298,6 @@
             "engines": {
                 "node": ">=0.8.19"
             }
-        },
-        "node_modules/indexof": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
         },
         "node_modules/inflight": {
             "version": "1.0.6",
@@ -6825,8 +6344,7 @@
         },
         "node_modules/invert-kv": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+            "license": "MIT",
             "peer": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -6840,7 +6358,7 @@
             }
         },
         "node_modules/ip6addr": {
-            "version": "0.2.3",
+            "version": "0.2.4",
             "license": "MPL-2.0",
             "dependencies": {
                 "assert-plus": "^1.0.0",
@@ -6858,12 +6376,30 @@
             "resolved": "samples/irc",
             "link": true
         },
-        "node_modules/irc-colors": {
-            "version": "1.5.0",
+        "node_modules/ircv3": {
+            "version": "0.28.1",
             "license": "MIT",
-            "engines": {
-                "node": ">=6"
+            "dependencies": {
+                "@d-fischer/connection": "^6.6.0",
+                "@d-fischer/escape-string-regexp": "^5.0.0",
+                "@d-fischer/logger": "^4.0.0",
+                "@d-fischer/shared-utils": "^3.0.1",
+                "@d-fischer/typed-event-emitter": "^3.2.2",
+                "@types/node": "^14.14.19",
+                "klona": "^2.0.4",
+                "tslib": "^2.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/d-fischer"
             }
+        },
+        "node_modules/ircv3/node_modules/@types/node": {
+            "version": "14.17.34",
+            "license": "MIT"
+        },
+        "node_modules/ircv3/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
         },
         "node_modules/is-arguments": {
             "version": "1.1.1",
@@ -7031,8 +6567,7 @@
         },
         "node_modules/is-iojs": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
-            "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/is-ip": {
@@ -7167,8 +6702,7 @@
         },
         "node_modules/is-running": {
             "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-running/-/is-running-2.1.0.tgz",
-            "integrity": "sha1-MKc/9cw4VOT8JUkICen1q/jeCeA="
+            "license": "BSD"
         },
         "node_modules/is-set": {
             "version": "2.0.2",
@@ -7424,6 +6958,47 @@
             },
             "engines": {
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+            }
+        },
+        "node_modules/jest-changed-files/node_modules/execa": {
+            "version": "5.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/jest-changed-files/node_modules/get-stream": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-changed-files/node_modules/human-signals": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
             }
         },
         "node_modules/jest-circus": {
@@ -7706,17 +7281,6 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
-        "node_modules/jest-message-util/node_modules/@babel/code-frame": {
-            "version": "7.15.8",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@babel/highlight": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/jest-mock": {
             "version": "27.3.0",
             "dev": true,
@@ -7854,6 +7418,47 @@
                 "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
             }
         },
+        "node_modules/jest-runtime/node_modules/execa": {
+            "version": "5.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/jest-runtime/node_modules/get-stream": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/jest-runtime/node_modules/human-signals": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/jest-serializer": {
             "version": "27.0.6",
             "dev": true,
@@ -7933,7 +7538,7 @@
             }
         },
         "node_modules/jest-validate/node_modules/camelcase": {
-            "version": "6.2.0",
+            "version": "6.2.1",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -7983,12 +7588,11 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "3.14.1",
+            "version": "4.1.0",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             },
             "bin": {
                 "js-yaml": "bin/js-yaml.js"
@@ -8044,17 +7648,6 @@
                 "canvas": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/jsdom/node_modules/acorn": {
-            "version": "8.5.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
             }
         },
         "node_modules/jsesc": {
@@ -8117,8 +7710,7 @@
         },
         "node_modules/jsonfile": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "license": "MIT",
             "peer": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
@@ -8186,9 +7778,8 @@
             }
         },
         "node_modules/knex": {
-            "version": "0.95.13",
-            "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.13.tgz",
-            "integrity": "sha512-XagG/iYA4RabYy1BmgY607Q00kBduOgb/Nej3+UDcCNdmuzDvZcfFo/726BYhfxv5amTBtGjewodZrTNbO63VA==",
+            "version": "0.95.14",
+            "license": "MIT",
             "dependencies": {
                 "colorette": "2.0.16",
                 "commander": "^7.1.0",
@@ -8266,8 +7857,7 @@
         },
         "node_modules/lcid": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "invert-kv": "^1.0.0"
@@ -8298,8 +7888,7 @@
         },
         "node_modules/listenercount": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
+            "license": "ISC",
             "peer": true
         },
         "node_modules/loader-runner": {
@@ -8312,9 +7901,8 @@
         },
         "node_modules/loader-utils": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "big.js": "^5.2.2",
                 "emojis-list": "^3.0.0",
@@ -8341,8 +7929,7 @@
         },
         "node_modules/lodash.isequal": {
             "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+            "license": "MIT"
         },
         "node_modules/lodash.memoize": {
             "version": "4.1.2",
@@ -8356,20 +7943,17 @@
         },
         "node_modules/lodash.pad": {
             "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-            "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/lodash.padend": {
             "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-            "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/lodash.padstart": {
             "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-            "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/long": {
@@ -8441,36 +8025,11 @@
         },
         "node_modules/memory-stream": {
             "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
-            "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
+            "license": "MMIT",
             "peer": true,
             "dependencies": {
                 "readable-stream": "~1.0.26-2"
             }
-        },
-        "node_modules/memory-stream/node_modules/isarray": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-            "peer": true
-        },
-        "node_modules/memory-stream/node_modules/readable-stream": {
-            "version": "1.0.34",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-            "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-            "peer": true,
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.1",
-                "isarray": "0.0.1",
-                "string_decoder": "~0.10.x"
-            }
-        },
-        "node_modules/memory-stream/node_modules/string_decoder": {
-            "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-            "peer": true
         },
         "node_modules/merge-descriptors": {
             "version": "1.0.1",
@@ -8483,9 +8042,8 @@
         },
         "node_modules/merge2": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
@@ -8511,7 +8069,6 @@
         },
         "node_modules/midi": {
             "version": "2.0.0",
-            "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
                 "bindings": "~1.5.0",
@@ -8544,17 +8101,17 @@
             }
         },
         "node_modules/mime-db": {
-            "version": "1.50.0",
+            "version": "1.51.0",
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
             }
         },
         "node_modules/mime-types": {
-            "version": "2.1.33",
+            "version": "2.1.34",
             "license": "MIT",
             "dependencies": {
-                "mime-db": "1.50.0"
+                "mime-db": "1.51.0"
             },
             "engines": {
                 "node": ">= 0.6"
@@ -8591,37 +8148,36 @@
             "license": "MIT"
         },
         "node_modules/minipass": {
-            "version": "3.1.5",
+            "version": "2.9.0",
             "license": "ISC",
-            "optional": true,
+            "peer": true,
             "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
             }
         },
+        "node_modules/minipass/node_modules/yallist": {
+            "version": "3.1.1",
+            "license": "ISC",
+            "peer": true
+        },
         "node_modules/minizlib": {
-            "version": "2.1.2",
+            "version": "1.3.3",
             "license": "MIT",
-            "optional": true,
+            "peer": true,
             "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
+                "minipass": "^2.9.0"
             }
         },
         "node_modules/mkdirp": {
-            "version": "1.0.4",
+            "version": "0.5.5",
             "license": "MIT",
-            "optional": true,
+            "peer": true,
+            "dependencies": {
+                "minimist": "^1.2.5"
+            },
             "bin": {
                 "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
             }
         },
         "node_modules/mkdirp-classic": {
@@ -8630,14 +8186,12 @@
         },
         "node_modules/monaco-editor": {
             "version": "0.30.1",
-            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
-            "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg=="
+            "license": "MIT"
         },
         "node_modules/monaco-editor-webpack-plugin": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-6.0.0.tgz",
-            "integrity": "sha512-vC886Mzpd2AkSM35XLkfQMjH+Ohz6RISVwhAejDUzZDheJAiz6G34lky1vyO8fZ702v7IrcKmsGwL1rRFnwvUA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "loader-utils": "^2.0.0"
             },
@@ -8717,6 +8271,43 @@
                 }
             }
         },
+        "node_modules/mqtt/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/mqtt/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/mqtt/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
         "node_modules/mri": {
             "version": "1.2.0",
             "dev": true,
@@ -8794,9 +8385,8 @@
         },
         "node_modules/nanoid": {
             "version": "3.1.30",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-            "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
             },
@@ -8810,8 +8400,7 @@
         },
         "node_modules/nanotimer": {
             "version": "0.3.15",
-            "resolved": "https://registry.npmjs.org/nanotimer/-/nanotimer-0.3.15.tgz",
-            "integrity": "sha1-KA0nfbkUbspvilcLVyq68qmsx1Q="
+            "license": "ISC"
         },
         "node_modules/napi-build-utils": {
             "version": "1.0.2",
@@ -8849,12 +8438,11 @@
             }
         },
         "node_modules/node-addon-api": {
-            "version": "1.7.2",
-            "license": "MIT",
-            "optional": true
+            "version": "3.2.1",
+            "license": "MIT"
         },
         "node_modules/node-fetch": {
-            "version": "2.6.5",
+            "version": "2.6.6",
             "license": "MIT",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
@@ -8909,6 +8497,107 @@
                 "node": ">= 10.12.0"
             }
         },
+        "node_modules/node-gyp/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "license": "MIT",
+            "optional": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/are-we-there-yet": {
+            "version": "1.1.7",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+            }
+        },
+        "node_modules/node-gyp/node_modules/chownr": {
+            "version": "2.0.0",
+            "license": "ISC",
+            "optional": true,
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/node-gyp/node_modules/fs-minipass": {
+            "version": "2.1.0",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "minipass": "^3.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/node-gyp/node_modules/gauge": {
+            "version": "2.7.4",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/isarray": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "optional": true
+        },
+        "node_modules/node-gyp/node_modules/minipass": {
+            "version": "3.1.5",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/node-gyp/node_modules/minizlib": {
+            "version": "2.1.2",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "minipass": "^3.0.0",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 8"
+            }
+        },
+        "node_modules/node-gyp/node_modules/mkdirp": {
+            "version": "1.0.4",
+            "license": "MIT",
+            "optional": true,
+            "bin": {
+                "mkdirp": "bin/cmd.js"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/node-gyp/node_modules/nopt": {
             "version": "5.0.0",
             "license": "ISC",
@@ -8921,6 +8610,79 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/node-gyp/node_modules/npmlog": {
+            "version": "4.1.2",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/node-gyp/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/string-width": {
+            "version": "1.0.2",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "license": "MIT",
+            "optional": true,
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/node-gyp/node_modules/tar": {
+            "version": "6.1.11",
+            "license": "ISC",
+            "optional": true,
+            "dependencies": {
+                "chownr": "^2.0.0",
+                "fs-minipass": "^2.0.0",
+                "minipass": "^3.0.0",
+                "minizlib": "^2.1.1",
+                "mkdirp": "^1.0.3",
+                "yallist": "^4.0.0"
+            },
+            "engines": {
+                "node": ">= 10"
             }
         },
         "node_modules/node-hid": {
@@ -8939,10 +8701,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/node-hid/node_modules/node-addon-api": {
-            "version": "3.2.1",
-            "license": "MIT"
-        },
         "node_modules/node-hue-api": {
             "version": "4.0.10",
             "license": "Apache-2.0",
@@ -8953,6 +8711,13 @@
             },
             "engines": {
                 "node": ">= 10.0.0"
+            }
+        },
+        "node_modules/node-hue-api/node_modules/axios": {
+            "version": "0.21.4",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.14.0"
             }
         },
         "node_modules/node-int64": {
@@ -9007,6 +8772,10 @@
             "dependencies": {
                 "ms": "^2.1.1"
             }
+        },
+        "node_modules/node-telegram-bot-api/node_modules/eventemitter3": {
+            "version": "3.1.2",
+            "license": "MIT"
         },
         "node_modules/node-telegram-bot-api/node_modules/isarray": {
             "version": "1.0.0",
@@ -9222,8 +8991,7 @@
         },
         "node_modules/nodecg-types": {
             "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/nodecg-types/-/nodecg-types-1.8.3.tgz",
-            "integrity": "sha512-ZK5HsYjoX73XMsI5BboQSvquDWcjlUdG0gwqNbWuowVeJWCZ6KGAE2ZLL6o1hQ12YIlKLcqb/6Jju/y8CBghOw==",
+            "license": "MIT",
             "dependencies": {
                 "@types/express": "^4.17.13",
                 "@types/node": "^16.7.1",
@@ -9233,20 +9001,20 @@
             }
         },
         "node_modules/nodemon": {
-            "version": "2.0.14",
+            "version": "2.0.15",
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {
-                "chokidar": "^3.2.2",
-                "debug": "^3.2.6",
+                "chokidar": "^3.5.2",
+                "debug": "^3.2.7",
                 "ignore-by-default": "^1.0.1",
                 "minimatch": "^3.0.4",
-                "pstree.remy": "^1.1.7",
+                "pstree.remy": "^1.1.8",
                 "semver": "^5.7.1",
                 "supports-color": "^5.5.0",
                 "touch": "^3.1.0",
-                "undefsafe": "^2.0.3",
+                "undefsafe": "^2.0.5",
                 "update-notifier": "^5.1.0"
             },
             "bin": {
@@ -9334,13 +9102,13 @@
             }
         },
         "node_modules/npmlog": {
-            "version": "4.1.2",
+            "version": "1.2.1",
             "license": "ISC",
+            "peer": true,
             "dependencies": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "ansi": "~0.3.0",
+                "are-we-there-yet": "~1.0.0",
+                "gauge": "~1.2.0"
             }
         },
         "node_modules/number-is-nan": {
@@ -9492,8 +9260,7 @@
         },
         "node_modules/os-locale": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "lcid": "^1.0.0"
@@ -9504,8 +9271,7 @@
         },
         "node_modules/ow": {
             "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-            "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
+            "license": "MIT",
             "dependencies": {
                 "@sindresorhus/is": "^4.0.1",
                 "callsites": "^3.1.0",
@@ -9523,8 +9289,7 @@
         },
         "node_modules/ow/node_modules/@sindresorhus/is": {
             "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-            "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10"
             },
@@ -9534,8 +9299,7 @@
         },
         "node_modules/ow/node_modules/dot-prop": {
             "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-            "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
+            "license": "MIT",
             "dependencies": {
                 "is-obj": "^2.0.0"
             },
@@ -9548,8 +9312,7 @@
         },
         "node_modules/ow/node_modules/type-fest": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-            "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
+            "license": "(MIT OR CC0-1.0)",
             "engines": {
                 "node": ">=10"
             },
@@ -9619,10 +9382,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-queue/node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "license": "MIT"
-        },
         "node_modules/p-retry": {
             "version": "4.6.1",
             "license": "MIT",
@@ -9676,9 +9435,8 @@
         },
         "node_modules/parent-module": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -9689,14 +9447,6 @@
         "node_modules/parse5": {
             "version": "6.0.1",
             "dev": true,
-            "license": "MIT"
-        },
-        "node_modules/parseqs": {
-            "version": "0.0.6",
-            "license": "MIT"
-        },
-        "node_modules/parseuri": {
-            "version": "0.0.6",
             "license": "MIT"
         },
         "node_modules/parseurl": {
@@ -9744,9 +9494,8 @@
         },
         "node_modules/path-type": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -9840,9 +9589,8 @@
         },
         "node_modules/postcss": {
             "version": "8.3.11",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-            "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "nanoid": "^3.1.30",
                 "picocolors": "^1.0.0",
@@ -9858,9 +9606,8 @@
         },
         "node_modules/postcss-modules-extract-imports": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
             "dev": true,
+            "license": "ISC",
             "engines": {
                 "node": "^10 || ^12 || >= 14"
             },
@@ -9870,9 +9617,8 @@
         },
         "node_modules/postcss-modules-local-by-default": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-            "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "icss-utils": "^5.0.0",
                 "postcss-selector-parser": "^6.0.2",
@@ -9887,9 +9633,8 @@
         },
         "node_modules/postcss-modules-scope": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-            "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "postcss-selector-parser": "^6.0.4"
             },
@@ -9902,9 +9647,8 @@
         },
         "node_modules/postcss-modules-values": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-            "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "icss-utils": "^5.0.0"
             },
@@ -9917,9 +9661,8 @@
         },
         "node_modules/postcss-selector-parser": {
             "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -9930,9 +9673,8 @@
         },
         "node_modules/postcss-value-parser": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-            "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/prebuild-install": {
             "version": "6.1.4",
@@ -9957,6 +9699,101 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/ansi-regex": {
+            "version": "2.1.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/are-we-there-yet": {
+            "version": "1.1.7",
+            "license": "ISC",
+            "dependencies": {
+                "delegates": "^1.0.0",
+                "readable-stream": "^2.0.6"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/gauge": {
+            "version": "2.7.4",
+            "license": "ISC",
+            "dependencies": {
+                "aproba": "^1.0.3",
+                "console-control-strings": "^1.0.0",
+                "has-unicode": "^2.0.0",
+                "object-assign": "^4.1.0",
+                "signal-exit": "^3.0.0",
+                "string-width": "^1.0.1",
+                "strip-ansi": "^3.0.1",
+                "wide-align": "^1.1.0"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "license": "MIT",
+            "dependencies": {
+                "number-is-nan": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/isarray": {
+            "version": "1.0.0",
+            "license": "MIT"
+        },
+        "node_modules/prebuild-install/node_modules/npmlog": {
+            "version": "4.1.2",
+            "license": "ISC",
+            "dependencies": {
+                "are-we-there-yet": "~1.1.2",
+                "console-control-strings": "~1.1.0",
+                "gauge": "~2.7.3",
+                "set-blocking": "~2.0.0"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/readable-stream": {
+            "version": "2.3.7",
+            "license": "MIT",
+            "dependencies": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/string_decoder": {
+            "version": "1.1.1",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.1.0"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/string-width": {
+            "version": "1.0.2",
+            "license": "MIT",
+            "dependencies": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/prebuild-install/node_modules/strip-ansi": {
+            "version": "3.0.1",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
             }
         },
         "node_modules/prelude-ls": {
@@ -10012,7 +9849,7 @@
             }
         },
         "node_modules/pretty-quick": {
-            "version": "3.1.1",
+            "version": "3.1.2",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -10043,50 +9880,6 @@
             },
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/pretty-quick/node_modules/execa": {
-            "version": "4.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "cross-spawn": "^7.0.0",
-                "get-stream": "^5.0.0",
-                "human-signals": "^1.1.1",
-                "is-stream": "^2.0.0",
-                "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.0",
-                "onetime": "^5.1.0",
-                "signal-exit": "^3.0.2",
-                "strip-final-newline": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sindresorhus/execa?sponsor=1"
-            }
-        },
-        "node_modules/pretty-quick/node_modules/get-stream": {
-            "version": "5.2.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "pump": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/pretty-quick/node_modules/human-signals": {
-            "version": "1.1.1",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=8.12.0"
             }
         },
         "node_modules/pretty-quick/node_modules/supports-color": {
@@ -10179,8 +9972,6 @@
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true,
             "funding": [
                 {
@@ -10195,7 +9986,8 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -10266,16 +10058,20 @@
             "license": "MIT"
         },
         "node_modules/readable-stream": {
-            "version": "3.6.0",
+            "version": "1.0.34",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
             }
+        },
+        "node_modules/readable-stream/node_modules/isarray": {
+            "version": "0.0.1",
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/readdirp": {
             "version": "3.6.0",
@@ -10321,16 +10117,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/mysticatea"
-            }
-        },
-        "node_modules/register-scheme": {
-            "version": "0.0.2",
-            "hasInstallScript": true,
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "bindings": "^1.3.0",
-                "node-addon-api": "^1.3.0"
             }
         },
         "node_modules/registry-auth-token": {
@@ -10473,13 +10259,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/require-from-string": {
-            "version": "2.0.2",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/resolve": {
             "version": "1.20.0",
             "license": "MIT",
@@ -10512,9 +10291,8 @@
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=4"
             }
@@ -10544,9 +10322,8 @@
         },
         "node_modules/reusify": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
@@ -10568,8 +10345,6 @@
         },
         "node_modules/run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
             "funding": [
                 {
@@ -10585,6 +10360,7 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
@@ -10599,11 +10375,6 @@
             "engines": {
                 "npm": ">=2.0.0"
             }
-        },
-        "node_modules/rxjs/node_modules/tslib": {
-            "version": "1.14.1",
-            "dev": true,
-            "license": "0BSD"
         },
         "node_modules/sacn": {
             "version": "4.1.0",
@@ -10742,12 +10513,11 @@
             }
         },
         "node_modules/serialport": {
-            "version": "9.2.5",
-            "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.2.5.tgz",
-            "integrity": "sha512-nsDsD2GN/43T2a8jQYr1HH76gmDZ575Ts8FOdcBRUY8ecaI16BPbXa612cPPkQjOfg28+KL5qtQL9c0vvTaidg==",
+            "version": "9.2.7",
+            "license": "MIT",
             "dependencies": {
                 "@serialport/binding-mock": "9.2.4",
-                "@serialport/bindings": "9.2.5",
+                "@serialport/bindings": "9.2.7",
                 "@serialport/parser-byte-length": "9.2.4",
                 "@serialport/parser-cctalk": "9.2.4",
                 "@serialport/parser-delimiter": "9.2.4",
@@ -10854,6 +10624,13 @@
                 "axios": "^0.21.0"
             }
         },
+        "node_modules/shlink-client/node_modules/axios": {
+            "version": "0.21.4",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.14.0"
+            }
+        },
         "node_modules/shlink-list-short-urls": {
             "resolved": "samples/shlink-list-short-urls",
             "link": true
@@ -10871,7 +10648,7 @@
             }
         },
         "node_modules/signal-exit": {
-            "version": "3.0.5",
+            "version": "3.0.6",
             "license": "ISC"
         },
         "node_modules/simple-concat": {
@@ -10974,15 +10751,14 @@
         },
         "node_modules/source-map-js": {
             "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-            "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
             }
         },
         "node_modules/source-map-support": {
-            "version": "0.5.20",
+            "version": "0.5.21",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -11012,10 +10788,46 @@
                 "readable-stream": "^3.0.0"
             }
         },
+        "node_modules/split2/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/split2/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/split2/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
         "node_modules/splitargs": {
             "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
-            "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
+            "license": "ISC",
             "peer": true
         },
         "node_modules/spotify-current-song": {
@@ -11067,10 +10879,6 @@
             "engines": {
                 "node": ">=0.10.0"
             }
-        },
-        "node_modules/sshpk/node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "license": "Unlicense"
         },
         "node_modules/stack-utils": {
             "version": "2.0.5",
@@ -11125,29 +10933,9 @@
             "link": true
         },
         "node_modules/string_decoder": {
-            "version": "1.3.0",
+            "version": "0.10.31",
             "license": "MIT",
-            "dependencies": {
-                "safe-buffer": "~5.2.0"
-            }
-        },
-        "node_modules/string_decoder/node_modules/safe-buffer": {
-            "version": "5.2.1",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ],
-            "license": "MIT"
+            "peer": true
         },
         "node_modules/string-length": {
             "version": "4.0.2",
@@ -11223,9 +11011,8 @@
         },
         "node_modules/strip-json-comments": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             },
@@ -11235,9 +11022,8 @@
         },
         "node_modules/style-loader": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 12.13.0"
             },
@@ -11285,7 +11071,7 @@
             }
         },
         "node_modules/superagent/node_modules/mime": {
-            "version": "2.5.2",
+            "version": "2.6.0",
             "license": "MIT",
             "bin": {
                 "mime": "cli.js"
@@ -11305,6 +11091,43 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/superagent/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
+            "engines": {
+                "node": ">= 6"
+            }
+        },
+        "node_modules/superagent/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/superagent/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
             }
         },
         "node_modules/supports-color": {
@@ -11358,19 +11181,20 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.1.11",
+            "version": "4.4.19",
             "license": "ISC",
-            "optional": true,
+            "peer": true,
             "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "chownr": "^1.1.4",
+                "fs-minipass": "^1.2.7",
+                "minipass": "^2.9.0",
+                "minizlib": "^1.3.3",
+                "mkdirp": "^0.5.5",
+                "safe-buffer": "^5.2.1",
+                "yallist": "^3.1.1"
             },
             "engines": {
-                "node": ">= 10"
+                "node": ">=4.5"
             }
         },
         "node_modules/tar-fs": {
@@ -11397,13 +11221,66 @@
                 "node": ">=6"
             }
         },
-        "node_modules/tar/node_modules/chownr": {
-            "version": "2.0.0",
-            "license": "ISC",
-            "optional": true,
+        "node_modules/tar-stream/node_modules/readable-stream": {
+            "version": "3.6.0",
+            "license": "MIT",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "string_decoder": "^1.1.1",
+                "util-deprecate": "^1.0.1"
+            },
             "engines": {
-                "node": ">=10"
+                "node": ">= 6"
             }
+        },
+        "node_modules/tar-stream/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/tar-stream/node_modules/string_decoder": {
+            "version": "1.3.0",
+            "license": "MIT",
+            "dependencies": {
+                "safe-buffer": "~5.2.0"
+            }
+        },
+        "node_modules/tar/node_modules/safe-buffer": {
+            "version": "5.2.1",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/tar/node_modules/yallist": {
+            "version": "3.1.1",
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/tarn": {
             "version": "3.0.1",
@@ -11436,7 +11313,7 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.9.0",
+            "version": "5.10.0",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -11449,15 +11326,22 @@
             },
             "engines": {
                 "node": ">=10"
+            },
+            "peerDependencies": {
+                "acorn": "^8.5.0"
+            },
+            "peerDependenciesMeta": {
+                "acorn": {
+                    "optional": true
+                }
             }
         },
         "node_modules/terser-webpack-plugin": {
-            "version": "5.2.4",
+            "version": "5.2.5",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "jest-worker": "^27.0.6",
-                "p-limit": "^3.1.0",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
                 "source-map": "^0.6.1",
@@ -11483,20 +11367,6 @@
                 "uglify-js": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/terser-webpack-plugin/node_modules/p-limit": {
-            "version": "3.1.0",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "yocto-queue": "^0.1.0"
-            },
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/terser/node_modules/commander": {
@@ -11532,8 +11402,7 @@
         },
         "node_modules/threadedclass": {
             "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/threadedclass/-/threadedclass-0.8.3.tgz",
-            "integrity": "sha512-cI6tVYRIIVYxFG7Nykt8NMVflrrdMvyvzAQfgAZdARdU/PaFSGd5Y7wChvJ3DXLsLiFb3datLhfn26K5DTKf+A==",
+            "license": "MIT",
             "dependencies": {
                 "callsites": "^3.1.0",
                 "eventemitter3": "^4.0.4",
@@ -11543,16 +11412,6 @@
             "engines": {
                 "node": ">=8.0"
             }
-        },
-        "node_modules/threadedclass/node_modules/eventemitter3": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-        },
-        "node_modules/threadedclass/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         },
         "node_modules/throat": {
             "version": "6.0.1",
@@ -11578,11 +11437,6 @@
             "version": "1.0.5",
             "dev": true,
             "license": "BSD-3-Clause"
-        },
-        "node_modules/to-array": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-            "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
         },
         "node_modules/to-fast-properties": {
             "version": "2.0.0",
@@ -11655,12 +11509,8 @@
         },
         "node_modules/traverse": {
             "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
-            "peer": true,
-            "engines": {
-                "node": "*"
-            }
+            "license": "MIT/X11",
+            "peer": true
         },
         "node_modules/tree-kill": {
             "version": "1.2.2",
@@ -11711,18 +11561,16 @@
         },
         "node_modules/ts-mixer": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-            "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+            "license": "MIT"
         },
         "node_modules/tslib": {
-            "version": "2.3.1",
+            "version": "1.14.1",
             "license": "0BSD"
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "tslib": "^1.8.1"
             },
@@ -11733,12 +11581,6 @@
                 "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
             }
         },
-        "node_modules/tsutils/node_modules/tslib": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-            "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-            "dev": true
-        },
         "node_modules/tunnel-agent": {
             "version": "0.6.0",
             "license": "Apache-2.0",
@@ -11748,6 +11590,10 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/tweetnacl": {
+            "version": "0.14.5",
+            "license": "Unlicense"
         },
         "node_modules/twitch-addons": {
             "resolved": "samples/twitch-addons",
@@ -11787,8 +11633,7 @@
         },
         "node_modules/twos-complement-buffer": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/twos-complement-buffer/-/twos-complement-buffer-0.0.1.tgz",
-            "integrity": "sha512-Ev3p2GfB2GO8pcyb7jIvctS9RAjSZrF/K+u5s3KN00ajY11Dda2oMqI72nXaHVU7doGYNXc0mJG6exWAbmzZiA==",
+            "license": "MIT",
             "dependencies": {
                 "uint-buffer": "^0.1.0"
             },
@@ -11854,7 +11699,7 @@
             }
         },
         "node_modules/typescript": {
-            "version": "4.4.4",
+            "version": "4.5.2",
             "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
@@ -11866,8 +11711,7 @@
         },
         "node_modules/uint-buffer": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/uint-buffer/-/uint-buffer-0.1.0.tgz",
-            "integrity": "sha512-7xjpjCTijFIXAMxN7OMRfykpCMVfbCrlAmAt2RIlihvkHgvkNV5DBFzyc8OpIQeVpRXJkgXBwmKos4hD8DrX1g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -11921,8 +11765,7 @@
         },
         "node_modules/unzipper": {
             "version": "0.8.14",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
-            "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "big-integer": "^1.6.17",
@@ -11938,26 +11781,22 @@
         },
         "node_modules/unzipper/node_modules/bluebird": {
             "version": "3.4.7",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-            "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/unzipper/node_modules/isarray": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/unzipper/node_modules/process-nextick-args": {
             "version": "1.0.7",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/unzipper/node_modules/readable-stream": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-            "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
+            "license": "MIT",
             "peer": true,
             "dependencies": {
                 "buffer-shims": "^1.0.0",
@@ -11968,12 +11807,6 @@
                 "string_decoder": "~0.10.x",
                 "util-deprecate": "~1.0.1"
             }
-        },
-        "node_modules/unzipper/node_modules/string_decoder": {
-            "version": "0.10.31",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-            "peer": true
         },
         "node_modules/update-notifier": {
             "version": "5.1.0",
@@ -12011,8 +11844,7 @@
         },
         "node_modules/url-join": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-            "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
+            "license": "MIT",
             "peer": true
         },
         "node_modules/url-parse-lax": {
@@ -12032,7 +11864,6 @@
         },
         "node_modules/usocket": {
             "version": "0.3.0",
-            "hasInstallScript": true,
             "license": "ISC",
             "optional": true,
             "dependencies": {
@@ -12043,8 +11874,7 @@
         },
         "node_modules/utf8-buffer": {
             "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/utf8-buffer/-/utf8-buffer-0.2.0.tgz",
-            "integrity": "sha512-DygDeOmOPQRjxnnv8LdfjoSQgG9EgJFH1m/1QcrKkDOxzoOcLLqZ2ONzRYHmiRqJYQYnAvV+zv2Wgk5tXjr4aA==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8"
             }
@@ -12095,8 +11925,7 @@
         },
         "node_modules/vali-date": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY=",
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -12119,6 +11948,10 @@
                 "core-util-is": "1.0.2",
                 "extsprintf": "^1.2.0"
             }
+        },
+        "node_modules/verror/node_modules/core-util-is": {
+            "version": "1.0.2",
+            "license": "MIT"
         },
         "node_modules/w3c-hr-time": {
             "version": "1.0.2",
@@ -12161,8 +11994,7 @@
         },
         "node_modules/wavefile": {
             "version": "8.4.6",
-            "resolved": "https://registry.npmjs.org/wavefile/-/wavefile-8.4.6.tgz",
-            "integrity": "sha512-mKvPtkXTFE3U8Uo8qJr/hCJP3booCI09vsoWY3OHrdKB+8ZefO/5/wSRZSbPSgFDB+WWn3Am3c01h/sguTYuyA==",
+            "license": "MIT",
             "dependencies": {
                 "alawmulaw": "^5.0.2",
                 "base64-arraybuffer-es6": "^0.3.1",
@@ -12186,10 +12018,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.64.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.0.tgz",
-            "integrity": "sha512-UclnN24m054HaPC45nmDEosX6yXWD+UGC12YtUs5i356DleAUGMDC9LBAw37xRRfgPKYIdCYjGA7RZ1AA+ZnGg==",
+            "version": "5.64.1",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@types/eslint-scope": "^3.7.0",
                 "@types/estree": "^0.0.50",
@@ -12214,7 +12045,7 @@
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.2.0",
-                "webpack-sources": "^3.2.0"
+                "webpack-sources": "^3.2.2"
             },
             "bin": {
                 "webpack": "bin/webpack.js"
@@ -12274,6 +12105,47 @@
                 }
             }
         },
+        "node_modules/webpack-cli/node_modules/execa": {
+            "version": "5.1.1",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cross-spawn": "^7.0.3",
+                "get-stream": "^6.0.0",
+                "human-signals": "^2.1.0",
+                "is-stream": "^2.0.0",
+                "merge-stream": "^2.0.0",
+                "npm-run-path": "^4.0.1",
+                "onetime": "^5.1.2",
+                "signal-exit": "^3.0.3",
+                "strip-final-newline": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/execa?sponsor=1"
+            }
+        },
+        "node_modules/webpack-cli/node_modules/get-stream": {
+            "version": "6.0.1",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/webpack-cli/node_modules/human-signals": {
+            "version": "2.1.0",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=10.17.0"
+            }
+        },
         "node_modules/webpack-merge": {
             "version": "5.8.0",
             "dev": true,
@@ -12287,30 +12159,11 @@
             }
         },
         "node_modules/webpack-sources": {
-            "version": "3.2.1",
+            "version": "3.2.2",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=10.13.0"
-            }
-        },
-        "node_modules/webpack/node_modules/acorn": {
-            "version": "8.5.0",
-            "dev": true,
-            "license": "MIT",
-            "bin": {
-                "acorn": "bin/acorn"
-            },
-            "engines": {
-                "node": ">=0.4.0"
-            }
-        },
-        "node_modules/webpack/node_modules/acorn-import-assertions": {
-            "version": "1.8.0",
-            "dev": true,
-            "license": "MIT",
-            "peerDependencies": {
-                "acorn": "^8"
             }
         },
         "node_modules/websocket-client": {
@@ -12400,8 +12253,7 @@
         },
         "node_modules/window-size": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
+            "license": "MIT",
             "peer": true,
             "bin": {
                 "window-size": "cli.js"
@@ -12552,27 +12404,12 @@
                 "node": ">=10"
             }
         },
-        "node_modules/yeast": {
-            "version": "0.1.2",
-            "license": "MIT"
-        },
-        "node_modules/yocto-queue": {
-            "version": "0.1.0",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/youtube-playlist": {
             "resolved": "samples/youtube-playlist",
             "link": true
         },
         "nodecg-io-core": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "ajv": "^8.6.3",
@@ -12591,18 +12428,18 @@
         },
         "nodecg-io-core/dashboard": {
             "name": "nodecg-io-dashboard",
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "crypto-js": "^4.1.1",
                 "monaco-editor": "^0.30.1",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-types": "^1.8.3"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "clean-webpack-plugin": "^4.0.0",
                 "css-loader": "^6.5.1",
                 "monaco-editor-webpack-plugin": "^6.0.0",
+                "nodecg-types": "^1.8.3",
                 "style-loader": "^3.3.1",
                 "typescript": "^4.4.4",
                 "webpack": "^5.64.0",
@@ -12627,499 +12464,503 @@
             "version": "1.0.0",
             "license": "MIT"
         },
+        "nodecg-io-core/node_modules/tslib": {
+            "version": "2.3.1",
+            "license": "0BSD"
+        },
         "samples/ahk-sendcommand": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-ahk": "^0.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-ahk": "^0.3.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/android": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-android": "^0.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-android": "^0.3.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/artnet-console": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-artnet": "^0.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-artnet": "^0.3.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/atem": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-atem": "^0.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-atem": "^0.3.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/curseforge": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-curseforge": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-curseforge": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/dbus-ratbagd": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-dbus": "0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-dbus": "0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/debug": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-debug": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-debug": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/discord-guild-chat": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-discord": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-discord": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/discord-rpc": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-discord-rpc": "0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-discord-rpc": "0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/elgato-light": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-elgato-light": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-elgato-light": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/github": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-github": "0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-github": "0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/gsheets": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-googleapis": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-googleapis": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/intellij": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-intellij": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-intellij": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/irc": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-irc": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-irc": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/midi-input": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-midi-input": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-midi-input": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/midi-io": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-midi-input": "^0.2.0",
-                "nodecg-io-midi-output": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-midi-input": "^0.3.0",
+                "nodecg-io-midi-output": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/midi-output": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-midi-output": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-midi-output": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/mqtt-client": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-mqtt-client": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-mqtt-client": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/nanoleaf": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-nanoleaf": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-nanoleaf": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/obs-scenelist": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-obs": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-obs": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/philipshue-lights": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-philipshue": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-philipshue": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/rcon-minecraft": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-rcon": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-rcon": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/reddit-msg-read": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-reddit": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-reddit": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/sacn-receiver": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-sacn-receiver": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-sacn-receiver": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/sacn-sender": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-sacn-sender": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-sacn-sender": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/serial": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-serial": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-serial": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/shlink-list-short-urls": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-shlink": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-shlink": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/slack-post": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-slack": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-slack": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/spotify-current-song": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-spotify": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-spotify": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/sql": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
                 "mysql": "^2.18.1",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-sql": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-sql": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/streamdeck-rainbow": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-streamdeck": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-streamdeck": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/streamelements-events": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-streamelements": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-streamelements": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/telegram-bot": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-telegram": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-telegram": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/template": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-template": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-template": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/tiane-discord": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-discord": "^0.2.0",
-                "nodecg-io-tiane": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-discord": "^0.3.0",
+                "nodecg-io-tiane": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/twitch-addons": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-addons": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-addons": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/twitch-api": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-api": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-api": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/twitch-chat": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-chat": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-chat": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/twitch-pubsub": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-pubsub": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-pubsub": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/twitter-timeline": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitter": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitter": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/websocket-client": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-websocket-client": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-websocket-client": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/websocket-server": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-websocket-server": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-websocket-server": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/xdotool-windowminimize": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-xdotool": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-xdotool": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "samples/youtube-playlist": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-googleapis": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-googleapis": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "services/nodecg-io-ahk": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13129,12 +12970,12 @@
             }
         },
         "services/nodecg-io-android": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@rauschma/stringio": "^1.4.0",
                 "get-stream": "^6.0.1",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13142,12 +12983,22 @@
                 "typescript": "^4.4.4"
             }
         },
+        "services/nodecg-io-android/node_modules/get-stream": {
+            "version": "6.0.1",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "services/nodecg-io-artnet": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "artnet-protocol": "^0.2.1",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13156,11 +13007,11 @@
             }
         },
         "services/nodecg-io-atem": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "atem-connection": "^2.3.1",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13169,11 +13020,11 @@
             }
         },
         "services/nodecg-io-curseforge": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13183,11 +13034,11 @@
             }
         },
         "services/nodecg-io-dbus": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "dbus-next": "^0.10.2",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13196,17 +13047,17 @@
             }
         },
         "services/nodecg-io-debug": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "monaco-editor": "^0.30.1",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-types": "^1.8.3"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
                 "css-loader": "^6.5.1",
+                "monaco-editor": "^0.30.1",
                 "monaco-editor-webpack-plugin": "^6.0.0",
-                "nodecg-types": "^1.8.3",
                 "style-loader": "^3.3.1",
                 "typescript": "^4.4.4",
                 "webpack": "^5.64.0",
@@ -13214,11 +13065,11 @@
             }
         },
         "services/nodecg-io-discord": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "discord.js": "^13.3.1",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13227,13 +13078,13 @@
             }
         },
         "services/nodecg-io-discord-rpc": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/discord-rpc": "^4.0.0",
                 "discord-rpc": "^4.0.1",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13254,12 +13105,12 @@
             }
         },
         "services/nodecg-io-elgato-light": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node-fetch": "^2.5.10",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13268,11 +13119,11 @@
             }
         },
         "services/nodecg-io-github": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@octokit/rest": "^18.12.0",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13281,13 +13132,13 @@
             }
         },
         "services/nodecg-io-googleapis": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/gapi": "^0.0.41",
                 "express": "^4.17.1",
                 "googleapis": "^89.0.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "open": "^8.4.0"
             },
             "devDependencies": {
@@ -13297,11 +13148,11 @@
             }
         },
         "services/nodecg-io-intellij": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13311,12 +13162,12 @@
             }
         },
         "services/nodecg-io-irc": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/irc": "^0.5.1",
                 "irc": "^0.5.2",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13339,11 +13190,11 @@
             }
         },
         "services/nodecg-io-midi-input": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "easymidi": "^2.1.0",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13352,11 +13203,11 @@
             }
         },
         "services/nodecg-io-midi-output": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "easymidi": "^2.1.0",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13365,11 +13216,11 @@
             }
         },
         "services/nodecg-io-mqtt-client": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "mqtt": "^4.2.8",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13378,24 +13229,24 @@
             }
         },
         "services/nodecg-io-nanoleaf": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node-fetch": "^2.5.10",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-types": "^1.8.3"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
-                "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "services/nodecg-io-obs": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "obs-websocket-js": "^4.0.3"
             },
             "devDependencies": {
@@ -13405,12 +13256,12 @@
             }
         },
         "services/nodecg-io-philipshue": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "is-ip": "^3.1.0",
                 "node-hue-api": "^4.0.10",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13419,10 +13270,10 @@
             }
         },
         "services/nodecg-io-rcon": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "rcon-client": "^4.2.3"
             },
             "devDependencies": {
@@ -13432,10 +13283,10 @@
             }
         },
         "services/nodecg-io-reddit": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "reddit-ts": "noeppi-noeppi/npm-reddit-ts#build"
             },
             "devDependencies": {
@@ -13445,10 +13296,10 @@
             }
         },
         "services/nodecg-io-sacn-receiver": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "sacn": "^4.1.0"
             },
             "devDependencies": {
@@ -13458,10 +13309,10 @@
             }
         },
         "services/nodecg-io-sacn-sender": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "sacn": "^4.1.0"
             },
             "devDependencies": {
@@ -13471,12 +13322,12 @@
             }
         },
         "services/nodecg-io-serial": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@serialport/parser-readline": "^9.2.4",
                 "@types/serialport": "^8.0.2",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "serialport": "^9.2.5"
             },
             "devDependencies": {
@@ -13486,10 +13337,10 @@
             }
         },
         "services/nodecg-io-shlink": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "shlink-client": "^1.0.1"
             },
             "devDependencies": {
@@ -13499,11 +13350,11 @@
             }
         },
         "services/nodecg-io-slack": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@slack/web-api": "^6.5.0",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13512,12 +13363,12 @@
             }
         },
         "services/nodecg-io-spotify": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/spotify-web-api-node": "^5.0.3",
                 "express": "^4.17.1",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "open": "^8.4.0",
                 "spotify-web-api-node": "^5.0.2"
             },
@@ -13528,11 +13379,11 @@
             }
         },
         "services/nodecg-io-sql": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "knex": "^0.95.13",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13541,11 +13392,11 @@
             }
         },
         "services/nodecg-io-streamdeck": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@elgato-stream-deck/node": "^5.1.1",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13554,11 +13405,11 @@
             }
         },
         "services/nodecg-io-streamelements": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/socket.io-client": "^1.4.36",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "socket.io-client": "^2.4.0"
             },
             "devDependencies": {
@@ -13569,24 +13420,20 @@
         },
         "services/nodecg-io-streamelements/node_modules/base64-arraybuffer": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-            "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI=",
             "engines": {
                 "node": ">= 0.6.0"
             }
         },
         "services/nodecg-io-streamelements/node_modules/debug": {
             "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "license": "MIT",
             "dependencies": {
                 "ms": "2.0.0"
             }
         },
         "services/nodecg-io-streamelements/node_modules/engine.io-client": {
             "version": "3.5.2",
-            "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
-            "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
+            "license": "MIT",
             "dependencies": {
                 "component-emitter": "~1.3.0",
                 "component-inherit": "0.0.3",
@@ -13603,8 +13450,7 @@
         },
         "services/nodecg-io-streamelements/node_modules/engine.io-parser": {
             "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
-            "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
+            "license": "MIT",
             "dependencies": {
                 "after": "0.8.2",
                 "arraybuffer.slice": "~0.0.7",
@@ -13615,18 +13461,15 @@
         },
         "services/nodecg-io-streamelements/node_modules/isarray": {
             "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-            "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+            "license": "MIT"
         },
         "services/nodecg-io-streamelements/node_modules/ms": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+            "license": "MIT"
         },
         "services/nodecg-io-streamelements/node_modules/socket.io-client": {
             "version": "2.4.0",
-            "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
-            "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
+            "license": "MIT",
             "dependencies": {
                 "backo2": "1.0.2",
                 "component-bind": "1.0.0",
@@ -13643,8 +13486,7 @@
         },
         "services/nodecg-io-streamelements/node_modules/socket.io-parser": {
             "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
-            "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
+            "license": "MIT",
             "dependencies": {
                 "component-emitter": "~1.3.0",
                 "debug": "~3.1.0",
@@ -13653,8 +13495,7 @@
         },
         "services/nodecg-io-streamelements/node_modules/ws": {
             "version": "7.4.6",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-            "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+            "license": "MIT",
             "engines": {
                 "node": ">=8.3.0"
             },
@@ -13673,19 +13514,17 @@
         },
         "services/nodecg-io-streamelements/node_modules/xmlhttprequest-ssl": {
             "version": "1.6.3",
-            "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
-            "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q==",
             "engines": {
                 "node": ">=0.4.0"
             }
         },
         "services/nodecg-io-telegram": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/node-telegram-bot-api": "^0.53.1",
                 "node-telegram-bot-api": "^0.54.0",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13694,10 +13533,10 @@
             }
         },
         "services/nodecg-io-template": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13706,10 +13545,10 @@
             }
         },
         "services/nodecg-io-tiane": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "ws": "^8.2.3"
             },
             "devDependencies": {
@@ -13739,12 +13578,12 @@
             }
         },
         "services/nodecg-io-twitch-addons": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-auth": "^0.2.0"
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-auth": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13754,12 +13593,12 @@
             }
         },
         "services/nodecg-io-twitch-api": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@twurple/api": "^5.0.9",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-auth": "^0.2.0"
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-auth": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13768,12 +13607,12 @@
             }
         },
         "services/nodecg-io-twitch-chat": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@twurple/chat": "^5.0.8",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-auth": "^0.2.0"
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-auth": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13782,13 +13621,13 @@
             }
         },
         "services/nodecg-io-twitch-pubsub": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@twurple/api": "^5.0.9",
                 "@twurple/pubsub": "^5.0.9",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-auth": "^0.2.0"
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-auth": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13797,11 +13636,11 @@
             }
         },
         "services/nodecg-io-twitter": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/twitter": "^1.7.1",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "twitter": "^1.7.1"
             },
             "devDependencies": {
@@ -13811,11 +13650,11 @@
             }
         },
         "services/nodecg-io-websocket-client": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ws": "^8.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "ws": "^8.2.3"
             },
             "devDependencies": {
@@ -13844,11 +13683,11 @@
             }
         },
         "services/nodecg-io-websocket-server": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@types/ws": "^8.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "ws": "^8.2.3"
             },
             "devDependencies": {
@@ -13877,12 +13716,12 @@
             }
         },
         "services/nodecg-io-xdotool": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@rauschma/stringio": "^1.4.0",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^16.11.7",
@@ -13892,7 +13731,7 @@
             }
         },
         "utils/nodecg-io-twitch-auth": {
-            "version": "0.2.0",
+            "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
                 "@twurple/auth": "^5.0.9"
@@ -13910,23 +13749,30 @@
                 "dayjs": "^1.8.28"
             }
         },
+        "@babel/code-frame": {
+            "version": "7.16.0",
+            "dev": true,
+            "requires": {
+                "@babel/highlight": "^7.16.0"
+            }
+        },
         "@babel/compat-data": {
-            "version": "7.15.0",
+            "version": "7.16.4",
             "dev": true
         },
         "@babel/core": {
-            "version": "7.15.8",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.15.8",
-                "@babel/generator": "^7.15.8",
-                "@babel/helper-compilation-targets": "^7.15.4",
-                "@babel/helper-module-transforms": "^7.15.8",
-                "@babel/helpers": "^7.15.4",
-                "@babel/parser": "^7.15.8",
-                "@babel/template": "^7.15.4",
-                "@babel/traverse": "^7.15.4",
-                "@babel/types": "^7.15.6",
+                "@babel/code-frame": "^7.16.0",
+                "@babel/generator": "^7.16.0",
+                "@babel/helper-compilation-targets": "^7.16.0",
+                "@babel/helper-module-transforms": "^7.16.0",
+                "@babel/helpers": "^7.16.0",
+                "@babel/parser": "^7.16.0",
+                "@babel/template": "^7.16.0",
+                "@babel/traverse": "^7.16.0",
+                "@babel/types": "^7.16.0",
                 "convert-source-map": "^1.7.0",
                 "debug": "^4.1.0",
                 "gensync": "^1.0.0-beta.2",
@@ -13935,13 +13781,6 @@
                 "source-map": "^0.5.0"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.15.8",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.14.5"
-                    }
-                },
                 "debug": {
                     "version": "4.3.2",
                     "dev": true,
@@ -13960,10 +13799,10 @@
             }
         },
         "@babel/generator": {
-            "version": "7.15.8",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.6",
+                "@babel/types": "^7.16.0",
                 "jsesc": "^2.5.1",
                 "source-map": "^0.5.0"
             },
@@ -13975,12 +13814,12 @@
             }
         },
         "@babel/helper-compilation-targets": {
-            "version": "7.15.4",
+            "version": "7.16.3",
             "dev": true,
             "requires": {
-                "@babel/compat-data": "^7.15.0",
+                "@babel/compat-data": "^7.16.0",
                 "@babel/helper-validator-option": "^7.14.5",
-                "browserslist": "^4.16.6",
+                "browserslist": "^4.17.5",
                 "semver": "^6.3.0"
             },
             "dependencies": {
@@ -13991,61 +13830,61 @@
             }
         },
         "@babel/helper-function-name": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/helper-get-function-arity": "^7.15.4",
-                "@babel/template": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/helper-get-function-arity": "^7.16.0",
+                "@babel/template": "^7.16.0",
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-get-function-arity": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-hoist-variables": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-member-expression-to-functions": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-module-imports": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-module-transforms": {
-            "version": "7.15.8",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/helper-module-imports": "^7.15.4",
-                "@babel/helper-replace-supers": "^7.15.4",
-                "@babel/helper-simple-access": "^7.15.4",
-                "@babel/helper-split-export-declaration": "^7.15.4",
+                "@babel/helper-module-imports": "^7.16.0",
+                "@babel/helper-replace-supers": "^7.16.0",
+                "@babel/helper-simple-access": "^7.16.0",
+                "@babel/helper-split-export-declaration": "^7.16.0",
                 "@babel/helper-validator-identifier": "^7.15.7",
-                "@babel/template": "^7.15.4",
-                "@babel/traverse": "^7.15.4",
-                "@babel/types": "^7.15.6"
+                "@babel/template": "^7.16.0",
+                "@babel/traverse": "^7.16.0",
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-optimise-call-expression": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-plugin-utils": {
@@ -14053,27 +13892,27 @@
             "dev": true
         },
         "@babel/helper-replace-supers": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/helper-member-expression-to-functions": "^7.15.4",
-                "@babel/helper-optimise-call-expression": "^7.15.4",
-                "@babel/traverse": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/helper-member-expression-to-functions": "^7.16.0",
+                "@babel/helper-optimise-call-expression": "^7.16.0",
+                "@babel/traverse": "^7.16.0",
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-simple-access": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-split-export-declaration": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/types": "^7.15.4"
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/helper-validator-identifier": {
@@ -14085,19 +13924,19 @@
             "dev": true
         },
         "@babel/helpers": {
-            "version": "7.15.4",
+            "version": "7.16.3",
             "dev": true,
             "requires": {
-                "@babel/template": "^7.15.4",
-                "@babel/traverse": "^7.15.4",
-                "@babel/types": "^7.15.4"
+                "@babel/template": "^7.16.0",
+                "@babel/traverse": "^7.16.3",
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/highlight": {
-            "version": "7.14.5",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.14.5",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
             },
@@ -14147,7 +13986,7 @@
             }
         },
         "@babel/parser": {
-            "version": "7.15.8",
+            "version": "7.16.4",
             "dev": true
         },
         "@babel/plugin-syntax-async-generators": {
@@ -14235,52 +14074,36 @@
             }
         },
         "@babel/plugin-syntax-typescript": {
-            "version": "7.14.5",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
                 "@babel/helper-plugin-utils": "^7.14.5"
             }
         },
         "@babel/template": {
-            "version": "7.15.4",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.15.8",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.14.5"
-                    }
-                }
+                "@babel/code-frame": "^7.16.0",
+                "@babel/parser": "^7.16.0",
+                "@babel/types": "^7.16.0"
             }
         },
         "@babel/traverse": {
-            "version": "7.15.4",
+            "version": "7.16.3",
             "dev": true,
             "requires": {
-                "@babel/code-frame": "^7.14.5",
-                "@babel/generator": "^7.15.4",
-                "@babel/helper-function-name": "^7.15.4",
-                "@babel/helper-hoist-variables": "^7.15.4",
-                "@babel/helper-split-export-declaration": "^7.15.4",
-                "@babel/parser": "^7.15.4",
-                "@babel/types": "^7.15.4",
+                "@babel/code-frame": "^7.16.0",
+                "@babel/generator": "^7.16.0",
+                "@babel/helper-function-name": "^7.16.0",
+                "@babel/helper-hoist-variables": "^7.16.0",
+                "@babel/helper-split-export-declaration": "^7.16.0",
+                "@babel/parser": "^7.16.3",
+                "@babel/types": "^7.16.0",
                 "debug": "^4.1.0",
                 "globals": "^11.1.0"
             },
             "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.15.8",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.14.5"
-                    }
-                },
                 "debug": {
                     "version": "4.3.2",
                     "dev": true,
@@ -14295,16 +14118,32 @@
             }
         },
         "@babel/types": {
-            "version": "7.15.6",
+            "version": "7.16.0",
             "dev": true,
             "requires": {
-                "@babel/helper-validator-identifier": "^7.14.9",
+                "@babel/helper-validator-identifier": "^7.15.7",
                 "to-fast-properties": "^2.0.0"
             }
         },
         "@bcoe/v8-coverage": {
             "version": "0.2.3",
             "dev": true
+        },
+        "@d-fischer/cache-decorators": {
+            "version": "3.0.0",
+            "requires": {
+                "@d-fischer/shared-utils": "^3.0.1",
+                "@types/node": "^14.14.22",
+                "tslib": "^2.1.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "14.17.34"
+                },
+                "tslib": {
+                    "version": "2.3.1"
+                }
+            }
         },
         "@d-fischer/connection": {
             "version": "6.6.1",
@@ -14323,13 +14162,8 @@
                     "version": "7.0.0",
                     "requires": {}
                 },
-                "@d-fischer/logger": {
-                    "version": "4.1.1",
-                    "requires": {
-                        "@d-fischer/shared-utils": "^3.2.0",
-                        "detect-node": "^2.0.4",
-                        "tslib": "^2.0.3"
-                    }
+                "tslib": {
+                    "version": "2.3.1"
                 },
                 "ws": {
                     "version": "8.2.3",
@@ -14354,6 +14188,19 @@
         "@d-fischer/escape-string-regexp": {
             "version": "5.0.0"
         },
+        "@d-fischer/logger": {
+            "version": "4.1.1",
+            "requires": {
+                "@d-fischer/shared-utils": "^3.2.0",
+                "detect-node": "^2.0.4",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1"
+                }
+            }
+        },
         "@d-fischer/promise.allsettled": {
             "version": "2.0.2",
             "requires": {
@@ -14377,16 +14224,11 @@
                 "tslib": "^2.0.3"
             },
             "dependencies": {
-                "@d-fischer/logger": {
-                    "version": "4.1.1",
-                    "requires": {
-                        "@d-fischer/shared-utils": "^3.2.0",
-                        "detect-node": "^2.0.4",
-                        "tslib": "^2.0.3"
-                    }
-                },
                 "@types/node": {
-                    "version": "12.20.36"
+                    "version": "12.20.37"
+                },
+                "tslib": {
+                    "version": "2.3.1"
                 }
             }
         },
@@ -14398,7 +14240,10 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "14.17.32"
+                    "version": "14.17.34"
+                },
+                "tslib": {
+                    "version": "2.3.1"
                 }
             }
         },
@@ -14410,14 +14255,15 @@
             },
             "dependencies": {
                 "@types/node": {
-                    "version": "14.17.32"
+                    "version": "14.17.34"
+                },
+                "tslib": {
+                    "version": "2.3.1"
                 }
             }
         },
         "@discordjs/builders": {
             "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-0.8.2.tgz",
-            "integrity": "sha512-/YRd11SrcluqXkKppq/FAVzLIPRVlIVmc6X8ZklspzMIHDtJ+A4W37D43SHvLdH//+NnK+SHW/WeOF4Ts54PeQ==",
             "requires": {
                 "@sindresorhus/is": "^4.2.0",
                 "discord-api-types": "^0.24.0",
@@ -14427,16 +14273,15 @@
             },
             "dependencies": {
                 "@sindresorhus/is": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-                    "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+                    "version": "4.2.0"
+                },
+                "tslib": {
+                    "version": "2.3.1"
                 }
             }
         },
         "@discordjs/collection": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-0.3.2.tgz",
-            "integrity": "sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg=="
+            "version": "0.3.2"
         },
         "@discordjs/form-data": {
             "version": "3.0.1",
@@ -14452,23 +14297,12 @@
         },
         "@elgato-stream-deck/core": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@elgato-stream-deck/core/-/core-5.1.1.tgz",
-            "integrity": "sha512-rj2UJThlPSdhY4V87UsxEM81Jte8WQGDJWnOt38VyI6waMZdiqgvzll6Ww9w93f6IFxIKVvPcKOUgCm+qRDofA==",
             "requires": {
                 "eventemitter3": "^4.0.7"
-            },
-            "dependencies": {
-                "eventemitter3": {
-                    "version": "4.0.7",
-                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-                    "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-                }
             }
         },
         "@elgato-stream-deck/node": {
             "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/@elgato-stream-deck/node/-/node-5.1.1.tgz",
-            "integrity": "sha512-zaAQWsZhVae/1kP/BK0iscyJ+3wweaNwm8APh1b7r9NyuMMtsDiRYHYcsaUjTnSOAwrnxogzUe0daS0BjmKJ4A==",
             "requires": {
                 "@elgato-stream-deck/core": "5.1.1",
                 "jpeg-js": "^0.4.2",
@@ -14477,8 +14311,6 @@
         },
         "@eslint/eslintrc": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.0.4.tgz",
-            "integrity": "sha512-h8Vx6MdxwWI2WM8/zREHMoqdgLNXEL4QX3MWSVMdyNJGvXVOs+6lp+m2hc3FnuMHDc4poxFNI20vCk0OmI4G0Q==",
             "dev": true,
             "requires": {
                 "ajv": "^6.12.4",
@@ -14492,16 +14324,8 @@
                 "strip-json-comments": "^3.1.1"
             },
             "dependencies": {
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
-                },
                 "debug": {
                     "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "dev": true,
                     "requires": {
                         "ms": "2.1.2"
@@ -14509,25 +14333,12 @@
                 },
                 "ignore": {
                     "version": "4.0.6",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
-                    "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
                     "dev": true
-                },
-                "js-yaml": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^2.0.1"
-                    }
                 }
             }
         },
         "@humanwhocodes/config-array": {
             "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.6.0.tgz",
-            "integrity": "sha512-JQlEKbcgEUjBFhLIF4iqM7u/9lwgHRBcpHrmUNCALK0Q3amXN6lxdoXLnF0sm11E9VqTmBALR87IlUg1bZ8A9A==",
             "dev": true,
             "requires": {
                 "@humanwhocodes/object-schema": "^1.2.0",
@@ -14537,8 +14348,6 @@
             "dependencies": {
                 "debug": {
                     "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "dev": true,
                     "requires": {
                         "ms": "2.1.2"
@@ -14547,9 +14356,7 @@
             }
         },
         "@humanwhocodes/object-schema": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.0.tgz",
-            "integrity": "sha512-wdppn25U8z/2yiaT6YGquE6X8sSv7hNMWSXYSSU1jGv/yd6XqjXgTDJ8KP4NgjTXfJ3GbRjeeb8RTV7a/VpM+w==",
+            "version": "1.2.1",
             "dev": true
         },
         "@istanbuljs/load-nyc-config": {
@@ -14563,6 +14370,21 @@
                 "resolve-from": "^5.0.0"
             },
             "dependencies": {
+                "argparse": {
+                    "version": "1.0.10",
+                    "dev": true,
+                    "requires": {
+                        "sprintf-js": "~1.0.2"
+                    }
+                },
+                "js-yaml": {
+                    "version": "3.14.1",
+                    "dev": true,
+                    "requires": {
+                        "argparse": "^1.0.7",
+                        "esprima": "^4.0.0"
+                    }
+                },
                 "resolve-from": {
                     "version": "5.0.0",
                     "dev": true
@@ -14744,28 +14566,16 @@
         },
         "@julusian/jpeg-turbo": {
             "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@julusian/jpeg-turbo/-/jpeg-turbo-1.1.1.tgz",
-            "integrity": "sha512-IO1KqXbR+Taded0BgAvIj/IPTXvSip8MhkZ0PDpHqxIi2YNGeQ8TodxAAW2MB8DThO4opHKq4Ngx2ybZWzGZQw==",
             "peer": true,
             "requires": {
                 "bindings": "^1.5.0",
                 "cmake-js": "^6.2.1",
                 "node-addon-api": "^3.2.1",
                 "prebuild-install": "^6.1.3"
-            },
-            "dependencies": {
-                "node-addon-api": {
-                    "version": "3.2.1",
-                    "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-                    "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A==",
-                    "peer": true
-                }
             }
         },
         "@nodelib/fs.scandir": {
             "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
-            "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "2.0.5",
@@ -14774,14 +14584,10 @@
         },
         "@nodelib/fs.stat": {
             "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
-            "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true
         },
         "@nodelib/fs.walk": {
             "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
-            "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
@@ -14891,9 +14697,7 @@
             }
         },
         "@sapphire/async-queue": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.1.9.tgz",
-            "integrity": "sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ=="
+            "version": "1.1.9"
         },
         "@serialport/binding-abstract": {
             "version": "9.2.3",
@@ -14925,9 +14729,7 @@
             }
         },
         "@serialport/bindings": {
-            "version": "9.2.5",
-            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.2.5.tgz",
-            "integrity": "sha512-fyabNg56gWbOMuYJc5c45z94sANC/WzTnGeML7Nr1IYVk0SJ1uksN4ETI8Nea9ZAtr4DhNiIMQ3/IOkyof6Tqg==",
+            "version": "9.2.7",
             "requires": {
                 "@serialport/binding-abstract": "9.2.3",
                 "@serialport/parser-readline": "9.2.4",
@@ -14939,8 +14741,6 @@
             "dependencies": {
                 "debug": {
                     "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "requires": {
                         "ms": "2.1.2"
                     }
@@ -14997,7 +14797,7 @@
             }
         },
         "@sinonjs/fake-timers": {
-            "version": "8.0.1",
+            "version": "8.1.0",
             "dev": true,
             "requires": {
                 "@sinonjs/commons": "^1.7.0"
@@ -15014,8 +14814,6 @@
         },
         "@slack/web-api": {
             "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-6.5.0.tgz",
-            "integrity": "sha512-yQOipaMZVj2R/CxTQa3CuE1XAmgjxaxQFCY1/GPsdpy1rRGeB8hCQPcQf4WPxsM2b7rSVMicF9qFjKPVP+cYbw==",
             "requires": {
                 "@slack/logger": "^3.0.0",
                 "@slack/types": "^2.0.0",
@@ -15030,13 +14828,8 @@
                 "p-retry": "^4.0.0"
             },
             "dependencies": {
-                "axios": {
-                    "version": "0.24.0",
-                    "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
-                    "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
-                    "requires": {
-                        "follow-redirects": "^1.14.4"
-                    }
+                "eventemitter3": {
+                    "version": "3.1.2"
                 },
                 "form-data": {
                     "version": "2.5.1",
@@ -15067,8 +14860,6 @@
         },
         "@twurple/api": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/api/-/api-5.0.9.tgz",
-            "integrity": "sha512-LO53jrfrtF1jkss78CC4W+uZ7Q+wQ96hkYjiQ37084c46foHgvwGJwOyfqSgOeSNsAvV603cQbjDJ043pdVu1w==",
             "requires": {
                 "@d-fischer/cache-decorators": "^3.0.0",
                 "@d-fischer/logger": "^4.0.0",
@@ -15079,49 +14870,28 @@
                 "tslib": "^2.0.3"
             },
             "dependencies": {
-                "@d-fischer/cache-decorators": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-3.0.0.tgz",
-                    "integrity": "sha512-mYUCjrp5hJgimceC5bof3zzmElyxzW4ty+73IjY12wvxLAqsq0CbgLGspnJm6KgwEfGoeRnISZD4EXJidG3FvA==",
-                    "requires": {
-                        "@d-fischer/shared-utils": "^3.0.1",
-                        "@types/node": "^14.14.22",
-                        "tslib": "^2.1.0"
-                    }
-                },
-                "@d-fischer/logger": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
-                    "integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
-                    "requires": {
-                        "@d-fischer/shared-utils": "^3.2.0",
-                        "detect-node": "^2.0.4",
-                        "tslib": "^2.0.3"
-                    }
-                },
-                "@types/node": {
-                    "version": "14.17.32",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-                    "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
+                "tslib": {
+                    "version": "2.3.1"
                 }
             }
         },
         "@twurple/api-call": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/api-call/-/api-call-5.0.9.tgz",
-            "integrity": "sha512-ug0t0O+vgyJO3sgp7QPX5GO4k1LbemK5qvdYbKK+VaWl1hdd9XrQ6iMRWG5MHeEObudENkNRCTpuEhr+hSvoIA==",
             "requires": {
                 "@d-fischer/cross-fetch": "^4.0.2",
                 "@d-fischer/qs": "^7.0.2",
                 "@twurple/common": "^5.0.9",
                 "@types/node-fetch": "^2.5.7",
                 "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1"
+                }
             }
         },
         "@twurple/auth": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/auth/-/auth-5.0.9.tgz",
-            "integrity": "sha512-dODbqMTiYCiUY3+DRY3Ul+TcQVKdEfKhTv1TfFP6QLLycZbxdNm/lnUl/3wVlmH7FW7rdo/G99CJVr9bYh6JYQ==",
             "requires": {
                 "@d-fischer/logger": "^4.0.0",
                 "@d-fischer/shared-utils": "^3.2.0",
@@ -15130,22 +14900,13 @@
                 "tslib": "^2.0.3"
             },
             "dependencies": {
-                "@d-fischer/logger": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
-                    "integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
-                    "requires": {
-                        "@d-fischer/shared-utils": "^3.2.0",
-                        "detect-node": "^2.0.4",
-                        "tslib": "^2.0.3"
-                    }
+                "tslib": {
+                    "version": "2.3.1"
                 }
             }
         },
         "@twurple/chat": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/@twurple/chat/-/chat-5.0.8.tgz",
-            "integrity": "sha512-2xlw1oRLS/ULukzbdf7O1n6qo53hxeRa7QpJDbhh0AhXGOPv+sCd6UTa9YG/O98XaXWyCp+9OPRljQy6SNtTgA==",
+            "version": "5.0.9",
             "requires": {
                 "@d-fischer/cache-decorators": "^3.0.0",
                 "@d-fischer/deprecate": "^2.0.2",
@@ -15153,67 +14914,31 @@
                 "@d-fischer/rate-limiter": "^0.4.4",
                 "@d-fischer/shared-utils": "^3.2.0",
                 "@d-fischer/typed-event-emitter": "^3.2.2",
-                "@twurple/common": "^5.0.8",
+                "@twurple/common": "^5.0.9",
                 "ircv3": "^0.28.0",
                 "tslib": "^2.0.3"
             },
             "dependencies": {
-                "@d-fischer/cache-decorators": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/@d-fischer/cache-decorators/-/cache-decorators-3.0.0.tgz",
-                    "integrity": "sha512-mYUCjrp5hJgimceC5bof3zzmElyxzW4ty+73IjY12wvxLAqsq0CbgLGspnJm6KgwEfGoeRnISZD4EXJidG3FvA==",
-                    "requires": {
-                        "@d-fischer/shared-utils": "^3.0.1",
-                        "@types/node": "^14.14.22",
-                        "tslib": "^2.1.0"
-                    }
-                },
-                "@d-fischer/logger": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
-                    "integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
-                    "requires": {
-                        "@d-fischer/shared-utils": "^3.2.0",
-                        "detect-node": "^2.0.4",
-                        "tslib": "^2.0.3"
-                    }
-                },
-                "@types/node": {
-                    "version": "14.17.32",
-                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.32.tgz",
-                    "integrity": "sha512-JcII3D5/OapPGx+eJ+Ik1SQGyt6WvuqdRfh9jUwL6/iHGjmyOriBDciBUu7lEIBTL2ijxwrR70WUnw5AEDmFvQ=="
-                },
-                "ircv3": {
-                    "version": "0.28.1",
-                    "resolved": "https://registry.npmjs.org/ircv3/-/ircv3-0.28.1.tgz",
-                    "integrity": "sha512-zYTN7S96evwQrQF7+1024JpGzPrK0enSiabd9uhzik9TZMstsellIUkLcQHYOxdq+P0dfDPqbvGqKrg2OAiaeA==",
-                    "requires": {
-                        "@d-fischer/connection": "^6.6.0",
-                        "@d-fischer/escape-string-regexp": "^5.0.0",
-                        "@d-fischer/logger": "^4.0.0",
-                        "@d-fischer/shared-utils": "^3.0.1",
-                        "@d-fischer/typed-event-emitter": "^3.2.2",
-                        "@types/node": "^14.14.19",
-                        "klona": "^2.0.4",
-                        "tslib": "^2.0.3"
-                    }
+                "tslib": {
+                    "version": "2.3.1"
                 }
             }
         },
         "@twurple/common": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/common/-/common-5.0.9.tgz",
-            "integrity": "sha512-9RUnPjWBn0FvoyFfO7SaV9TZ34J/6OBBZ1+dwHzf/1v1piDuK5dOuvgTR2q+8Qgf2zxZIUdoGe44s1ZjUspKkw==",
             "requires": {
                 "@d-fischer/shared-utils": "^3.2.0",
                 "klona": "^2.0.4",
                 "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "tslib": {
+                    "version": "2.3.1"
+                }
             }
         },
         "@twurple/pubsub": {
             "version": "5.0.9",
-            "resolved": "https://registry.npmjs.org/@twurple/pubsub/-/pubsub-5.0.9.tgz",
-            "integrity": "sha512-6feaTbG7vDuAiZD4/rqUL26IWOTW7paTJRodg40a9WQnAa4tLLJT3Sh+/ShdS9KMNjF16ouvNRM1dfsa36EBZw==",
             "requires": {
                 "@d-fischer/connection": "^6.6.0",
                 "@d-fischer/logger": "^4.0.0",
@@ -15223,15 +14948,8 @@
                 "tslib": "^2.0.3"
             },
             "dependencies": {
-                "@d-fischer/logger": {
-                    "version": "4.1.1",
-                    "resolved": "https://registry.npmjs.org/@d-fischer/logger/-/logger-4.1.1.tgz",
-                    "integrity": "sha512-yQPteWFcO7+js+AxE/uO01gN4E6rxaePWLKnLAUT+0aFcaRq+kWWCoI5r2fa04jbadn9qUpSVxvK/YiC9cfVjw==",
-                    "requires": {
-                        "@d-fischer/shared-utils": "^3.2.0",
-                        "detect-node": "^2.0.4",
-                        "tslib": "^2.0.3"
-                    }
+                "tslib": {
+                    "version": "2.3.1"
                 }
             }
         },
@@ -15269,7 +14987,7 @@
             }
         },
         "@types/body-parser": {
-            "version": "1.19.1",
+            "version": "1.19.2",
             "requires": {
                 "@types/connect": "*",
                 "@types/node": "*"
@@ -15301,7 +15019,7 @@
             }
         },
         "@types/eslint": {
-            "version": "7.28.2",
+            "version": "8.2.0",
             "dev": true,
             "requires": {
                 "@types/estree": "*",
@@ -15330,7 +15048,7 @@
             }
         },
         "@types/express-serve-static-core": {
-            "version": "4.17.24",
+            "version": "4.17.25",
             "requires": {
                 "@types/node": "*",
                 "@types/qs": "*",
@@ -15386,7 +15104,7 @@
             }
         },
         "@types/jest": {
-            "version": "27.0.2",
+            "version": "27.0.3",
             "dev": true,
             "requires": {
                 "jest-diff": "^27.0.0",
@@ -15405,9 +15123,7 @@
             "dev": true
         },
         "@types/node": {
-            "version": "16.11.7",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.7.tgz",
-            "integrity": "sha512-QB5D2sqfSjCmTuWcBWyJ+/44bcjO7VbjSbOE0ucoVbAsSNQc4Lt6QkgkVXkTDwkL4z/beecZNDvVX15D4P8Jbw=="
+            "version": "16.11.9"
         },
         "@types/node-fetch": {
             "version": "2.5.12",
@@ -15417,7 +15133,7 @@
             }
         },
         "@types/node-telegram-bot-api": {
-            "version": "0.53.1",
+            "version": "0.53.2",
             "requires": {
                 "@types/node": "*",
                 "@types/request": "*"
@@ -15430,7 +15146,7 @@
             }
         },
         "@types/prettier": {
-            "version": "2.4.1",
+            "version": "2.4.2",
             "dev": true
         },
         "@types/qs": {
@@ -15499,10 +15215,10 @@
             }
         },
         "@types/spotify-api": {
-            "version": "0.0.11"
+            "version": "0.0.12"
         },
         "@types/spotify-web-api-node": {
-            "version": "5.0.3",
+            "version": "5.0.4",
             "requires": {
                 "@types/spotify-api": "*"
             }
@@ -15539,13 +15255,11 @@
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.3.1.tgz",
-            "integrity": "sha512-cFImaoIr5Ojj358xI/SDhjog57OK2NqlpxwdcgyxDA3bJlZcJq5CPzUXtpD7CxI2Hm6ATU7w5fQnnkVnmwpHqw==",
+            "version": "5.4.0",
             "dev": true,
             "requires": {
-                "@typescript-eslint/experimental-utils": "5.3.1",
-                "@typescript-eslint/scope-manager": "5.3.1",
+                "@typescript-eslint/experimental-utils": "5.4.0",
+                "@typescript-eslint/scope-manager": "5.4.0",
                 "debug": "^4.3.2",
                 "functional-red-black-tree": "^1.0.1",
                 "ignore": "^5.1.8",
@@ -15554,135 +15268,39 @@
                 "tsutils": "^3.21.0"
             },
             "dependencies": {
-                "@typescript-eslint/scope-manager": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.1.tgz",
-                    "integrity": "sha512-XksFVBgAq0Y9H40BDbuPOTUIp7dn4u8oOuhcgGq7EoDP50eqcafkMVGrypyVGvDYHzjhdUCUwuwVUK4JhkMAMg==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "5.3.1",
-                        "@typescript-eslint/visitor-keys": "5.3.1"
-                    }
-                },
-                "@typescript-eslint/types": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.1.tgz",
-                    "integrity": "sha512-bG7HeBLolxKHtdHG54Uac750eXuQQPpdJfCYuw4ZI3bZ7+GgKClMWM8jExBtp7NSP4m8PmLRM8+lhzkYnSmSxQ==",
-                    "dev": true
-                },
-                "@typescript-eslint/visitor-keys": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.1.tgz",
-                    "integrity": "sha512-3cHUzUuVTuNHx0Gjjt5pEHa87+lzyqOiHXy/Gz+SJOCW1mpw9xQHIIEwnKn+Thph1mgWyZ90nboOcSuZr/jTTQ==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "5.3.1",
-                        "eslint-visitor-keys": "^3.0.0"
-                    }
-                },
                 "debug": {
                     "version": "4.3.2",
                     "dev": true,
                     "requires": {
                         "ms": "2.1.2"
                     }
-                },
-                "eslint-visitor-keys": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-                    "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-                    "dev": true
                 }
             }
         },
         "@typescript-eslint/experimental-utils": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.3.1.tgz",
-            "integrity": "sha512-RgFn5asjZ5daUhbK5Sp0peq0SSMytqcrkNfU4pnDma2D8P3ElZ6JbYjY8IMSFfZAJ0f3x3tnO3vXHweYg0g59w==",
+            "version": "5.4.0",
             "dev": true,
             "requires": {
                 "@types/json-schema": "^7.0.9",
-                "@typescript-eslint/scope-manager": "5.3.1",
-                "@typescript-eslint/types": "5.3.1",
-                "@typescript-eslint/typescript-estree": "5.3.1",
+                "@typescript-eslint/scope-manager": "5.4.0",
+                "@typescript-eslint/types": "5.4.0",
+                "@typescript-eslint/typescript-estree": "5.4.0",
                 "eslint-scope": "^5.1.1",
                 "eslint-utils": "^3.0.0"
-            },
-            "dependencies": {
-                "@typescript-eslint/scope-manager": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.3.1.tgz",
-                    "integrity": "sha512-XksFVBgAq0Y9H40BDbuPOTUIp7dn4u8oOuhcgGq7EoDP50eqcafkMVGrypyVGvDYHzjhdUCUwuwVUK4JhkMAMg==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "5.3.1",
-                        "@typescript-eslint/visitor-keys": "5.3.1"
-                    }
-                },
-                "@typescript-eslint/types": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.3.1.tgz",
-                    "integrity": "sha512-bG7HeBLolxKHtdHG54Uac750eXuQQPpdJfCYuw4ZI3bZ7+GgKClMWM8jExBtp7NSP4m8PmLRM8+lhzkYnSmSxQ==",
-                    "dev": true
-                },
-                "@typescript-eslint/typescript-estree": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.3.1.tgz",
-                    "integrity": "sha512-PwFbh/PKDVo/Wct6N3w+E4rLZxUDgsoII/GrWM2A62ETOzJd4M6s0Mu7w4CWsZraTbaC5UQI+dLeyOIFF1PquQ==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "5.3.1",
-                        "@typescript-eslint/visitor-keys": "5.3.1",
-                        "debug": "^4.3.2",
-                        "globby": "^11.0.4",
-                        "is-glob": "^4.0.3",
-                        "semver": "^7.3.5",
-                        "tsutils": "^3.21.0"
-                    }
-                },
-                "@typescript-eslint/visitor-keys": {
-                    "version": "5.3.1",
-                    "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.3.1.tgz",
-                    "integrity": "sha512-3cHUzUuVTuNHx0Gjjt5pEHa87+lzyqOiHXy/Gz+SJOCW1mpw9xQHIIEwnKn+Thph1mgWyZ90nboOcSuZr/jTTQ==",
-                    "dev": true,
-                    "requires": {
-                        "@typescript-eslint/types": "5.3.1",
-                        "eslint-visitor-keys": "^3.0.0"
-                    }
-                },
-                "debug": {
-                    "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "2.1.2"
-                    }
-                },
-                "eslint-visitor-keys": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-                    "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-                    "dev": true
-                }
             }
         },
         "@typescript-eslint/parser": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.2.0.tgz",
-            "integrity": "sha512-Uyy4TjJBlh3NuA8/4yIQptyJb95Qz5PX//6p8n7zG0QnN4o3NF9Je3JHbVU7fxf5ncSXTmnvMtd/LDQWDk0YqA==",
+            "version": "5.4.0",
             "dev": true,
             "requires": {
-                "@typescript-eslint/scope-manager": "5.2.0",
-                "@typescript-eslint/types": "5.2.0",
-                "@typescript-eslint/typescript-estree": "5.2.0",
+                "@typescript-eslint/scope-manager": "5.4.0",
+                "@typescript-eslint/types": "5.4.0",
+                "@typescript-eslint/typescript-estree": "5.4.0",
                 "debug": "^4.3.2"
             },
             "dependencies": {
                 "debug": {
                     "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "dev": true,
                     "requires": {
                         "ms": "2.1.2"
@@ -15691,29 +15309,23 @@
             }
         },
         "@typescript-eslint/scope-manager": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.2.0.tgz",
-            "integrity": "sha512-RW+wowZqPzQw8MUFltfKYZfKXqA2qgyi6oi/31J1zfXJRpOn6tCaZtd9b5u9ubnDG2n/EMvQLeZrsLNPpaUiFQ==",
+            "version": "5.4.0",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.2.0",
-                "@typescript-eslint/visitor-keys": "5.2.0"
+                "@typescript-eslint/types": "5.4.0",
+                "@typescript-eslint/visitor-keys": "5.4.0"
             }
         },
         "@typescript-eslint/types": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.2.0.tgz",
-            "integrity": "sha512-cTk6x08qqosps6sPyP2j7NxyFPlCNsJwSDasqPNjEQ8JMD5xxj2NHxcLin5AJQ8pAVwpQ8BMI3bTxR0zxmK9qQ==",
+            "version": "5.4.0",
             "dev": true
         },
         "@typescript-eslint/typescript-estree": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.2.0.tgz",
-            "integrity": "sha512-RsdXq2XmVgKbm9nLsE3mjNUM7BTr/K4DYR9WfFVMUuozHWtH5gMpiNZmtrMG8GR385EOSQ3kC9HiEMJWimxd/g==",
+            "version": "5.4.0",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.2.0",
-                "@typescript-eslint/visitor-keys": "5.2.0",
+                "@typescript-eslint/types": "5.4.0",
+                "@typescript-eslint/visitor-keys": "5.4.0",
                 "debug": "^4.3.2",
                 "globby": "^11.0.4",
                 "is-glob": "^4.0.3",
@@ -15723,8 +15335,6 @@
             "dependencies": {
                 "debug": {
                     "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "dev": true,
                     "requires": {
                         "ms": "2.1.2"
@@ -15733,21 +15343,11 @@
             }
         },
         "@typescript-eslint/visitor-keys": {
-            "version": "5.2.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.2.0.tgz",
-            "integrity": "sha512-Nk7HizaXWWCUBfLA/rPNKMzXzWS8Wg9qHMuGtT+v2/YpPij4nVXrVJc24N/r5WrrmqK31jCrZxeHqIgqRzs0Xg==",
+            "version": "5.4.0",
             "dev": true,
             "requires": {
-                "@typescript-eslint/types": "5.2.0",
+                "@typescript-eslint/types": "5.4.0",
                 "eslint-visitor-keys": "^3.0.0"
-            },
-            "dependencies": {
-                "eslint-visitor-keys": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-                    "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
-                    "dev": true
-                }
             }
         },
         "@webassemblyjs/ast": {
@@ -15913,7 +15513,7 @@
             }
         },
         "acorn": {
-            "version": "7.4.1",
+            "version": "8.6.0",
             "dev": true
         },
         "acorn-globals": {
@@ -15922,23 +15522,27 @@
             "requires": {
                 "acorn": "^7.1.1",
                 "acorn-walk": "^7.1.1"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "7.4.1",
+                    "dev": true
+                }
             }
+        },
+        "acorn-import-assertions": {
+            "version": "1.8.0",
+            "dev": true,
+            "requires": {}
         },
         "acorn-jsx": {
             "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-            "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
             "requires": {}
         },
         "acorn-walk": {
             "version": "7.2.0",
             "dev": true
-        },
-        "after": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/after/-/after-0.8.2.tgz",
-            "integrity": "sha1-/ts5T58OAqqXaOcCvaI7UF+ufh8="
         },
         "agent-base": {
             "version": "6.0.2",
@@ -15958,8 +15562,8 @@
             "version": "file:samples/ahk-sendcommand",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-ahk": "^0.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-ahk": "^0.3.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -15979,24 +15583,20 @@
             "requires": {}
         },
         "alawmulaw": {
-            "version": "5.0.2",
-            "resolved": "https://registry.npmjs.org/alawmulaw/-/alawmulaw-5.0.2.tgz",
-            "integrity": "sha512-W3bWBB7MwTNGALlAKbOxe+tMNW9DpqGsv1V1idGPzctnBH++eS+Dx3UuucHNe5nk38WvAuy0sgMAbS5idHCArw=="
+            "version": "5.0.2"
         },
         "android": {
             "version": "file:samples/android",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-android": "^0.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-android": "^0.3.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "ansi": {
             "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-            "integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE=",
             "peer": true
         },
         "ansi-align": {
@@ -16045,17 +15645,20 @@
             "version": "1.2.0"
         },
         "are-we-there-yet": {
-            "version": "1.1.7",
+            "version": "1.0.6",
+            "peer": true,
             "requires": {
                 "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
+                "readable-stream": "^2.0.0 || ^1.1.13"
             },
             "dependencies": {
                 "isarray": {
-                    "version": "1.0.0"
+                    "version": "1.0.0",
+                    "peer": true
                 },
                 "readable-stream": {
                     "version": "2.3.7",
+                    "peer": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
                         "inherits": "~2.0.3",
@@ -16068,6 +15671,7 @@
                 },
                 "string_decoder": {
                     "version": "1.1.1",
+                    "peer": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
                     }
@@ -16075,11 +15679,8 @@
             }
         },
         "argparse": {
-            "version": "1.0.10",
-            "dev": true,
-            "requires": {
-                "sprintf-js": "~1.0.2"
-            }
+            "version": "2.0.1",
+            "dev": true
         },
         "array-differ": {
             "version": "3.0.0",
@@ -16113,11 +15714,6 @@
                 "is-string": "^1.0.7"
             }
         },
-        "arraybuffer.slice": {
-            "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/arraybuffer.slice/-/arraybuffer.slice-0.0.7.tgz",
-            "integrity": "sha512-wGUIVQXuehL5TCqQun8OW81jGzAWycqzFF8lFp+GOM5BXLYj3bKNsYC4daB7n6XjCqxQA/qgTJ+8ANR3acjrog=="
-        },
         "arrify": {
             "version": "2.0.1"
         },
@@ -16125,8 +15721,8 @@
             "version": "file:samples/artnet-console",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-artnet": "^0.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-artnet": "^0.3.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -16138,7 +15734,7 @@
             }
         },
         "asn1": {
-            "version": "0.2.4",
+            "version": "0.2.6",
             "requires": {
                 "safer-buffer": "~2.1.0"
             }
@@ -16153,36 +15749,22 @@
             "version": "file:samples/atem",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-atem": "^0.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-atem": "^0.3.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "atem-connection": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/atem-connection/-/atem-connection-2.3.1.tgz",
-            "integrity": "sha512-lw0k0uYDt+Ljf/w4zAEdQSI0g4/FZkFKEsohcYaliotH2rtkRMXkbfHbtQ9e/f8SIdZN4VikJBBeAkHqApi0GA==",
+            "version": "2.4.0",
             "requires": {
-                "big-integer": "^1.6.48",
+                "big-integer": "^1.6.51",
                 "eventemitter3": "^4.0.4",
-                "exit-hook": "^2.0.0",
+                "exit-hook": "^2.2.1",
                 "nanotimer": "^0.3.15",
                 "threadedclass": "^0.8.0",
                 "tslib": "^1.13.0",
                 "wavefile": "^8.4.4"
-            },
-            "dependencies": {
-                "eventemitter3": {
-                    "version": "4.0.7",
-                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-                    "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-                },
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
             }
         },
         "aws-sign2": {
@@ -16192,9 +15774,9 @@
             "version": "1.11.0"
         },
         "axios": {
-            "version": "0.21.4",
+            "version": "0.24.0",
             "requires": {
-                "follow-redirects": "^1.14.0"
+                "follow-redirects": "^1.14.4"
             }
         },
         "babel-jest": {
@@ -16275,16 +15857,11 @@
                 "babel-preset-current-node-syntax": "^1.0.0"
             }
         },
-        "backo2": {
-            "version": "1.0.2"
-        },
         "balanced-match": {
             "version": "1.0.2"
         },
         "base64-arraybuffer-es6": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/base64-arraybuffer-es6/-/base64-arraybuffer-es6-0.3.1.tgz",
-            "integrity": "sha512-TrhBheudYaff9adiTAqjSScjvtmClQ4vF9l4cqkPNkVsA11m4/NRdH4LkZ/tAMmpzzwfI20BXnJ/PTtafECCNA=="
+            "version": "0.3.1"
         },
         "base64-js": {
             "version": "1.5.1"
@@ -16293,25 +15870,16 @@
             "version": "1.0.2",
             "requires": {
                 "tweetnacl": "^0.14.3"
-            },
-            "dependencies": {
-                "tweetnacl": {
-                    "version": "0.14.5"
-                }
             }
         },
         "before-after-hook": {
             "version": "2.2.2"
         },
         "big-integer": {
-            "version": "1.6.50",
-            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.50.tgz",
-            "integrity": "sha512-+O2uoQWFRo8ysZNo/rjtri2jIwjr3XfeAgRjAUADRqGG+ZITvyn8J1kvXLTaKVr3hhGXk+f23tKfdzmklVM9vQ=="
+            "version": "1.6.51"
         },
         "big.js": {
             "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
-            "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
             "dev": true
         },
         "bignumber.js": {
@@ -16319,8 +15887,6 @@
         },
         "binary": {
             "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-            "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
             "peer": true,
             "requires": {
                 "buffers": "~0.1.1",
@@ -16338,9 +15904,7 @@
             }
         },
         "bitdepth": {
-            "version": "7.0.2",
-            "resolved": "https://registry.npmjs.org/bitdepth/-/bitdepth-7.0.2.tgz",
-            "integrity": "sha512-Ed11TL4IIWyUEoQTfkbRBDCgDNurxYzFgmk30ZU6SgNCsysoEx7UMm+g7SDFHxA2lhLbWyjV8T1ab3z0BtYOAw=="
+            "version": "7.0.2"
         },
         "bl": {
             "version": "4.1.0",
@@ -16348,12 +15912,26 @@
                 "buffer": "^5.5.0",
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1"
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
             }
-        },
-        "blob": {
-            "version": "0.0.5",
-            "resolved": "https://registry.npmjs.org/blob/-/blob-0.0.5.tgz",
-            "integrity": "sha512-gaqbzQPqOoamawKg0LGVd7SzLgXS+JH61oWprSLH+P+abTczqJbhTR8CmJ2u9/bUYNmHTGJx/UEmn6doAvvuig=="
         },
         "bluebird": {
             "version": "3.7.2"
@@ -16402,7 +15980,7 @@
             },
             "dependencies": {
                 "camelcase": {
-                    "version": "6.2.0",
+                    "version": "6.2.1",
                     "dev": true
                 }
             }
@@ -16426,11 +16004,11 @@
             "dev": true
         },
         "browserslist": {
-            "version": "4.17.5",
+            "version": "4.18.1",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001271",
-                "electron-to-chromium": "^1.3.878",
+                "caniuse-lite": "^1.0.30001280",
+                "electron-to-chromium": "^1.3.896",
                 "escalade": "^3.1.1",
                 "node-releases": "^2.0.1",
                 "picocolors": "^1.0.0"
@@ -16465,26 +16043,18 @@
         },
         "buffer-indexof-polyfill": {
             "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/buffer-indexof-polyfill/-/buffer-indexof-polyfill-1.0.2.tgz",
-            "integrity": "sha512-I7wzHwA3t1/lwXQh+A5PbNvJxgfo5r3xulgpYDB5zckTu/Z9oUK9biouBKQUjEqzaz3HnAT6TYoovmE+GqSf7A==",
             "peer": true
         },
         "buffer-shims": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
-            "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E=",
             "peer": true
         },
         "buffers": {
             "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-            "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s=",
             "peer": true
         },
         "byte-data": {
             "version": "16.0.3",
-            "resolved": "https://registry.npmjs.org/byte-data/-/byte-data-16.0.3.tgz",
-            "integrity": "sha512-IzV3mzv8OnnzPdb9CoESQr2ikPX/gkHUesRu+vff9XB7KwMxyflPDewtPFWXPvF+Xukl52ceor2IRLbnQZf3PQ==",
             "requires": {
                 "endianness": "^8.0.2",
                 "ieee754-buffer": "^0.2.1",
@@ -16509,13 +16079,6 @@
                 "responselike": "^1.0.2"
             },
             "dependencies": {
-                "get-stream": {
-                    "version": "5.2.0",
-                    "dev": true,
-                    "requires": {
-                        "pump": "^3.0.0"
-                    }
-                },
                 "lowercase-keys": {
                     "version": "2.0.0",
                     "dev": true
@@ -16537,7 +16100,7 @@
             "dev": true
         },
         "caniuse-lite": {
-            "version": "1.0.30001271",
+            "version": "1.0.30001282",
             "dev": true
         },
         "caseless": {
@@ -16545,8 +16108,6 @@
         },
         "chainsaw": {
             "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-            "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
             "peer": true,
             "requires": {
                 "traverse": ">=0.3.0 <0.4"
@@ -16585,6 +16146,15 @@
                 "is-glob": "~4.0.1",
                 "normalize-path": "~3.0.0",
                 "readdirp": "~3.6.0"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "5.1.2",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                }
             }
         },
         "chownr": {
@@ -16649,8 +16219,6 @@
         },
         "cmake-js": {
             "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/cmake-js/-/cmake-js-6.2.1.tgz",
-            "integrity": "sha512-wEpg0Z8SY6ihXTe+xosadh4PbASdWSM/locbLacWRYJCZfAjWLyOrd4RoVIeirLkfPxmG8GdNQA9tW/Rz5SfJA==",
             "peer": true,
             "requires": {
                 "axios": "^0.21.1",
@@ -16672,30 +16240,21 @@
             "dependencies": {
                 "ansi-regex": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
                     "peer": true
                 },
-                "are-we-there-yet": {
-                    "version": "1.0.6",
-                    "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.0.6.tgz",
-                    "integrity": "sha1-otKMkxAqpsyWJFomy5VN4G7FPww=",
+                "axios": {
+                    "version": "0.21.4",
                     "peer": true,
                     "requires": {
-                        "delegates": "^1.0.0",
-                        "readable-stream": "^2.0.0 || ^1.1.13"
+                        "follow-redirects": "^1.14.0"
                     }
                 },
                 "camelcase": {
                     "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-                    "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8=",
                     "peer": true
                 },
                 "cliui": {
                     "version": "3.2.0",
-                    "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-                    "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
                     "peer": true,
                     "requires": {
                         "string-width": "^1.0.1",
@@ -16705,123 +16264,24 @@
                 },
                 "debug": {
                     "version": "4.3.2",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-                    "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
                     "peer": true,
                     "requires": {
                         "ms": "2.1.2"
                     }
                 },
-                "fs-minipass": {
-                    "version": "1.2.7",
-                    "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz",
-                    "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
-                    "peer": true,
-                    "requires": {
-                        "minipass": "^2.6.0"
-                    }
-                },
-                "gauge": {
-                    "version": "1.2.7",
-                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-1.2.7.tgz",
-                    "integrity": "sha1-6c7FSD09TuDvRLYKfZnkk14TbZM=",
-                    "peer": true,
-                    "requires": {
-                        "ansi": "^0.3.0",
-                        "has-unicode": "^2.0.0",
-                        "lodash.pad": "^4.1.0",
-                        "lodash.padend": "^4.1.0",
-                        "lodash.padstart": "^4.1.0"
-                    }
-                },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
                     "peer": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
                 },
-                "isarray": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-                    "peer": true
-                },
-                "minipass": {
-                    "version": "2.9.0",
-                    "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.9.0.tgz",
-                    "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
-                    "peer": true,
-                    "requires": {
-                        "safe-buffer": "^5.1.2",
-                        "yallist": "^3.0.0"
-                    }
-                },
-                "minizlib": {
-                    "version": "1.3.3",
-                    "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.3.3.tgz",
-                    "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
-                    "peer": true,
-                    "requires": {
-                        "minipass": "^2.9.0"
-                    }
-                },
-                "mkdirp": {
-                    "version": "0.5.5",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-                    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-                    "peer": true,
-                    "requires": {
-                        "minimist": "^1.2.5"
-                    }
-                },
-                "npmlog": {
-                    "version": "1.2.1",
-                    "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-1.2.1.tgz",
-                    "integrity": "sha1-KOe+YZYJtT960d0wChDWTXFiaLY=",
-                    "peer": true,
-                    "requires": {
-                        "ansi": "~0.3.0",
-                        "are-we-there-yet": "~1.0.0",
-                        "gauge": "~1.2.0"
-                    }
-                },
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "peer": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
                 "semver": {
                     "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
                     "peer": true
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "peer": true,
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
                 },
                 "string-width": {
                     "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
                     "peer": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
@@ -16831,40 +16291,13 @@
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
                     "peer": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
                 },
-                "tar": {
-                    "version": "4.4.19",
-                    "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.19.tgz",
-                    "integrity": "sha512-a20gEsvHnWe0ygBY8JbxoM4w3SJdhc7ZAuxkLqh+nvNQN2IOt0B5lLgM490X5Hl8FF0dl0tOf2ewFYAlIFgzVA==",
-                    "peer": true,
-                    "requires": {
-                        "chownr": "^1.1.4",
-                        "fs-minipass": "^1.2.7",
-                        "minipass": "^2.9.0",
-                        "minizlib": "^1.3.3",
-                        "mkdirp": "^0.5.5",
-                        "safe-buffer": "^5.2.1",
-                        "yallist": "^3.1.1"
-                    },
-                    "dependencies": {
-                        "safe-buffer": {
-                            "version": "5.2.1",
-                            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-                            "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-                            "peer": true
-                        }
-                    }
-                },
                 "which": {
                     "version": "1.3.1",
-                    "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
-                    "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
                     "peer": true,
                     "requires": {
                         "isexe": "^2.0.0"
@@ -16872,8 +16305,6 @@
                 },
                 "wrap-ansi": {
                     "version": "2.1.0",
-                    "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-                    "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
                     "peer": true,
                     "requires": {
                         "string-width": "^1.0.1",
@@ -16882,20 +16313,10 @@
                 },
                 "y18n": {
                     "version": "3.2.2",
-                    "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.2.tgz",
-                    "integrity": "sha512-uGZHXkHnhF0XeeAPgnKfPv1bgKAYyVvmNL1xlKsPYZPaIHxGti2hHqvOCQv71XMsLxu1QjergkqogUnms5D3YQ==",
-                    "peer": true
-                },
-                "yallist": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
-                    "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
                     "peer": true
                 },
                 "yargs": {
                     "version": "3.32.0",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-                    "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
                     "peer": true,
                     "requires": {
                         "camelcase": "^2.0.1",
@@ -16932,9 +16353,7 @@
             "dev": true
         },
         "colorette": {
-            "version": "2.0.16",
-            "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
-            "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g=="
+            "version": "2.0.16"
         },
         "combined-stream": {
             "version": "1.0.8",
@@ -16957,18 +16376,8 @@
                 }
             }
         },
-        "component-bind": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/component-bind/-/component-bind-1.0.0.tgz",
-            "integrity": "sha1-AMYIq33Nk4l8AAllGx06jh5zu9E="
-        },
         "component-emitter": {
             "version": "1.3.0"
-        },
-        "component-inherit": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
-            "integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM="
         },
         "concat-map": {
             "version": "0.0.1"
@@ -16980,10 +16389,29 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^3.0.2",
                 "typedarray": "^0.0.6"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1"
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
             }
         },
         "concurrently": {
-            "version": "6.3.0",
+            "version": "6.4.0",
             "dev": true,
             "requires": {
                 "chalk": "^4.1.0",
@@ -17037,7 +16465,7 @@
             "version": "2.1.3"
         },
         "core-util-is": {
-            "version": "1.0.2"
+            "version": "1.0.3"
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -17057,8 +16485,6 @@
         },
         "css-loader": {
             "version": "6.5.1",
-            "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.5.1.tgz",
-            "integrity": "sha512-gEy2w9AnJNnD9Kuo4XAP9VflW/ujKoS9c/syO+uWMlm5igc7LysKzPXaDoR2vroROkSwsTS2tGr1yGGEbZOYZQ==",
             "dev": true,
             "requires": {
                 "icss-utils": "^5.1.0",
@@ -17073,8 +16499,6 @@
         },
         "cssesc": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
-            "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
             "dev": true
         },
         "cssom": {
@@ -17098,8 +16522,8 @@
             "version": "file:samples/curseforge",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-curseforge": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-curseforge": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -17120,7 +16544,7 @@
             }
         },
         "date-fns": {
-            "version": "2.25.0",
+            "version": "2.26.0",
             "dev": true
         },
         "dayjs": {
@@ -17143,8 +16567,8 @@
             "version": "file:samples/dbus-ratbagd",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-dbus": "0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-dbus": "0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -17153,16 +16577,14 @@
             "version": "file:samples/debug",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-debug": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-debug": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "decamelize": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "peer": true
         },
         "decimal.js": {
@@ -17281,24 +16703,20 @@
         },
         "dir-glob": {
             "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
             "dev": true,
             "requires": {
                 "path-type": "^4.0.0"
             }
         },
         "discord-api-types": {
-            "version": "0.24.0",
-            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.24.0.tgz",
-            "integrity": "sha512-X0uA2a92cRjowUEXpLZIHWl4jiX1NsUpDhcEOpa1/hpO1vkaokgZ8kkPtPih9hHth5UVQ3mHBu/PpB4qjyfJ4A=="
+            "version": "0.24.0"
         },
         "discord-guild-chat": {
             "version": "file:samples/discord-guild-chat",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-discord": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-discord": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -17307,16 +16725,14 @@
             "version": "file:samples/discord-rpc",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-discord-rpc": "0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-discord-rpc": "0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "discord.js": {
             "version": "13.3.1",
-            "resolved": "https://registry.npmjs.org/discord.js/-/discord.js-13.3.1.tgz",
-            "integrity": "sha512-zn4G8tL5+tMV00+0aSsVYNYcIfMSdT2g0nudKny+Ikd+XKv7m6bqI7n3Vji0GIRqXDr5ArPaw+iYFM2I1Iw3vg==",
             "requires": {
                 "@discordjs/builders": "^0.8.1",
                 "@discordjs/collection": "^0.3.2",
@@ -17331,8 +16747,6 @@
             "dependencies": {
                 "ws": {
                     "version": "8.2.3",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-8.2.3.tgz",
-                    "integrity": "sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==",
                     "requires": {}
                 }
             }
@@ -17372,8 +16786,6 @@
         },
         "duplexer2": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-            "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
             "peer": true,
             "requires": {
                 "readable-stream": "^2.0.2"
@@ -17381,14 +16793,10 @@
             "dependencies": {
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "peer": true
                 },
                 "readable-stream": {
                     "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
                     "peer": true,
                     "requires": {
                         "core-util-is": "~1.0.0",
@@ -17402,8 +16810,6 @@
                 },
                 "string_decoder": {
                     "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "peer": true,
                     "requires": {
                         "safe-buffer": "~5.1.0"
@@ -17422,6 +16828,25 @@
                 "inherits": "^2.0.3",
                 "readable-stream": "^3.1.1",
                 "stream-shift": "^1.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1"
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
             }
         },
         "easymidi": {
@@ -17447,15 +16872,15 @@
             "version": "1.1.1"
         },
         "electron-to-chromium": {
-            "version": "1.3.880",
+            "version": "1.3.903",
             "dev": true
         },
         "elgato-light": {
             "version": "file:samples/elgato-light",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-elgato-light": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-elgato-light": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -17469,8 +16894,6 @@
         },
         "emojis-list": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
-            "integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
             "dev": true
         },
         "encodeurl": {
@@ -17483,9 +16906,7 @@
             }
         },
         "endianness": {
-            "version": "8.0.2",
-            "resolved": "https://registry.npmjs.org/endianness/-/endianness-8.0.2.tgz",
-            "integrity": "sha512-IU+77+jJ7lpw2qZ3NUuqBZFy3GuioNgXUdsL1L9tooDNTaw0TgOnwNuc+8Ns+haDaTifK97QLzmOANJtI/rGvw=="
+            "version": "8.0.2"
         },
         "enhanced-resolve": {
             "version": "5.8.3",
@@ -17627,8 +17048,6 @@
         },
         "eslint": {
             "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.2.0.tgz",
-            "integrity": "sha512-erw7XmM+CLxTOickrimJ1SiF55jiNlVSp2qqm0NuBWPtHYQCegD5ZMaW0c3i5ytPqL+SSLaCxdvQXFPLJn+ABw==",
             "dev": true,
             "requires": {
                 "@eslint/eslintrc": "^1.0.4",
@@ -17671,12 +17090,6 @@
                 "v8-compile-cache": "^2.0.3"
             },
             "dependencies": {
-                "argparse": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-                    "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-                    "dev": true
-                },
                 "debug": {
                     "version": "4.3.2",
                     "dev": true,
@@ -17686,47 +17099,19 @@
                 },
                 "eslint-scope": {
                     "version": "6.0.0",
-                    "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-6.0.0.tgz",
-                    "integrity": "sha512-uRDL9MWmQCkaFus8RF5K9/L/2fn+80yoW3jkD53l4shjCh26fCtvJGasxjUqP5OT87SYTxCVA3BwTUzuELx9kA==",
                     "dev": true,
                     "requires": {
                         "esrecurse": "^4.3.0",
                         "estraverse": "^5.2.0"
                     }
                 },
-                "eslint-visitor-keys": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.0.0.tgz",
-                    "integrity": "sha512-mJOZa35trBTb3IyRmo8xmKBZlxf+N7OnUl4+ZhJHs/r+0770Wh/LEACE2pqMGMe27G/4y8P2bYGk4J70IC5k1Q==",
-                    "dev": true
-                },
                 "estraverse": {
                     "version": "5.3.0",
-                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
-                    "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
                     "dev": true
-                },
-                "glob-parent": {
-                    "version": "6.0.2",
-                    "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
-                    "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
-                    "dev": true,
-                    "requires": {
-                        "is-glob": "^4.0.3"
-                    }
                 },
                 "ignore": {
                     "version": "4.0.6",
                     "dev": true
-                },
-                "js-yaml": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-                    "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-                    "dev": true,
-                    "requires": {
-                        "argparse": "^2.0.1"
-                    }
                 }
             }
         },
@@ -17740,15 +17125,19 @@
         },
         "eslint-utils": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
-            "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
             "dev": true,
             "requires": {
                 "eslint-visitor-keys": "^2.0.0"
+            },
+            "dependencies": {
+                "eslint-visitor-keys": {
+                    "version": "2.1.0",
+                    "dev": true
+                }
             }
         },
         "eslint-visitor-keys": {
-            "version": "2.1.0",
+            "version": "3.1.0",
             "dev": true
         },
         "esm": {
@@ -17756,27 +17145,11 @@
         },
         "espree": {
             "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.0.0.tgz",
-            "integrity": "sha512-r5EQJcYZ2oaGbeR0jR0fFVijGOcwai07/690YRXLINuhmVeRY4UKSAsQPe/0BNuDgwP7Ophoc1PRsr2E3tkbdQ==",
             "dev": true,
             "requires": {
                 "acorn": "^8.5.0",
                 "acorn-jsx": "^5.3.1",
                 "eslint-visitor-keys": "^3.0.0"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "8.5.0",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.5.0.tgz",
-                    "integrity": "sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==",
-                    "dev": true
-                },
-                "eslint-visitor-keys": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.1.0.tgz",
-                    "integrity": "sha512-yWJFpu4DtjsWKkt5GeNBBuZMlNcYVs6vRCLoCVEJrTjaSB6LC98gFipNK/erM2Heg/E8mIK+hXG/pJMLK+eRZA==",
-                    "dev": true
-                }
             }
         },
         "esprima": {
@@ -17836,24 +17209,24 @@
             "version": "5.0.1"
         },
         "eventemitter3": {
-            "version": "3.1.2"
+            "version": "4.0.7"
         },
         "events": {
             "version": "3.3.0",
             "dev": true
         },
         "execa": {
-            "version": "5.1.1",
+            "version": "4.1.0",
             "dev": true,
             "requires": {
-                "cross-spawn": "^7.0.3",
-                "get-stream": "^6.0.0",
-                "human-signals": "^2.1.0",
+                "cross-spawn": "^7.0.0",
+                "get-stream": "^5.0.0",
+                "human-signals": "^1.1.1",
                 "is-stream": "^2.0.0",
                 "merge-stream": "^2.0.0",
-                "npm-run-path": "^4.0.1",
-                "onetime": "^5.1.2",
-                "signal-exit": "^3.0.3",
+                "npm-run-path": "^4.0.0",
+                "onetime": "^5.1.0",
+                "signal-exit": "^3.0.2",
                 "strip-final-newline": "^2.0.0"
             }
         },
@@ -17862,9 +17235,7 @@
             "dev": true
         },
         "exit-hook": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
-            "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw=="
+            "version": "2.2.1"
         },
         "expand-template": {
             "version": "2.0.3"
@@ -17944,8 +17315,6 @@
         },
         "fast-glob": {
             "version": "3.2.7",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-            "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
             "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
@@ -17953,6 +17322,15 @@
                 "glob-parent": "^5.1.2",
                 "merge2": "^1.3.0",
                 "micromatch": "^4.0.4"
+            },
+            "dependencies": {
+                "glob-parent": {
+                    "version": "5.1.2",
+                    "dev": true,
+                    "requires": {
+                        "is-glob": "^4.0.1"
+                    }
+                }
             }
         },
         "fast-json-stable-stringify": {
@@ -17974,8 +17352,6 @@
         },
         "fastq": {
             "version": "1.13.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
-            "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
             "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
@@ -18048,11 +17424,11 @@
             }
         },
         "flatted": {
-            "version": "3.2.2",
+            "version": "3.2.4",
             "dev": true
         },
         "follow-redirects": {
-            "version": "1.14.4"
+            "version": "1.14.5"
         },
         "forever-agent": {
             "version": "0.6.1"
@@ -18066,7 +17442,7 @@
             }
         },
         "formidable": {
-            "version": "1.2.2"
+            "version": "1.2.6"
         },
         "forwarded": {
             "version": "0.2.0"
@@ -18082,8 +17458,6 @@
         },
         "fs-extra": {
             "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-            "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
             "peer": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -18092,10 +17466,10 @@
             }
         },
         "fs-minipass": {
-            "version": "2.1.0",
-            "optional": true,
+            "version": "1.2.7",
+            "peer": true,
             "requires": {
-                "minipass": "^3.0.0"
+                "minipass": "^2.6.0"
             }
         },
         "fs.realpath": {
@@ -18103,8 +17477,6 @@
         },
         "fstream": {
             "version": "1.0.12",
-            "resolved": "https://registry.npmjs.org/fstream/-/fstream-1.0.12.tgz",
-            "integrity": "sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==",
             "peer": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
@@ -18113,19 +17485,8 @@
                 "rimraf": "2"
             },
             "dependencies": {
-                "mkdirp": {
-                    "version": "0.5.5",
-                    "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-                    "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-                    "peer": true,
-                    "requires": {
-                        "minimist": "^1.2.5"
-                    }
-                },
                 "rimraf": {
                     "version": "2.7.1",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
-                    "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
                     "peer": true,
                     "requires": {
                         "glob": "^7.1.3"
@@ -18141,41 +17502,14 @@
             "dev": true
         },
         "gauge": {
-            "version": "2.7.4",
+            "version": "1.2.7",
+            "peer": true,
             "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
+                "ansi": "^0.3.0",
                 "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1"
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                }
+                "lodash.pad": "^4.1.0",
+                "lodash.padend": "^4.1.0",
+                "lodash.padstart": "^4.1.0"
             }
         },
         "gaxios": {
@@ -18219,7 +17553,11 @@
             "version": "2.3.3"
         },
         "get-stream": {
-            "version": "6.0.1"
+            "version": "5.2.0",
+            "dev": true,
+            "requires": {
+                "pump": "^3.0.0"
+            }
         },
         "get-symbol-description": {
             "version": "1.0.0",
@@ -18241,8 +17579,8 @@
             "version": "file:samples/github",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-github": "0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-github": "0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -18262,10 +17600,10 @@
             }
         },
         "glob-parent": {
-            "version": "5.1.2",
+            "version": "6.0.2",
             "dev": true,
             "requires": {
-                "is-glob": "^4.0.1"
+                "is-glob": "^4.0.3"
             }
         },
         "glob-to-regexp": {
@@ -18281,8 +17619,6 @@
         },
         "globals": {
             "version": "13.12.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-            "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
             "dev": true,
             "requires": {
                 "type-fest": "^0.20.2"
@@ -18290,8 +17626,6 @@
         },
         "globby": {
             "version": "11.0.4",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-            "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
             "dev": true,
             "requires": {
                 "array-union": "^2.1.0",
@@ -18303,7 +17637,7 @@
             }
         },
         "google-auth-library": {
-            "version": "7.10.1",
+            "version": "7.10.2",
             "requires": {
                 "arrify": "^2.0.0",
                 "base64-js": "^1.3.0",
@@ -18373,8 +17707,8 @@
             "version": "file:samples/gsheets",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-googleapis": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-googleapis": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -18406,24 +17740,6 @@
         "has-bigints": {
             "version": "1.0.1"
         },
-        "has-binary2": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/has-binary2/-/has-binary2-1.0.3.tgz",
-            "integrity": "sha512-G1LWKhDSvhGeAQ8mPVQlqNcOB2sJdwATtZKl2pDKKHfpf/rYj24lkinxf69blJbnsvtqqNU+L3SL50vzZhXOnw==",
-            "requires": {
-                "isarray": "2.0.1"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
-                }
-            }
-        },
-        "has-cors": {
-            "version": "1.1.0"
-        },
         "has-flag": {
             "version": "4.0.0",
             "dev": true
@@ -18449,6 +17765,25 @@
             "requires": {
                 "glob": "^7.1.6",
                 "readable-stream": "^3.6.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1"
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
             }
         },
         "hexy": {
@@ -18573,13 +17908,11 @@
             }
         },
         "human-signals": {
-            "version": "2.1.0",
+            "version": "1.1.1",
             "dev": true
         },
         "husky": {
             "version": "7.0.4",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-7.0.4.tgz",
-            "integrity": "sha512-vbaCKN2QLtP/vD4yvs6iz6hBEo6wkSzs8HpRah1Z6aGmF2KW5PdYuAd7uX5a+OyBZHBhd+TFLqgjUgytQr4RvQ==",
             "dev": true
         },
         "iconv-lite": {
@@ -18590,8 +17923,6 @@
         },
         "icss-utils": {
             "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
-            "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
             "dev": true,
             "requires": {}
         },
@@ -18599,12 +17930,10 @@
             "version": "1.2.1"
         },
         "ieee754-buffer": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/ieee754-buffer/-/ieee754-buffer-0.2.1.tgz",
-            "integrity": "sha512-dDlJhYk8BAmH1HDncTjCt6xOm2+kT+MxGhRKB+mUoF8nocDzPAgZPEWTRI9QgkGvbDkbJgCqyxweGlIV0yhbUQ=="
+            "version": "0.2.1"
         },
         "ignore": {
-            "version": "5.1.8",
+            "version": "5.1.9",
             "dev": true
         },
         "ignore-by-default": {
@@ -18612,14 +17941,10 @@
             "dev": true
         },
         "imaadpcm": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/imaadpcm/-/imaadpcm-4.1.2.tgz",
-            "integrity": "sha512-7gwxe6lKCGitmkMtGbm1ecnt0Q59KcWwo7AVi2RAd3lQ9VghVN5zX5x3oK6xNhfD9KUMbaYzku43UBn3Ix3RIA=="
+            "version": "4.1.2"
         },
         "import-fresh": {
             "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
             "requires": {
                 "parent-module": "^1.0.0",
@@ -18642,11 +17967,6 @@
             "version": "0.1.4",
             "dev": true
         },
-        "indexof": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-            "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10="
-        },
         "inflight": {
             "version": "1.0.6",
             "requires": {
@@ -18665,8 +17985,8 @@
             "version": "file:samples/intellij",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-intellij": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-intellij": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -18684,15 +18004,13 @@
         },
         "invert-kv": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
             "peer": true
         },
         "ip-regex": {
             "version": "4.3.0"
         },
         "ip6addr": {
-            "version": "0.2.3",
+            "version": "0.2.4",
             "requires": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.4.0"
@@ -18705,14 +18023,32 @@
             "version": "file:samples/irc",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-irc": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-irc": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
-        "irc-colors": {
-            "version": "1.5.0"
+        "ircv3": {
+            "version": "0.28.1",
+            "requires": {
+                "@d-fischer/connection": "^6.6.0",
+                "@d-fischer/escape-string-regexp": "^5.0.0",
+                "@d-fischer/logger": "^4.0.0",
+                "@d-fischer/shared-utils": "^3.0.1",
+                "@d-fischer/typed-event-emitter": "^3.2.2",
+                "@types/node": "^14.14.19",
+                "klona": "^2.0.4",
+                "tslib": "^2.0.3"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "14.17.34"
+                },
+                "tslib": {
+                    "version": "2.3.1"
+                }
+            }
         },
         "is-arguments": {
             "version": "1.1.1",
@@ -18803,8 +18139,6 @@
         },
         "is-iojs": {
             "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-iojs/-/is-iojs-1.1.0.tgz",
-            "integrity": "sha1-TBEDO11dlNbqs3dd7cm+fQCDJfE=",
             "peer": true
         },
         "is-ip": {
@@ -18875,9 +18209,7 @@
             }
         },
         "is-running": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/is-running/-/is-running-2.1.0.tgz",
-            "integrity": "sha1-MKc/9cw4VOT8JUkICen1q/jeCeA="
+            "version": "2.1.0"
         },
         "is-set": {
             "version": "2.0.2"
@@ -19026,6 +18358,31 @@
                 "@jest/types": "^27.2.5",
                 "execa": "^5.0.0",
                 "throat": "^6.0.1"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "5.1.1",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^6.0.0",
+                        "human-signals": "^2.1.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.1",
+                        "onetime": "^5.1.2",
+                        "signal-exit": "^3.0.3",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "dev": true
+                },
+                "human-signals": {
+                    "version": "2.1.0",
+                    "dev": true
+                }
             }
         },
         "jest-circus": {
@@ -19229,15 +18586,6 @@
                 "pretty-format": "^27.3.1",
                 "slash": "^3.0.0",
                 "stack-utils": "^2.0.3"
-            },
-            "dependencies": {
-                "@babel/code-frame": {
-                    "version": "7.15.8",
-                    "dev": true,
-                    "requires": {
-                        "@babel/highlight": "^7.14.5"
-                    }
-                }
             }
         },
         "jest-mock": {
@@ -19340,6 +18688,31 @@
                 "slash": "^3.0.0",
                 "strip-bom": "^4.0.0",
                 "yargs": "^16.2.0"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "5.1.1",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^6.0.0",
+                        "human-signals": "^2.1.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.1",
+                        "onetime": "^5.1.2",
+                        "signal-exit": "^3.0.3",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "dev": true
+                },
+                "human-signals": {
+                    "version": "2.1.0",
+                    "dev": true
+                }
             }
         },
         "jest-serializer": {
@@ -19405,7 +18778,7 @@
             },
             "dependencies": {
                 "camelcase": {
-                    "version": "6.2.0",
+                    "version": "6.2.1",
                     "dev": true
                 }
             }
@@ -19440,11 +18813,10 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.14.1",
+            "version": "4.1.0",
             "dev": true,
             "requires": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
+                "argparse": "^2.0.1"
             }
         },
         "jsbi": {
@@ -19484,12 +18856,6 @@
                 "whatwg-url": "^8.5.0",
                 "ws": "^7.4.6",
                 "xml-name-validator": "^3.0.0"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "8.5.0",
-                    "dev": true
-                }
             }
         },
         "jsesc": {
@@ -19532,8 +18898,6 @@
         },
         "jsonfile": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
-            "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
             "peer": true,
             "requires": {
                 "graceful-fs": "^4.1.6"
@@ -19582,9 +18946,7 @@
             "version": "2.0.5"
         },
         "knex": {
-            "version": "0.95.13",
-            "resolved": "https://registry.npmjs.org/knex/-/knex-0.95.13.tgz",
-            "integrity": "sha512-XagG/iYA4RabYy1BmgY607Q00kBduOgb/Nej3+UDcCNdmuzDvZcfFo/726BYhfxv5amTBtGjewodZrTNbO63VA==",
+            "version": "0.95.14",
             "requires": {
                 "colorette": "2.0.16",
                 "commander": "^7.1.0",
@@ -19621,8 +18983,6 @@
         },
         "lcid": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
             "peer": true,
             "requires": {
                 "invert-kv": "^1.0.0"
@@ -19642,8 +19002,6 @@
         },
         "listenercount": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/listenercount/-/listenercount-1.0.1.tgz",
-            "integrity": "sha1-hMinKrWcRyUyFIDJdeZQg0LnCTc=",
             "peer": true
         },
         "loader-runner": {
@@ -19652,8 +19010,6 @@
         },
         "loader-utils": {
             "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-2.0.2.tgz",
-            "integrity": "sha512-TM57VeHptv569d/GKh6TAYdzKblwDNiumOdkFnejjD0XwTH87K90w3O7AiJRqdQoXygvi1VQTJTLGhJl7WqA7A==",
             "dev": true,
             "requires": {
                 "big.js": "^5.2.2",
@@ -19672,9 +19028,7 @@
             "version": "4.17.21"
         },
         "lodash.isequal": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
-            "integrity": "sha1-QVxEePK8wwEgwizhDtMib30+GOA="
+            "version": "4.5.0"
         },
         "lodash.memoize": {
             "version": "4.1.2",
@@ -19686,20 +19040,14 @@
         },
         "lodash.pad": {
             "version": "4.5.1",
-            "resolved": "https://registry.npmjs.org/lodash.pad/-/lodash.pad-4.5.1.tgz",
-            "integrity": "sha1-QzCUmoM6fI2iLMIPaibE1Z3runA=",
             "peer": true
         },
         "lodash.padend": {
             "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.padend/-/lodash.padend-4.6.1.tgz",
-            "integrity": "sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=",
             "peer": true
         },
         "lodash.padstart": {
             "version": "4.6.1",
-            "resolved": "https://registry.npmjs.org/lodash.padstart/-/lodash.padstart-4.6.1.tgz",
-            "integrity": "sha1-0uPuv/DZ05rVD1y9G1KnvOa7YRs=",
             "peer": true
         },
         "long": {
@@ -19747,37 +19095,9 @@
         },
         "memory-stream": {
             "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/memory-stream/-/memory-stream-0.0.3.tgz",
-            "integrity": "sha1-6+jdHDuLw4wOeUHp3dWuvmtN6D8=",
             "peer": true,
             "requires": {
                 "readable-stream": "~1.0.26-2"
-            },
-            "dependencies": {
-                "isarray": {
-                    "version": "0.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-                    "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
-                    "peer": true
-                },
-                "readable-stream": {
-                    "version": "1.0.34",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
-                    "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
-                    "peer": true,
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.1",
-                        "isarray": "0.0.1",
-                        "string_decoder": "~0.10.x"
-                    }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "peer": true
-                }
             }
         },
         "merge-descriptors": {
@@ -19789,8 +19109,6 @@
         },
         "merge2": {
             "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true
         },
         "methods": {
@@ -19815,8 +19133,8 @@
             "version": "file:samples/midi-input",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-midi-input": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-midi-input": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -19825,9 +19143,9 @@
             "version": "file:samples/midi-io",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-midi-input": "^0.2.0",
-                "nodecg-io-midi-output": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-midi-input": "^0.3.0",
+                "nodecg-io-midi-output": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -19836,8 +19154,8 @@
             "version": "file:samples/midi-output",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-midi-output": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-midi-output": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -19846,12 +19164,12 @@
             "version": "1.6.0"
         },
         "mime-db": {
-            "version": "1.50.0"
+            "version": "1.51.0"
         },
         "mime-types": {
-            "version": "2.1.33",
+            "version": "2.1.34",
             "requires": {
-                "mime-db": "1.50.0"
+                "mime-db": "1.51.0"
             }
         },
         "mimic-fn": {
@@ -19872,36 +19190,41 @@
             "version": "1.2.5"
         },
         "minipass": {
-            "version": "3.1.5",
-            "optional": true,
+            "version": "2.9.0",
+            "peer": true,
             "requires": {
-                "yallist": "^4.0.0"
+                "safe-buffer": "^5.1.2",
+                "yallist": "^3.0.0"
+            },
+            "dependencies": {
+                "yallist": {
+                    "version": "3.1.1",
+                    "peer": true
+                }
             }
         },
         "minizlib": {
-            "version": "2.1.2",
-            "optional": true,
+            "version": "1.3.3",
+            "peer": true,
             "requires": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
+                "minipass": "^2.9.0"
             }
         },
         "mkdirp": {
-            "version": "1.0.4",
-            "optional": true
+            "version": "0.5.5",
+            "peer": true,
+            "requires": {
+                "minimist": "^1.2.5"
+            }
         },
         "mkdirp-classic": {
             "version": "0.5.3"
         },
         "monaco-editor": {
-            "version": "0.30.1",
-            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
-            "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg=="
+            "version": "0.30.1"
         },
         "monaco-editor-webpack-plugin": {
             "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-6.0.0.tgz",
-            "integrity": "sha512-vC886Mzpd2AkSM35XLkfQMjH+Ohz6RISVwhAejDUzZDheJAiz6G34lky1vyO8fZ702v7IrcKmsGwL1rRFnwvUA==",
             "dev": true,
             "requires": {
                 "loader-utils": "^2.0.0"
@@ -19931,6 +19254,23 @@
                     "requires": {
                         "ms": "2.1.2"
                     }
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1"
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
                 }
             }
         },
@@ -19938,8 +19278,8 @@
             "version": "file:samples/mqtt-client",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-mqtt-client": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-mqtt-client": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20018,24 +19358,20 @@
         },
         "nanoid": {
             "version": "3.1.30",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-            "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
             "dev": true
         },
         "nanoleaf": {
             "version": "file:samples/nanoleaf",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-nanoleaf": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-nanoleaf": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "nanotimer": {
-            "version": "0.3.15",
-            "resolved": "https://registry.npmjs.org/nanotimer/-/nanotimer-0.3.15.tgz",
-            "integrity": "sha1-KA0nfbkUbspvilcLVyq68qmsx1Q="
+            "version": "0.3.15"
         },
         "napi-build-utils": {
             "version": "1.0.2"
@@ -20063,11 +19399,10 @@
             }
         },
         "node-addon-api": {
-            "version": "1.7.2",
-            "optional": true
+            "version": "3.2.1"
         },
         "node-fetch": {
-            "version": "2.6.5",
+            "version": "2.6.6",
             "requires": {
                 "whatwg-url": "^5.0.0"
             },
@@ -20106,11 +19441,136 @@
                 "which": "^2.0.2"
             },
             "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1",
+                    "optional": true
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.7",
+                    "optional": true,
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "chownr": {
+                    "version": "2.0.0",
+                    "optional": true
+                },
+                "fs-minipass": {
+                    "version": "2.1.0",
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^3.0.0"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "optional": true,
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "optional": true,
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0",
+                    "optional": true
+                },
+                "minipass": {
+                    "version": "3.1.5",
+                    "optional": true,
+                    "requires": {
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "2.1.2",
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^3.0.0",
+                        "yallist": "^4.0.0"
+                    }
+                },
+                "mkdirp": {
+                    "version": "1.0.4",
+                    "optional": true
+                },
                 "nopt": {
                     "version": "5.0.0",
                     "optional": true,
                     "requires": {
                         "abbrev": "1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "optional": true,
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "optional": true,
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "optional": true,
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "optional": true,
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                },
+                "tar": {
+                    "version": "6.1.11",
+                    "optional": true,
+                    "requires": {
+                        "chownr": "^2.0.0",
+                        "fs-minipass": "^2.0.0",
+                        "minipass": "^3.0.0",
+                        "minizlib": "^2.1.1",
+                        "mkdirp": "^1.0.3",
+                        "yallist": "^4.0.0"
                     }
                 }
             }
@@ -20121,11 +19581,6 @@
                 "bindings": "^1.5.0",
                 "node-addon-api": "^3.0.2",
                 "prebuild-install": "^6.0.0"
-            },
-            "dependencies": {
-                "node-addon-api": {
-                    "version": "3.2.1"
-                }
             }
         },
         "node-hue-api": {
@@ -20134,6 +19589,14 @@
                 "axios": "^0.21.1",
                 "bottleneck": "^2.19.5",
                 "get-ssl-certificate": "^2.3.3"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "0.21.4",
+                    "requires": {
+                        "follow-redirects": "^1.14.0"
+                    }
+                }
             }
         },
         "node-int64": {
@@ -20177,6 +19640,9 @@
                         "ms": "^2.1.1"
                     }
                 },
+                "eventemitter3": {
+                    "version": "3.1.2"
+                },
                 "isarray": {
                     "version": "1.0.0"
                 },
@@ -20213,7 +19679,7 @@
                 "@types/node": "^16.11.7",
                 "@types/node-fetch": "^2.5.10",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20224,9 +19690,14 @@
                 "@rauschma/stringio": "^1.4.0",
                 "@types/node": "^16.11.7",
                 "get-stream": "^6.0.1",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "6.0.1"
+                }
             }
         },
         "nodecg-io-artnet": {
@@ -20234,7 +19705,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "artnet-protocol": "^0.2.1",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20244,7 +19715,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "atem-connection": "^2.3.1",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20275,6 +19746,9 @@
                 },
                 "json-schema-traverse": {
                     "version": "1.0.0"
+                },
+                "tslib": {
+                    "version": "2.3.1"
                 }
             }
         },
@@ -20284,7 +19758,7 @@
                 "@types/node": "^16.11.7",
                 "@types/node-fetch": "^2.5.10",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20297,7 +19771,7 @@
                 "css-loader": "^6.5.1",
                 "monaco-editor": "^0.30.1",
                 "monaco-editor-webpack-plugin": "^6.0.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "style-loader": "^3.3.1",
                 "typescript": "^4.4.4",
@@ -20310,7 +19784,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "dbus-next": "^0.10.2",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20322,7 +19796,7 @@
                 "css-loader": "^6.5.1",
                 "monaco-editor": "^0.30.1",
                 "monaco-editor-webpack-plugin": "^6.0.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "style-loader": "^3.3.1",
                 "typescript": "^4.4.4",
@@ -20335,7 +19809,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "discord.js": "^13.3.1",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20348,7 +19822,7 @@
                 "@types/node-fetch": "^2.5.10",
                 "discord-rpc": "^4.0.1",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             },
@@ -20369,7 +19843,7 @@
                 "@types/node": "^16.11.7",
                 "@types/node-fetch": "^2.5.10",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20379,7 +19853,7 @@
             "requires": {
                 "@octokit/rest": "^18.12.0",
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20391,7 +19865,7 @@
                 "@types/node": "^16.11.7",
                 "express": "^4.17.1",
                 "googleapis": "^89.0.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "open": "^8.4.0",
                 "typescript": "^4.4.4"
@@ -20403,7 +19877,7 @@
                 "@types/node": "^16.11.7",
                 "@types/node-fetch": "^2.5.10",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20414,7 +19888,7 @@
                 "@types/irc": "^0.5.1",
                 "@types/node": "^16.11.7",
                 "irc": "^0.5.2",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             },
@@ -20434,7 +19908,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "easymidi": "^2.1.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20444,7 +19918,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "easymidi": "^2.1.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20454,7 +19928,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "mqtt": "^4.2.8",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20465,7 +19939,7 @@
                 "@types/node": "^16.11.7",
                 "@types/node-fetch": "^2.5.10",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20474,7 +19948,7 @@
             "version": "file:services/nodecg-io-obs",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "obs-websocket-js": "^4.0.3",
                 "typescript": "^4.4.4"
@@ -20486,7 +19960,7 @@
                 "@types/node": "^16.11.7",
                 "is-ip": "^3.1.0",
                 "node-hue-api": "^4.0.10",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20495,7 +19969,7 @@
             "version": "file:services/nodecg-io-rcon",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "rcon-client": "^4.2.3",
                 "typescript": "^4.4.4"
@@ -20505,7 +19979,7 @@
             "version": "file:services/nodecg-io-reddit",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "reddit-ts": "noeppi-noeppi/npm-reddit-ts#build",
                 "typescript": "^4.4.4"
@@ -20515,7 +19989,7 @@
             "version": "file:services/nodecg-io-sacn-receiver",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "sacn": "^4.1.0",
                 "typescript": "^4.4.4"
@@ -20525,7 +19999,7 @@
             "version": "file:services/nodecg-io-sacn-sender",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "sacn": "^4.1.0",
                 "typescript": "^4.4.4"
@@ -20537,7 +20011,7 @@
                 "@serialport/parser-readline": "^9.2.4",
                 "@types/node": "^16.11.7",
                 "@types/serialport": "^8.0.2",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "serialport": "^9.2.5",
                 "typescript": "^4.4.4"
@@ -20547,7 +20021,7 @@
             "version": "file:services/nodecg-io-shlink",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "shlink-client": "^1.0.1",
                 "typescript": "^4.4.4"
@@ -20558,7 +20032,7 @@
             "requires": {
                 "@slack/web-api": "^6.5.0",
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20569,7 +20043,7 @@
                 "@types/node": "^16.11.7",
                 "@types/spotify-web-api-node": "^5.0.3",
                 "express": "^4.17.1",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "open": "^8.4.0",
                 "spotify-web-api-node": "^5.0.2",
@@ -20581,7 +20055,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "knex": "^0.95.13",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20591,7 +20065,7 @@
             "requires": {
                 "@elgato-stream-deck/node": "^5.1.1",
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20601,29 +20075,23 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "@types/socket.io-client": "^1.4.36",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "socket.io-client": "^2.4.0",
                 "typescript": "^4.4.4"
             },
             "dependencies": {
                 "base64-arraybuffer": {
-                    "version": "0.1.4",
-                    "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-0.1.4.tgz",
-                    "integrity": "sha1-mBjHngWbE1X5fgQooBfIOOkLqBI="
+                    "version": "0.1.4"
                 },
                 "debug": {
                     "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-                    "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
                     "requires": {
                         "ms": "2.0.0"
                     }
                 },
                 "engine.io-client": {
                     "version": "3.5.2",
-                    "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-3.5.2.tgz",
-                    "integrity": "sha512-QEqIp+gJ/kMHeUun7f5Vv3bteRHppHH/FMBQX/esFj/fuYfjyUKWGMo3VCvIP/V8bE9KcjHmRZrhIz2Z9oNsDA==",
                     "requires": {
                         "component-emitter": "~1.3.0",
                         "component-inherit": "0.0.3",
@@ -20640,8 +20108,6 @@
                 },
                 "engine.io-parser": {
                     "version": "2.2.1",
-                    "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-2.2.1.tgz",
-                    "integrity": "sha512-x+dN/fBH8Ro8TFwJ+rkB2AmuVw9Yu2mockR/p3W8f8YtExwFgDvBDi0GWyb4ZLkpahtDGZgtr3zLovanJghPqg==",
                     "requires": {
                         "after": "0.8.2",
                         "arraybuffer.slice": "~0.0.7",
@@ -20651,19 +20117,13 @@
                     }
                 },
                 "isarray": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.1.tgz",
-                    "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4="
+                    "version": "2.0.1"
                 },
                 "ms": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-                    "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+                    "version": "2.0.0"
                 },
                 "socket.io-client": {
                     "version": "2.4.0",
-                    "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-2.4.0.tgz",
-                    "integrity": "sha512-M6xhnKQHuuZd4Ba9vltCLT9oa+YvTsP8j9NcEiLElfIg8KeYPyhWOes6x4t+LTAC8enQbE/995AdTem2uNyKKQ==",
                     "requires": {
                         "backo2": "1.0.2",
                         "component-bind": "1.0.0",
@@ -20680,8 +20140,6 @@
                 },
                 "socket.io-parser": {
                     "version": "3.3.2",
-                    "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-3.3.2.tgz",
-                    "integrity": "sha512-FJvDBuOALxdCI9qwRrO/Rfp9yfndRtc1jSgVgV8FDraihmSP/MLGD5PEuJrNfjALvcQ+vMDM/33AWOYP/JSjDg==",
                     "requires": {
                         "component-emitter": "~1.3.0",
                         "debug": "~3.1.0",
@@ -20690,14 +20148,10 @@
                 },
                 "ws": {
                     "version": "7.4.6",
-                    "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-                    "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
                     "requires": {}
                 },
                 "xmlhttprequest-ssl": {
-                    "version": "1.6.3",
-                    "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-1.6.3.tgz",
-                    "integrity": "sha512-3XfeQE/wNkvrIktn2Kf0869fC0BN6UpydVasGIeSm2B1Llihf7/0UfZM+eCkOw3P7bP4+qPgqhm7ZoxuJtFU0Q=="
+                    "version": "1.6.3"
                 }
             }
         },
@@ -20707,7 +20161,7 @@
                 "@types/node": "^16.11.7",
                 "@types/node-telegram-bot-api": "^0.53.1",
                 "node-telegram-bot-api": "^0.54.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20716,7 +20170,7 @@
             "version": "file:services/nodecg-io-template",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20726,7 +20180,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "@types/ws": "^8.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4",
                 "ws": "^8.2.3"
@@ -20744,8 +20198,8 @@
                 "@types/node": "^16.11.7",
                 "@types/node-fetch": "^2.5.10",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-auth": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-auth": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20755,8 +20209,8 @@
             "requires": {
                 "@twurple/api": "^5.0.9",
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-auth": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-auth": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20774,8 +20228,8 @@
             "requires": {
                 "@twurple/chat": "^5.0.8",
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-auth": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-auth": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20786,8 +20240,8 @@
                 "@twurple/api": "^5.0.9",
                 "@twurple/pubsub": "^5.0.9",
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-auth": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-auth": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -20797,7 +20251,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "@types/twitter": "^1.7.1",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "twitter": "^1.7.1",
                 "typescript": "^4.4.4"
@@ -20808,7 +20262,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "@types/ws": "^8.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4",
                 "ws": "^8.2.3"
@@ -20825,7 +20279,7 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "@types/ws": "^8.2.0",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4",
                 "ws": "^8.2.3"
@@ -20844,15 +20298,13 @@
                 "@types/node": "^16.11.7",
                 "@types/node-fetch": "^2.5.10",
                 "node-fetch": "^2.6.5",
-                "nodecg-io-core": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "nodecg-types": {
             "version": "1.8.3",
-            "resolved": "https://registry.npmjs.org/nodecg-types/-/nodecg-types-1.8.3.tgz",
-            "integrity": "sha512-ZK5HsYjoX73XMsI5BboQSvquDWcjlUdG0gwqNbWuowVeJWCZ6KGAE2ZLL6o1hQ12YIlKLcqb/6Jju/y8CBghOw==",
             "requires": {
                 "@types/express": "^4.17.13",
                 "@types/node": "^16.7.1",
@@ -20862,18 +20314,18 @@
             }
         },
         "nodemon": {
-            "version": "2.0.14",
+            "version": "2.0.15",
             "dev": true,
             "requires": {
-                "chokidar": "^3.2.2",
-                "debug": "^3.2.6",
+                "chokidar": "^3.5.2",
+                "debug": "^3.2.7",
                 "ignore-by-default": "^1.0.1",
                 "minimatch": "^3.0.4",
-                "pstree.remy": "^1.1.7",
+                "pstree.remy": "^1.1.8",
                 "semver": "^5.7.1",
                 "supports-color": "^5.5.0",
                 "touch": "^3.1.0",
-                "undefsafe": "^2.0.3",
+                "undefsafe": "^2.0.5",
                 "update-notifier": "^5.1.0"
             },
             "dependencies": {
@@ -20924,12 +20376,12 @@
             }
         },
         "npmlog": {
-            "version": "4.1.2",
+            "version": "1.2.1",
+            "peer": true,
             "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
+                "ansi": "~0.3.0",
+                "are-we-there-yet": "~1.0.0",
+                "gauge": "~1.2.0"
             }
         },
         "number-is-nan": {
@@ -20964,8 +20416,8 @@
             "version": "file:samples/obs-scenelist",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-obs": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-obs": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -21028,8 +20480,6 @@
         },
         "os-locale": {
             "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-            "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
             "peer": true,
             "requires": {
                 "lcid": "^1.0.0"
@@ -21037,8 +20487,6 @@
         },
         "ow": {
             "version": "0.27.0",
-            "resolved": "https://registry.npmjs.org/ow/-/ow-0.27.0.tgz",
-            "integrity": "sha512-SGnrGUbhn4VaUGdU0EJLMwZWSupPmF46hnTRII7aCLCrqixTAC5eKo8kI4/XXf1eaaI8YEVT+3FeGNJI9himAQ==",
             "requires": {
                 "@sindresorhus/is": "^4.0.1",
                 "callsites": "^3.1.0",
@@ -21049,22 +20497,16 @@
             },
             "dependencies": {
                 "@sindresorhus/is": {
-                    "version": "4.2.0",
-                    "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.2.0.tgz",
-                    "integrity": "sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw=="
+                    "version": "4.2.0"
                 },
                 "dot-prop": {
                     "version": "6.0.1",
-                    "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-6.0.1.tgz",
-                    "integrity": "sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==",
                     "requires": {
                         "is-obj": "^2.0.0"
                     }
                 },
                 "type-fest": {
-                    "version": "1.4.0",
-                    "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-                    "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+                    "version": "1.4.0"
                 }
             }
         },
@@ -21098,11 +20540,6 @@
             "requires": {
                 "eventemitter3": "^4.0.4",
                 "p-timeout": "^3.2.0"
-            },
-            "dependencies": {
-                "eventemitter3": {
-                    "version": "4.0.7"
-                }
             }
         },
         "p-retry": {
@@ -21140,8 +20577,6 @@
         },
         "parent-module": {
             "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-            "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
             "requires": {
                 "callsites": "^3.0.0"
@@ -21150,12 +20585,6 @@
         "parse5": {
             "version": "6.0.1",
             "dev": true
-        },
-        "parseqs": {
-            "version": "0.0.6"
-        },
-        "parseuri": {
-            "version": "0.0.6"
         },
         "parseurl": {
             "version": "1.3.3"
@@ -21183,8 +20612,6 @@
         },
         "path-type": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
             "dev": true
         },
         "pause-stream": {
@@ -21203,8 +20630,8 @@
             "version": "file:samples/philipshue-lights",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-philipshue": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-philipshue": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -21248,8 +20675,6 @@
         },
         "postcss": {
             "version": "8.3.11",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.3.11.tgz",
-            "integrity": "sha512-hCmlUAIlUiav8Xdqw3Io4LcpA1DOt7h3LSTAC4G6JGHFFaWzI6qvFt9oilvl8BmkbBRX1IhM90ZAmpk68zccQA==",
             "dev": true,
             "requires": {
                 "nanoid": "^3.1.30",
@@ -21259,15 +20684,11 @@
         },
         "postcss-modules-extract-imports": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
-            "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
             "dev": true,
             "requires": {}
         },
         "postcss-modules-local-by-default": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
-            "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
             "dev": true,
             "requires": {
                 "icss-utils": "^5.0.0",
@@ -21277,8 +20698,6 @@
         },
         "postcss-modules-scope": {
             "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
-            "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
             "dev": true,
             "requires": {
                 "postcss-selector-parser": "^6.0.4"
@@ -21286,8 +20705,6 @@
         },
         "postcss-modules-values": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
-            "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
             "dev": true,
             "requires": {
                 "icss-utils": "^5.0.0"
@@ -21295,8 +20712,6 @@
         },
         "postcss-selector-parser": {
             "version": "6.0.6",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.6.tgz",
-            "integrity": "sha512-9LXrvaaX3+mcv5xkg5kFwqSzSH1JIObIx51PrndZwlmznwXRfxMddDvo9gve3gVR8ZTKgoFDdWkbRFmEhT4PMg==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
@@ -21305,8 +20720,6 @@
         },
         "postcss-value-parser": {
             "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
-            "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
             "dev": true
         },
         "prebuild-install": {
@@ -21325,6 +20738,81 @@
                 "simple-get": "^3.0.3",
                 "tar-fs": "^2.0.0",
                 "tunnel-agent": "^0.6.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "2.1.1"
+                },
+                "are-we-there-yet": {
+                    "version": "1.1.7",
+                    "requires": {
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
+                    }
+                },
+                "gauge": {
+                    "version": "2.7.4",
+                    "requires": {
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
+                    }
+                },
+                "is-fullwidth-code-point": {
+                    "version": "1.0.0",
+                    "requires": {
+                        "number-is-nan": "^1.0.0"
+                    }
+                },
+                "isarray": {
+                    "version": "1.0.0"
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
+                    }
+                },
+                "readable-stream": {
+                    "version": "2.3.7",
+                    "requires": {
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
+                    }
+                },
+                "string_decoder": {
+                    "version": "1.1.1",
+                    "requires": {
+                        "safe-buffer": "~5.1.0"
+                    }
+                },
+                "string-width": {
+                    "version": "1.0.2",
+                    "requires": {
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "requires": {
+                        "ansi-regex": "^2.0.0"
+                    }
+                }
             }
         },
         "prelude-ls": {
@@ -21356,7 +20844,7 @@
             }
         },
         "pretty-quick": {
-            "version": "3.1.1",
+            "version": "3.1.2",
             "dev": true,
             "requires": {
                 "chalk": "^3.0.0",
@@ -21374,32 +20862,6 @@
                         "ansi-styles": "^4.1.0",
                         "supports-color": "^7.1.0"
                     }
-                },
-                "execa": {
-                    "version": "4.1.0",
-                    "dev": true,
-                    "requires": {
-                        "cross-spawn": "^7.0.0",
-                        "get-stream": "^5.0.0",
-                        "human-signals": "^1.1.1",
-                        "is-stream": "^2.0.0",
-                        "merge-stream": "^2.0.0",
-                        "npm-run-path": "^4.0.0",
-                        "onetime": "^5.1.0",
-                        "signal-exit": "^3.0.2",
-                        "strip-final-newline": "^2.0.0"
-                    }
-                },
-                "get-stream": {
-                    "version": "5.2.0",
-                    "dev": true,
-                    "requires": {
-                        "pump": "^3.0.0"
-                    }
-                },
-                "human-signals": {
-                    "version": "1.1.1",
-                    "dev": true
                 },
                 "supports-color": {
                     "version": "7.2.0",
@@ -21461,8 +20923,6 @@
         },
         "queue-microtask": {
             "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
-            "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
             "dev": true
         },
         "randombytes": {
@@ -21511,8 +20971,8 @@
             "version": "file:samples/rcon-minecraft",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-rcon": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-rcon": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -21522,11 +20982,19 @@
             "dev": true
         },
         "readable-stream": {
-            "version": "3.6.0",
+            "version": "1.0.34",
+            "peer": true,
             "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "peer": true
+                }
             }
         },
         "readdirp": {
@@ -21546,8 +21014,8 @@
             "version": "file:samples/reddit-msg-read",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-reddit": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-reddit": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -21564,14 +21032,6 @@
         "regexpp": {
             "version": "3.2.0",
             "dev": true
-        },
-        "register-scheme": {
-            "version": "0.0.2",
-            "optional": true,
-            "requires": {
-                "bindings": "^1.3.0",
-                "node-addon-api": "^1.3.0"
-            }
         },
         "registry-auth-token": {
             "version": "4.2.1",
@@ -21666,9 +21126,6 @@
             "version": "2.1.1",
             "dev": true
         },
-        "require-from-string": {
-            "version": "2.0.2"
-        },
         "resolve": {
             "version": "1.20.0",
             "requires": {
@@ -21691,8 +21148,6 @@
         },
         "resolve-from": {
             "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-            "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true
         },
         "resolve.exports": {
@@ -21711,8 +21166,6 @@
         },
         "reusify": {
             "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true
         },
         "rimraf": {
@@ -21724,8 +21177,6 @@
         },
         "run-parallel": {
             "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
-            "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
             "dev": true,
             "requires": {
                 "queue-microtask": "^1.2.2"
@@ -21736,12 +21187,6 @@
             "dev": true,
             "requires": {
                 "tslib": "^1.9.0"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "dev": true
-                }
             }
         },
         "sacn": {
@@ -21751,8 +21196,8 @@
             "version": "file:samples/sacn-receiver",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-sacn-receiver": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-sacn-receiver": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -21761,8 +21206,8 @@
             "version": "file:samples/sacn-sender",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-sacn-sender": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-sacn-sender": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -21849,8 +21294,8 @@
             "version": "file:samples/serial",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-serial": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-serial": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -21863,12 +21308,10 @@
             }
         },
         "serialport": {
-            "version": "9.2.5",
-            "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.2.5.tgz",
-            "integrity": "sha512-nsDsD2GN/43T2a8jQYr1HH76gmDZ575Ts8FOdcBRUY8ecaI16BPbXa612cPPkQjOfg28+KL5qtQL9c0vvTaidg==",
+            "version": "9.2.7",
             "requires": {
                 "@serialport/binding-mock": "9.2.4",
-                "@serialport/bindings": "9.2.5",
+                "@serialport/bindings": "9.2.7",
                 "@serialport/parser-byte-length": "9.2.4",
                 "@serialport/parser-cctalk": "9.2.4",
                 "@serialport/parser-delimiter": "9.2.4",
@@ -21936,14 +21379,22 @@
             "version": "1.0.1",
             "requires": {
                 "axios": "^0.21.0"
+            },
+            "dependencies": {
+                "axios": {
+                    "version": "0.21.4",
+                    "requires": {
+                        "follow-redirects": "^1.14.0"
+                    }
+                }
             }
         },
         "shlink-list-short-urls": {
             "version": "file:samples/shlink-list-short-urls",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-shlink": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-shlink": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -21957,7 +21408,7 @@
             }
         },
         "signal-exit": {
-            "version": "3.0.5"
+            "version": "3.0.6"
         },
         "simple-concat": {
             "version": "1.0.1"
@@ -21989,8 +21440,8 @@
             "version": "file:samples/slack-post",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-slack": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-slack": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22020,12 +21471,10 @@
         },
         "source-map-js": {
             "version": "0.6.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-0.6.2.tgz",
-            "integrity": "sha512-/3GptzWzu0+0MBQFrDKzw/DvvMTUORvgY6k6jd/VS6iCR4RDTKWH6v6WPwQoUO8667uQEf9Oe38DxAYWY5F/Ug==",
             "dev": true
         },
         "source-map-support": {
-            "version": "0.5.20",
+            "version": "0.5.21",
             "dev": true,
             "requires": {
                 "buffer-from": "^1.0.0",
@@ -22046,20 +21495,37 @@
             "version": "3.2.2",
             "requires": {
                 "readable-stream": "^3.0.0"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1"
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
             }
         },
         "splitargs": {
             "version": "0.0.7",
-            "resolved": "https://registry.npmjs.org/splitargs/-/splitargs-0.0.7.tgz",
-            "integrity": "sha1-/p965lc3GzOxDLgNoUPPgknPazs=",
             "peer": true
         },
         "spotify-current-song": {
             "version": "file:samples/spotify-current-song",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-spotify": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-spotify": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22079,8 +21545,8 @@
             "requires": {
                 "@types/node": "^16.11.7",
                 "mysql": "^2.18.1",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-sql": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-sql": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22100,11 +21566,6 @@
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.0.2",
                 "tweetnacl": "~0.14.0"
-            },
-            "dependencies": {
-                "tweetnacl": {
-                    "version": "0.14.5"
-                }
             }
         },
         "stack-utils": {
@@ -22139,8 +21600,8 @@
             "version": "file:samples/streamdeck-rainbow",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-streamdeck": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-streamdeck": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22149,22 +21610,15 @@
             "version": "file:samples/streamelements-events",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-streamelements": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-streamelements": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "string_decoder": {
-            "version": "1.3.0",
-            "requires": {
-                "safe-buffer": "~5.2.0"
-            },
-            "dependencies": {
-                "safe-buffer": {
-                    "version": "5.2.1"
-                }
-            }
+            "version": "0.10.31",
+            "peer": true
         },
         "string-length": {
             "version": "4.0.2",
@@ -22212,14 +21666,10 @@
         },
         "strip-json-comments": {
             "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-            "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true
         },
         "style-loader": {
             "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
-            "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
             "dev": true,
             "requires": {}
         },
@@ -22246,12 +21696,29 @@
                     }
                 },
                 "mime": {
-                    "version": "2.5.2"
+                    "version": "2.6.0"
                 },
                 "qs": {
                     "version": "6.10.1",
                     "requires": {
                         "side-channel": "^1.0.4"
+                    }
+                },
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1"
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
                     }
                 }
             }
@@ -22289,20 +21756,25 @@
             "dev": true
         },
         "tar": {
-            "version": "6.1.11",
-            "optional": true,
+            "version": "4.4.19",
+            "peer": true,
             "requires": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "chownr": "^1.1.4",
+                "fs-minipass": "^1.2.7",
+                "minipass": "^2.9.0",
+                "minizlib": "^1.3.3",
+                "mkdirp": "^0.5.5",
+                "safe-buffer": "^5.2.1",
+                "yallist": "^3.1.1"
             },
             "dependencies": {
-                "chownr": {
-                    "version": "2.0.0",
-                    "optional": true
+                "safe-buffer": {
+                    "version": "5.2.1",
+                    "peer": true
+                },
+                "yallist": {
+                    "version": "3.1.1",
+                    "peer": true
                 }
             }
         },
@@ -22323,6 +21795,25 @@
                 "fs-constants": "^1.0.0",
                 "inherits": "^2.0.3",
                 "readable-stream": "^3.1.1"
+            },
+            "dependencies": {
+                "readable-stream": {
+                    "version": "3.6.0",
+                    "requires": {
+                        "inherits": "^2.0.3",
+                        "string_decoder": "^1.1.1",
+                        "util-deprecate": "^1.0.1"
+                    }
+                },
+                "safe-buffer": {
+                    "version": "5.2.1"
+                },
+                "string_decoder": {
+                    "version": "1.3.0",
+                    "requires": {
+                        "safe-buffer": "~5.2.0"
+                    }
+                }
             }
         },
         "tarn": {
@@ -22332,8 +21823,8 @@
             "version": "file:samples/telegram-bot",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-telegram": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-telegram": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22342,8 +21833,8 @@
             "version": "file:samples/template",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-template": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-template": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22357,7 +21848,7 @@
             }
         },
         "terser": {
-            "version": "5.9.0",
+            "version": "5.10.0",
             "dev": true,
             "requires": {
                 "commander": "^2.20.0",
@@ -22376,24 +21867,14 @@
             }
         },
         "terser-webpack-plugin": {
-            "version": "5.2.4",
+            "version": "5.2.5",
             "dev": true,
             "requires": {
                 "jest-worker": "^27.0.6",
-                "p-limit": "^3.1.0",
                 "schema-utils": "^3.1.1",
                 "serialize-javascript": "^6.0.0",
                 "source-map": "^0.6.1",
                 "terser": "^5.7.2"
-            },
-            "dependencies": {
-                "p-limit": {
-                    "version": "3.1.0",
-                    "dev": true,
-                    "requires": {
-                        "yocto-queue": "^0.1.0"
-                    }
-                }
             }
         },
         "test-exclude": {
@@ -22411,25 +21892,11 @@
         },
         "threadedclass": {
             "version": "0.8.3",
-            "resolved": "https://registry.npmjs.org/threadedclass/-/threadedclass-0.8.3.tgz",
-            "integrity": "sha512-cI6tVYRIIVYxFG7Nykt8NMVflrrdMvyvzAQfgAZdARdU/PaFSGd5Y7wChvJ3DXLsLiFb3datLhfn26K5DTKf+A==",
             "requires": {
                 "callsites": "^3.1.0",
                 "eventemitter3": "^4.0.4",
                 "is-running": "^2.1.0",
                 "tslib": "^1.13.0"
-            },
-            "dependencies": {
-                "eventemitter3": {
-                    "version": "4.0.7",
-                    "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-                    "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
-                },
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
-                }
             }
         },
         "throat": {
@@ -22443,9 +21910,9 @@
             "version": "file:samples/tiane-discord",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-discord": "^0.2.0",
-                "nodecg-io-tiane": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-discord": "^0.3.0",
+                "nodecg-io-tiane": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22456,11 +21923,6 @@
         "tmpl": {
             "version": "1.0.5",
             "dev": true
-        },
-        "to-array": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/to-array/-/to-array-0.1.4.tgz",
-            "integrity": "sha1-F+bBH3PdTz10zaek/zI46a2b+JA="
         },
         "to-fast-properties": {
             "version": "2.0.0",
@@ -22505,8 +21967,6 @@
         },
         "traverse": {
             "version": "0.3.9",
-            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-            "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk=",
             "peer": true
         },
         "tree-kill": {
@@ -22528,28 +21988,16 @@
             }
         },
         "ts-mixer": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.0.tgz",
-            "integrity": "sha512-nXIb1fvdY5CBSrDIblLn73NW0qRDk5yJ0Sk1qPBF560OdJfQp9jhl+0tzcY09OZ9U+6GpeoI9RjwoIKFIoB9MQ=="
+            "version": "6.0.0"
         },
         "tslib": {
-            "version": "2.3.1"
+            "version": "1.14.1"
         },
         "tsutils": {
             "version": "3.21.0",
-            "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
-            "integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
             "dev": true,
             "requires": {
                 "tslib": "^1.8.1"
-            },
-            "dependencies": {
-                "tslib": {
-                    "version": "1.14.1",
-                    "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-                    "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-                    "dev": true
-                }
             }
         },
         "tunnel-agent": {
@@ -22558,12 +22006,15 @@
                 "safe-buffer": "^5.0.1"
             }
         },
+        "tweetnacl": {
+            "version": "0.14.5"
+        },
         "twitch-addons": {
             "version": "file:samples/twitch-addons",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-addons": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-addons": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22572,8 +22023,8 @@
             "version": "file:samples/twitch-api",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-api": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-api": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22582,8 +22033,8 @@
             "version": "file:samples/twitch-chat",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-chat": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-chat": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22592,8 +22043,8 @@
             "version": "file:samples/twitch-pubsub",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitch-pubsub": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitch-pubsub": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22614,16 +22065,14 @@
             "version": "file:samples/twitter-timeline",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-twitter": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-twitter": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
         },
         "twos-complement-buffer": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/twos-complement-buffer/-/twos-complement-buffer-0.0.1.tgz",
-            "integrity": "sha512-Ev3p2GfB2GO8pcyb7jIvctS9RAjSZrF/K+u5s3KN00ajY11Dda2oMqI72nXaHVU7doGYNXc0mJG6exWAbmzZiA==",
             "requires": {
                 "uint-buffer": "^0.1.0"
             }
@@ -22664,12 +22113,10 @@
             }
         },
         "typescript": {
-            "version": "4.4.4"
+            "version": "4.5.2"
         },
         "uint-buffer": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/uint-buffer/-/uint-buffer-0.1.0.tgz",
-            "integrity": "sha512-7xjpjCTijFIXAMxN7OMRfykpCMVfbCrlAmAt2RIlihvkHgvkNV5DBFzyc8OpIQeVpRXJkgXBwmKos4hD8DrX1g=="
+            "version": "0.1.0"
         },
         "unbox-primitive": {
             "version": "1.0.1",
@@ -22702,8 +22149,6 @@
         },
         "unzipper": {
             "version": "0.8.14",
-            "resolved": "https://registry.npmjs.org/unzipper/-/unzipper-0.8.14.tgz",
-            "integrity": "sha512-8rFtE7EP5ssOwGpN2dt1Q4njl0N1hUXJ7sSPz0leU2hRdq6+pra57z4YPBlVqm40vcgv6ooKZEAx48fMTv9x4w==",
             "peer": true,
             "requires": {
                 "big-integer": "^1.6.17",
@@ -22719,26 +22164,18 @@
             "dependencies": {
                 "bluebird": {
                     "version": "3.4.7",
-                    "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.7.tgz",
-                    "integrity": "sha1-9y12C+Cbf3bQjtj66Ysomo0F+rM=",
                     "peer": true
                 },
                 "isarray": {
                     "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
                     "peer": true
                 },
                 "process-nextick-args": {
                     "version": "1.0.7",
-                    "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-                    "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
                     "peer": true
                 },
                 "readable-stream": {
                     "version": "2.1.5",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.1.5.tgz",
-                    "integrity": "sha1-ZvqLcg4UOLNkaB8q0aY8YYRIydA=",
                     "peer": true,
                     "requires": {
                         "buffer-shims": "^1.0.0",
@@ -22749,12 +22186,6 @@
                         "string_decoder": "~0.10.x",
                         "util-deprecate": "~1.0.1"
                     }
-                },
-                "string_decoder": {
-                    "version": "0.10.31",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-                    "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-                    "peer": true
                 }
             }
         },
@@ -22786,8 +22217,6 @@
         },
         "url-join": {
             "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/url-join/-/url-join-0.0.1.tgz",
-            "integrity": "sha1-HbSK1CLTQCRpqH99l73r/k+x48g=",
             "peer": true
         },
         "url-parse-lax": {
@@ -22810,9 +22239,7 @@
             }
         },
         "utf8-buffer": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/utf8-buffer/-/utf8-buffer-0.2.0.tgz",
-            "integrity": "sha512-DygDeOmOPQRjxnnv8LdfjoSQgG9EgJFH1m/1QcrKkDOxzoOcLLqZ2ONzRYHmiRqJYQYnAvV+zv2Wgk5tXjr4aA=="
+            "version": "0.2.0"
         },
         "util-deprecate": {
             "version": "1.0.2"
@@ -22843,9 +22270,7 @@
             }
         },
         "vali-date": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/vali-date/-/vali-date-1.0.0.tgz",
-            "integrity": "sha1-G5BKWWCfsyjvB4E4Qgk09rhnCaY="
+            "version": "1.0.0"
         },
         "vary": {
             "version": "1.1.2"
@@ -22856,6 +22281,11 @@
                 "assert-plus": "^1.0.0",
                 "core-util-is": "1.0.2",
                 "extsprintf": "^1.2.0"
+            },
+            "dependencies": {
+                "core-util-is": {
+                    "version": "1.0.2"
+                }
             }
         },
         "w3c-hr-time": {
@@ -22889,8 +22319,6 @@
         },
         "wavefile": {
             "version": "8.4.6",
-            "resolved": "https://registry.npmjs.org/wavefile/-/wavefile-8.4.6.tgz",
-            "integrity": "sha512-mKvPtkXTFE3U8Uo8qJr/hCJP3booCI09vsoWY3OHrdKB+8ZefO/5/wSRZSbPSgFDB+WWn3Am3c01h/sguTYuyA==",
             "requires": {
                 "alawmulaw": "^5.0.2",
                 "base64-arraybuffer-es6": "^0.3.1",
@@ -22904,9 +22332,7 @@
             "dev": true
         },
         "webpack": {
-            "version": "5.64.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.64.0.tgz",
-            "integrity": "sha512-UclnN24m054HaPC45nmDEosX6yXWD+UGC12YtUs5i356DleAUGMDC9LBAw37xRRfgPKYIdCYjGA7RZ1AA+ZnGg==",
+            "version": "5.64.1",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.0",
@@ -22932,18 +22358,7 @@
                 "tapable": "^2.1.1",
                 "terser-webpack-plugin": "^5.1.3",
                 "watchpack": "^2.2.0",
-                "webpack-sources": "^3.2.0"
-            },
-            "dependencies": {
-                "acorn": {
-                    "version": "8.5.0",
-                    "dev": true
-                },
-                "acorn-import-assertions": {
-                    "version": "1.8.0",
-                    "dev": true,
-                    "requires": {}
-                }
+                "webpack-sources": "^3.2.2"
             }
         },
         "webpack-cli": {
@@ -22962,6 +22377,31 @@
                 "interpret": "^2.2.0",
                 "rechoir": "^0.7.0",
                 "webpack-merge": "^5.7.3"
+            },
+            "dependencies": {
+                "execa": {
+                    "version": "5.1.1",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^7.0.3",
+                        "get-stream": "^6.0.0",
+                        "human-signals": "^2.1.0",
+                        "is-stream": "^2.0.0",
+                        "merge-stream": "^2.0.0",
+                        "npm-run-path": "^4.0.1",
+                        "onetime": "^5.1.2",
+                        "signal-exit": "^3.0.3",
+                        "strip-final-newline": "^2.0.0"
+                    }
+                },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "dev": true
+                },
+                "human-signals": {
+                    "version": "2.1.0",
+                    "dev": true
+                }
             }
         },
         "webpack-merge": {
@@ -22973,15 +22413,15 @@
             }
         },
         "webpack-sources": {
-            "version": "3.2.1",
+            "version": "3.2.2",
             "dev": true
         },
         "websocket-client": {
             "version": "file:samples/websocket-client",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-websocket-client": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-websocket-client": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -22990,8 +22430,8 @@
             "version": "file:samples/websocket-server",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-websocket-server": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-websocket-server": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -23052,8 +22492,6 @@
         },
         "window-size": {
             "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-            "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY=",
             "peer": true
         },
         "word-wrap": {
@@ -23094,8 +22532,8 @@
             "version": "file:samples/xdotool-windowminimize",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-xdotool": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-xdotool": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }
@@ -23145,19 +22583,12 @@
             "version": "20.2.9",
             "dev": true
         },
-        "yeast": {
-            "version": "0.1.2"
-        },
-        "yocto-queue": {
-            "version": "0.1.0",
-            "dev": true
-        },
         "youtube-playlist": {
             "version": "file:samples/youtube-playlist",
             "requires": {
                 "@types/node": "^16.11.7",
-                "nodecg-io-core": "^0.2.0",
-                "nodecg-io-googleapis": "^0.2.0",
+                "nodecg-io-core": "^0.3.0",
+                "nodecg-io-googleapis": "^0.3.0",
                 "nodecg-types": "^1.8.3",
                 "typescript": "^4.4.4"
             }

--- a/samples/ahk-sendcommand/package.json
+++ b/samples/ahk-sendcommand/package.json
@@ -1,19 +1,19 @@
 {
     "name": "ahk-sendcommand",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-ahk": "^0.2.0"
+            "nodecg-io-ahk": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-ahk": "^0.2.0",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-ahk": "^0.3.0",
+        "nodecg-io-core": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/android/package.json
+++ b/samples/android/package.json
@@ -1,19 +1,19 @@
 {
     "name": "android",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-android": "^0.2.0"
+            "nodecg-io-android": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-android": "^0.2.0",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-android": "^0.3.0",
+        "nodecg-io-core": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/artnet-console/package.json
+++ b/samples/artnet-console/package.json
@@ -10,20 +10,20 @@
         "url": "https://github.com/codeoverflow-org/nodecg-io.git",
         "directory": "samples/artnet-console"
     },
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-artnet": "^0.2.0"
+            "nodecg-io-artnet": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-artnet": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-artnet": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/atem/package.json
+++ b/samples/atem/package.json
@@ -10,20 +10,20 @@
         "url": "https://github.com/codeoverflow-org/nodecg-io.git",
         "directory": "samples/atem"
     },
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-atem": "^0.2.0"
+            "nodecg-io-atem": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-atem": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-atem": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/curseforge/package.json
+++ b/samples/curseforge/package.json
@@ -1,19 +1,19 @@
 {
     "name": "curseforge",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-curseforge": "0.2.0"
+            "nodecg-io-curseforge": "0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-curseforge": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-curseforge": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/dbus-ratbagd/package.json
+++ b/samples/dbus-ratbagd/package.json
@@ -1,19 +1,19 @@
 {
     "name": "dbus-ratbagd",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-dbus": "0.2.0"
+            "nodecg-io-dbus": "0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "typescript": "^4.4.4",
-        "nodecg-io-dbus": "0.2.0"
+        "nodecg-io-dbus": "0.3.0"
     }
 }

--- a/samples/debug/package.json
+++ b/samples/debug/package.json
@@ -1,19 +1,19 @@
 {
     "name": "debug",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-debug": "^0.2.0"
+            "nodecg-io-debug": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-debug": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-debug": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/discord-guild-chat/package.json
+++ b/samples/discord-guild-chat/package.json
@@ -1,6 +1,6 @@
 {
     "name": "discord-guild-chat",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Example nodecg-io Discord-Bundle. At the end of the day another Discord-bot",
     "private": true,
     "author": {
@@ -10,15 +10,15 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-discord": "^0.2.0"
+            "nodecg-io-discord": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-discord": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-discord": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/discord-rpc/package.json
+++ b/samples/discord-rpc/package.json
@@ -1,19 +1,19 @@
 {
     "name": "discord-rpc",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-discord-rpc": "0.2.0"
+            "nodecg-io-discord-rpc": "0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "typescript": "^4.4.4",
-        "nodecg-io-discord-rpc": "0.2.0"
+        "nodecg-io-discord-rpc": "0.3.0"
     }
 }

--- a/samples/elgato-light/package.json
+++ b/samples/elgato-light/package.json
@@ -1,19 +1,19 @@
 {
     "name": "elgato-light",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-elgato-light": "^0.2.0"
+            "nodecg-io-elgato-light": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-elgato-light": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-elgato-light": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/github/package.json
+++ b/samples/github/package.json
@@ -1,19 +1,19 @@
 {
     "name": "github",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-github": "0.2.0"
+            "nodecg-io-github": "0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "typescript": "^4.4.4",
-        "nodecg-io-github": "0.2.0"
+        "nodecg-io-github": "0.3.0"
     }
 }

--- a/samples/gsheets/package.json
+++ b/samples/gsheets/package.json
@@ -1,19 +1,19 @@
 {
     "name": "gsheets",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-googleapis": "^0.2.0"
+            "nodecg-io-googleapis": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-googleapis": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-googleapis": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/intellij/package.json
+++ b/samples/intellij/package.json
@@ -1,19 +1,19 @@
 {
     "name": "intellij",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-intellij": "^0.2.0"
+            "nodecg-io-intellij": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-intellij": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-intellij": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/irc/package.json
+++ b/samples/irc/package.json
@@ -1,19 +1,19 @@
 {
     "name": "irc",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-irc": "^0.2.0"
+            "nodecg-io-irc": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-irc": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-irc": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/midi-input/package.json
+++ b/samples/midi-input/package.json
@@ -1,11 +1,11 @@
 {
     "name": "midi-input",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-midi-input": "^0.2.0"
+            "nodecg-io-midi-input": "^0.3.0"
         }
     },
     "scripts": {
@@ -15,8 +15,8 @@
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-midi-input": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-midi-input": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/midi-io/package.json
+++ b/samples/midi-io/package.json
@@ -1,12 +1,12 @@
 {
     "name": "midi-io",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-midi-input": "^0.2.0",
-            "nodecg-io-midi-output": "^0.2.0"
+            "nodecg-io-midi-input": "^0.3.0",
+            "nodecg-io-midi-output": "^0.3.0"
         }
     },
     "scripts": {
@@ -16,9 +16,9 @@
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-midi-input": "^0.2.0",
-        "nodecg-io-midi-output": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-midi-input": "^0.3.0",
+        "nodecg-io-midi-output": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/midi-output/package.json
+++ b/samples/midi-output/package.json
@@ -1,11 +1,11 @@
 {
     "name": "midi-output",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-midi-output": "^0.2.0"
+            "nodecg-io-midi-output": "^0.3.0"
         }
     },
     "scripts": {
@@ -15,8 +15,8 @@
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-midi-output": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-midi-output": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/mqtt-client/package.json
+++ b/samples/mqtt-client/package.json
@@ -1,19 +1,19 @@
 {
     "name": "mqtt-client",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-mqtt-client": "^0.2.0"
+            "nodecg-io-mqtt-client": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-mqtt-client": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-mqtt-client": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/nanoleaf/package.json
+++ b/samples/nanoleaf/package.json
@@ -1,19 +1,19 @@
 {
     "name": "nanoleaf",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-nanoleaf": "^0.2.0"
+            "nodecg-io-nanoleaf": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-nanoleaf": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-nanoleaf": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/obs-scenelist/package.json
+++ b/samples/obs-scenelist/package.json
@@ -1,19 +1,19 @@
 {
     "name": "obs-scenelist",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-obs": "^0.2.0"
+            "nodecg-io-obs": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-obs": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-obs": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -1,6 +1,6 @@
 {
     "name": "samples",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "",
     "private": true,
     "nodecg": {

--- a/samples/philipshue-lights/package.json
+++ b/samples/philipshue-lights/package.json
@@ -1,19 +1,19 @@
 {
     "name": "philipshue-lights",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-philipshue": "^0.2.0"
+            "nodecg-io-philipshue": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-philipshue": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-philipshue": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/rcon-minecraft/package.json
+++ b/samples/rcon-minecraft/package.json
@@ -1,6 +1,6 @@
 {
     "name": "rcon-minecraft",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Example nodecg-io-rcon Bundle. Sends simple commands to a server",
     "private": true,
     "author": {
@@ -10,15 +10,15 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-rcon": "^0.2.0"
+            "nodecg-io-rcon": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-rcon": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-rcon": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/reddit-msg-read/package.json
+++ b/samples/reddit-msg-read/package.json
@@ -1,6 +1,6 @@
 {
     "name": "reddit-msg-read",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Example nodecg-io Reddit-Bundle that monitors messages from reddit.",
     "private": true,
     "author": {
@@ -10,15 +10,15 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-reddit": "^0.2.0"
+            "nodecg-io-reddit": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-reddit": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-reddit": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/sacn-receiver/package.json
+++ b/samples/sacn-receiver/package.json
@@ -1,6 +1,6 @@
 {
     "name": "sacn-receiver",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Example nodecg-io-sacn-receiver Bundle. Receives data via sACN",
     "private": true,
     "author": {
@@ -10,15 +10,15 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-sacn-receiver": "^0.2.0"
+            "nodecg-io-sacn-receiver": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-sacn-receiver": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-sacn-receiver": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/sacn-sender/package.json
+++ b/samples/sacn-sender/package.json
@@ -1,19 +1,19 @@
 {
     "name": "sacn-sender",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-sacn-sender": "^0.2.0"
+            "nodecg-io-sacn-sender": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-sacn-sender": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-sacn-sender": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/serial/package.json
+++ b/samples/serial/package.json
@@ -1,19 +1,19 @@
 {
     "name": "serial",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-serial": "^0.2.0"
+            "nodecg-io-serial": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-serial": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-serial": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/shlink-list-short-urls/package.json
+++ b/samples/shlink-list-short-urls/package.json
@@ -1,19 +1,19 @@
 {
     "name": "shlink-list-short-urls",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-shlink": "^0.2.0"
+            "nodecg-io-shlink": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-shlink": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-shlink": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/slack-post/package.json
+++ b/samples/slack-post/package.json
@@ -1,19 +1,19 @@
 {
     "name": "slack-post",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-slack": "^0.2.0"
+            "nodecg-io-slack": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-slack": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-slack": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/spotify-current-song/package.json
+++ b/samples/spotify-current-song/package.json
@@ -1,19 +1,19 @@
 {
     "name": "spotify-current-song",
     "private": true,
-    "version": "0.2.0",
+    "version": "0.3.0",
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-spotify": "^0.2.0"
+            "nodecg-io-spotify": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-spotify": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-spotify": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/sql/package.json
+++ b/samples/sql/package.json
@@ -1,19 +1,19 @@
 {
     "name": "sql",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-sql": "^0.2.0"
+            "nodecg-io-sql": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-sql": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-sql": "^0.3.0",
         "typescript": "^4.4.4",
         "mysql": "^2.18.1"
     }

--- a/samples/streamdeck-rainbow/package.json
+++ b/samples/streamdeck-rainbow/package.json
@@ -1,19 +1,19 @@
 {
     "name": "streamdeck-rainbow",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-streamdeck": "^0.2.0"
+            "nodecg-io-streamdeck": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-streamdeck": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-streamdeck": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/streamelements-events/package.json
+++ b/samples/streamelements-events/package.json
@@ -1,19 +1,19 @@
 {
     "name": "streamelements-events",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-streamelements": "^0.2.0"
+            "nodecg-io-streamelements": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-streamelements": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-streamelements": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/telegram-bot/package.json
+++ b/samples/telegram-bot/package.json
@@ -1,19 +1,19 @@
 {
     "name": "telegram-bot",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-telegram": "^0.2.0"
+            "nodecg-io-telegram": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-telegram": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-telegram": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/template/package.json
+++ b/samples/template/package.json
@@ -1,19 +1,19 @@
 {
     "name": "template",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-template": "^0.2.0"
+            "nodecg-io-template": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-template": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-template": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/tiane-discord/package.json
+++ b/samples/tiane-discord/package.json
@@ -1,21 +1,21 @@
 {
     "name": "tiane-discord",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-discord": "^0.2.0",
-            "nodecg-io-tiane": "^0.2.0"
+            "nodecg-io-discord": "^0.3.0",
+            "nodecg-io-tiane": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-discord": "^0.2.0",
-        "nodecg-io-tiane": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-discord": "^0.3.0",
+        "nodecg-io-tiane": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/twitch-addons/package.json
+++ b/samples/twitch-addons/package.json
@@ -1,19 +1,19 @@
 {
     "name": "twitch-addons",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-twitch-addons": "^0.2.0"
+            "nodecg-io-twitch-addons": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-twitch-addons": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-twitch-addons": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/twitch-api/package.json
+++ b/samples/twitch-api/package.json
@@ -1,19 +1,19 @@
 {
     "name": "twitch-api",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-twitch-api": "^0.2.0"
+            "nodecg-io-twitch-api": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-twitch-api": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-twitch-api": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/twitch-chat/package.json
+++ b/samples/twitch-chat/package.json
@@ -1,19 +1,19 @@
 {
     "name": "twitch-chat",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-twitch-chat": "^0.2.0"
+            "nodecg-io-twitch-chat": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-twitch-chat": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-twitch-chat": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/twitch-pubsub/package.json
+++ b/samples/twitch-pubsub/package.json
@@ -1,19 +1,19 @@
 {
     "name": "twitch-pubsub",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-twitch-pubsub": "^0.2.0"
+            "nodecg-io-twitch-pubsub": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-twitch-pubsub": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-twitch-pubsub": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/twitter-timeline/package.json
+++ b/samples/twitter-timeline/package.json
@@ -1,19 +1,19 @@
 {
     "name": "twitter-timeline",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-twitter": "^0.2.0"
+            "nodecg-io-twitter": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-twitter": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-twitter": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/websocket-client/package.json
+++ b/samples/websocket-client/package.json
@@ -1,19 +1,19 @@
 {
     "name": "websocket-client",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-websocket-client": "^0.2.0"
+            "nodecg-io-websocket-client": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-websocket-client": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-websocket-client": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/websocket-server/package.json
+++ b/samples/websocket-server/package.json
@@ -1,19 +1,19 @@
 {
     "name": "websocket-server",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-websocket-server": "^0.2.0"
+            "nodecg-io-websocket-server": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-websocket-server": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-websocket-server": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/xdotool-windowminimize/package.json
+++ b/samples/xdotool-windowminimize/package.json
@@ -1,19 +1,19 @@
 {
     "name": "xdotool-windowminimize",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-xdotool": "^0.2.0"
+            "nodecg-io-xdotool": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-xdotool": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-xdotool": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/samples/youtube-playlist/package.json
+++ b/samples/youtube-playlist/package.json
@@ -1,19 +1,19 @@
 {
     "name": "youtube-playlist",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "private": true,
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-googleapis": "^0.2.0"
+            "nodecg-io-googleapis": "^0.3.0"
         }
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^16.11.7",
         "nodecg-types": "^1.8.3",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-googleapis": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-googleapis": "^0.3.0",
         "typescript": "^4.4.4"
     }
 }

--- a/services/nodecg-io-ahk/package.json
+++ b/services/nodecg-io-ahk/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-ahk",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to send commands to AutoHotkey.",
     "homepage": "https://nodecg.io/RELEASE/samples/ahk",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,6 +38,6 @@
     },
     "dependencies": {
         "node-fetch": "^2.6.5",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-android/package.json
+++ b/services/nodecg-io-android/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-android",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to an android device via adb.",
     "homepage": "https://nodecg.io/RELEASE/samples/android",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,6 +38,6 @@
     "dependencies": {
         "@rauschma/stringio": "^1.4.0",
         "get-stream": "^6.0.1",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-artnet/package.json
+++ b/services/nodecg-io-artnet/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-artnet",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to send DMX512 data over Art-Net™ to to Art-Net nodes i.e. professional lighting fixtures.",
     "homepage": "https://nodecg.io/RELEASE/samples/artnet",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "artnet-protocol": "^0.2.1"
     }
 }

--- a/services/nodecg-io-atem/package.json
+++ b/services/nodecg-io-atem/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-atem",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect via the Atem Protocol.",
     "homepage": "https://nodecg.io/RELEASE/samples/atem",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,6 +37,6 @@
     },
     "dependencies": {
         "atem-connection": "^2.3.1",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-curseforge/package.json
+++ b/services/nodecg-io-curseforge/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-curseforge",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "A service to communicate with the CurseForge API.",
     "homepage": "https://nodecg.io/RELEASE/samples/curseforge",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,6 +38,6 @@
     },
     "dependencies": {
         "node-fetch": "^2.6.5",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-dbus/package.json
+++ b/services/nodecg-io-dbus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-dbus",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to interface with DBus",
     "homepage": "https://nodecg.io/RELEASE/samples/dbus",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "dbus-next": "^0.10.2"
     }
 }

--- a/services/nodecg-io-debug/package.json
+++ b/services/nodecg-io-debug/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-debug",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Debug helper service that helps to easily trigger your code for debugging purposes.",
     "homepage": "https://nodecg.io/RELEASE/samples/debug",
     "author": {
@@ -31,7 +31,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         },
         "dashboardPanels": [
             {
@@ -55,7 +55,7 @@
         "monaco-editor": "^0.30.1"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "nodecg-types": "^1.8.3"
     }
 }

--- a/services/nodecg-io-discord-rpc/package.json
+++ b/services/nodecg-io-discord-rpc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-discord-rpc",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to interface with a locally running discord client via RPC",
     "homepage": "https://nodecg.io/RELEASE/samples/discord-rpc",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,7 +37,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "discord-rpc": "^4.0.1",
         "@types/discord-rpc": "^4.0.0",
         "node-fetch": "^2.6.5"

--- a/services/nodecg-io-discord/package.json
+++ b/services/nodecg-io-discord/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-discord",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to discord via a discord-bot.",
     "homepage": "https://nodecg.io/RELEASE/samples/discord",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,6 +37,6 @@
     },
     "dependencies": {
         "discord.js": "^13.3.1",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-elgato-light/package.json
+++ b/services/nodecg-io-elgato-light/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-elgato-light",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Control your Elgato lights, e.g. key lights and light stripes.",
     "homepage": "https://nodecg.io/RELEASE/samples/elgato-light",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,6 +38,6 @@
     "dependencies": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.5",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-github/package.json
+++ b/services/nodecg-io-github/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-github",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to the GitHub REST API",
     "homepage": "https://nodecg.io/RELEASE/samples/github",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "@octokit/rest": "^18.12.0"
     }
 }

--- a/services/nodecg-io-googleapis/package.json
+++ b/services/nodecg-io-googleapis/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-googleapis",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to and interact with many google-apis",
     "homepage": "https://nodecg.io/RELEASE/samples/youtube",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -39,7 +39,7 @@
         "@types/gapi": "^0.0.41",
         "express": "^4.17.1",
         "googleapis": "^89.0.0",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "open": "^8.4.0"
     }
 }

--- a/services/nodecg-io-intellij/package.json
+++ b/services/nodecg-io-intellij/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-intellij",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to control JetBrains IDEs via nodecg-io",
     "homepage": "https://nodecg.io/RELEASE/samples/intellij",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,6 +38,6 @@
     },
     "dependencies": {
         "node-fetch": "^2.6.5",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-irc/package.json
+++ b/services/nodecg-io-irc/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-irc",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allow to connect to IRC Servers.",
     "homepage": "https://nodecg.io/RELEASE",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,6 +38,6 @@
     "dependencies": {
         "@types/irc": "^0.5.1",
         "irc": "^0.5.2",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-midi-input/package.json
+++ b/services/nodecg-io-midi-input/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-midi-input",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Connect to MIDI devices and control the volume of your voice or music with a fader.",
     "homepage": "https://nodecg.io/RELEASE/samples/midi-input",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,6 +37,6 @@
     },
     "dependencies": {
         "easymidi": "^2.1.0",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-midi-output/package.json
+++ b/services/nodecg-io-midi-output/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-midi-output",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Connect to MIDI devices and control the volume of your voice or music with a fader.",
     "homepage": "https://nodecg.io/RELEASE/samples/midi-output",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,6 +37,6 @@
     },
     "dependencies": {
         "easymidi": "^2.1.0",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-mqtt-client/package.json
+++ b/services/nodecg-io-mqtt-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-mqtt-client",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to connect with an MQTT server.",
     "homepage": "https://nodecg.io/RELEASE/samples/mqtt-client",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "mqtt": "^4.2.8"
     }
 }

--- a/services/nodecg-io-nanoleaf/package.json
+++ b/services/nodecg-io-nanoleaf/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-nanoleaf",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to a nanoleaf controller and trigger custom lighting effects.",
     "homepage": "https://nodecg.io/RELEASE/samples/nanoleaf",
     "author": {
@@ -25,7 +25,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
     "dependencies": {
         "@types/node-fetch": "^2.5.10",
         "node-fetch": "^2.6.5",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "nodecg-types": "^1.8.3"
     }
 }

--- a/services/nodecg-io-obs/package.json
+++ b/services/nodecg-io-obs/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-obs",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to control your obs instance to e.g. switch scenes.",
     "homepage": "https://nodecg.io/RELEASE",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "obs-websocket-js": "^4.0.3"
     }
 }

--- a/services/nodecg-io-philipshue/package.json
+++ b/services/nodecg-io-philipshue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-philipshue",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to connect with your Philips Hue bridge. This allows you to control your lights etc.",
     "homepage": "https://nodecg.io/RELEASE",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,6 +38,6 @@
     "dependencies": {
         "is-ip": "^3.1.0",
         "node-hue-api": "^4.0.10",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-rcon/package.json
+++ b/services/nodecg-io-rcon/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-rcon",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to send commands to a minecraft server via RCON.",
     "homepage": "https://nodecg.io/RELEASE/samples/rcon",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "rcon-client": "^4.2.3"
     }
 }

--- a/services/nodecg-io-reddit/package.json
+++ b/services/nodecg-io-reddit/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-reddit",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Provides an interface to the Reddit-API.",
     "homepage": "https://nodecg.io/RELEASE/samples/reddit",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "reddit-ts": "noeppi-noeppi/npm-reddit-ts#build"
     }
 }

--- a/services/nodecg-io-sacn-receiver/package.json
+++ b/services/nodecg-io-sacn-receiver/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-sacn-receiver",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to receive data via sACN from e.g professional lighting consoles.",
     "homepage": "https://nodecg.io/RELEASE/samples/sacn-receiver",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "sacn": "^4.1.0"
     }
 }

--- a/services/nodecg-io-sacn-sender/package.json
+++ b/services/nodecg-io-sacn-sender/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-sacn-sender",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to send data via sACN to e.g professional lights.",
     "homepage": "https://nodecg.io/RELEASE/samples/sacn-sender",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "sacn": "^4.1.0"
     }
 }

--- a/services/nodecg-io-serial/package.json
+++ b/services/nodecg-io-serial/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-serial",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Exposes serial deivces to nodecg-io",
     "homepage": "https://nodecg.io/RELEASE/samples/serial",
     "author": {
@@ -29,7 +29,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -41,7 +41,7 @@
     "dependencies": {
         "@serialport/parser-readline": "^9.2.4",
         "@types/serialport": "^8.0.2",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "serialport": "^9.2.5"
     }
 }

--- a/services/nodecg-io-shlink/package.json
+++ b/services/nodecg-io-shlink/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-shlink",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to create Shlink short links",
     "homepage": "https://nodecg.io/RELEASE/samples/shlink",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,7 +36,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "shlink-client": "^1.0.1"
     }
 }

--- a/services/nodecg-io-slack/package.json
+++ b/services/nodecg-io-slack/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-slack",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to your slack. This enables you to e.g. send messages and list all channel. Visit https://api.slack.com/methods to see all methods ",
     "homepage": "https://nodecg.io/RELEASE/samples/slack",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,6 +37,6 @@
     },
     "dependencies": {
         "@slack/web-api": "^6.5.0",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-spotify/package.json
+++ b/services/nodecg-io-spotify/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-spotify",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to your personal Spotify account. This enables you to e.g. control music playback or get current song information. ",
     "homepage": "https://nodecg.io/RELEASE",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,7 +38,7 @@
     "dependencies": {
         "@types/spotify-web-api-node": "^5.0.3",
         "express": "^4.17.1",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "open": "^8.4.0",
         "spotify-web-api-node": "^5.0.2"
     }

--- a/services/nodecg-io-sql/package.json
+++ b/services/nodecg-io-sql/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-sql",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "SQL service based on knex.js. Different clients like mysql are supported but have to be installed separately.",
     "homepage": "https://nodecg.io/RELEASE/samples/sql",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,6 +37,6 @@
     },
     "dependencies": {
         "knex": "^0.95.13",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-streamdeck/package.json
+++ b/services/nodecg-io-streamdeck/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-streamdeck",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to interface with the elgato streamdeck.",
     "homepage": "https://nodecg.io/RELEASE/samples/streamdeck",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,6 +37,6 @@
     },
     "dependencies": {
         "@elgato-stream-deck/node": "^5.1.1",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-streamelements/package.json
+++ b/services/nodecg-io-streamelements/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-streamelements",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to streamelements to e.g. react to donations.",
     "homepage": "https://nodecg.io/RELEASE",
     "author": {
@@ -31,7 +31,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -42,7 +42,7 @@
     },
     "dependencies": {
         "@types/socket.io-client": "^1.4.36",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "socket.io-client": "^2.4.0"
     }
 }

--- a/services/nodecg-io-telegram/package.json
+++ b/services/nodecg-io-telegram/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-telegram",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to control a telegram bot.",
     "homepage": "https://nodecg.io/RELEASE/samples/telegram",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,6 +38,6 @@
     "dependencies": {
         "@types/node-telegram-bot-api": "^0.53.1",
         "node-telegram-bot-api": "^0.54.0",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-template/package.json
+++ b/services/nodecg-io-template/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-template",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Template package.",
     "homepage": "https://nodecg.io/RELEASE/samples/template",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,6 +36,6 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-tiane/package.json
+++ b/services/nodecg-io-tiane/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-tiane",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Connect to TIANE and make her for example a discord bot. https://github.com/FerdiKr/TIANE",
     "homepage": "https://nodecg.io/RELEASE/samples/tiane",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,7 +37,7 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "ws": "^8.2.3"
     }
 }

--- a/services/nodecg-io-twitch-addons/package.json
+++ b/services/nodecg-io-twitch-addons/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-twitch-addons",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Support for the API's of BetterTTV and FrankerFaceZ",
     "homepage": "https://nodecg.io/RELEASE/samples/twitch-addons",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -38,7 +38,7 @@
     },
     "dependencies": {
         "node-fetch": "^2.6.5",
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-twitch-auth": "^0.2.0"
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-twitch-auth": "^0.3.0"
     }
 }

--- a/services/nodecg-io-twitch-api/package.json
+++ b/services/nodecg-io-twitch-api/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-twitch-api",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows talking to twitch APIs like helix.",
     "homepage": "https://nodecg.io/RELEASE/samples/twitch-api",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,8 +36,8 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-twitch-auth": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-twitch-auth": "^0.3.0",
         "@twurple/api": "^5.0.9"
     }
 }

--- a/services/nodecg-io-twitch-chat/package.json
+++ b/services/nodecg-io-twitch-chat/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-twitch-chat",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to the twitch chat with your account, send and receive messages and much more. It can be used to create Twitch-Bots.",
     "homepage": "https://nodecg.io/RELEASE/samples/twitch-chat",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,8 +36,8 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-twitch-auth": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-twitch-auth": "^0.3.0",
         "@twurple/chat": "^5.0.8"
     }
 }

--- a/services/nodecg-io-twitch-pubsub/package.json
+++ b/services/nodecg-io-twitch-pubsub/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-twitch-pubsub",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows access to the Twitch PubSub API.",
     "homepage": "https://nodecg.io/RELEASE/samples/twitch-pubsub",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -36,8 +36,8 @@
         "typescript": "^4.4.4"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.2.0",
-        "nodecg-io-twitch-auth": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
+        "nodecg-io-twitch-auth": "^0.3.0",
         "@twurple/api": "^5.0.9",
         "@twurple/pubsub": "^5.0.9"
     }

--- a/services/nodecg-io-twitter/package.json
+++ b/services/nodecg-io-twitter/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-twitter",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to twitter, send, retweet or like messages.",
     "homepage": "https://nodecg.io/RELEASE/samples/twitter",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@types/twitter": "^1.7.1",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "twitter": "^1.7.1"
     }
 }

--- a/services/nodecg-io-websocket-client/package.json
+++ b/services/nodecg-io-websocket-client/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-websocket-client",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to connect to a external WebSocket server.",
     "homepage": "https://nodecg.io/RELEASE/samples/websocket-client/",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@types/ws": "^8.2.0",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "ws": "^8.2.3"
     }
 }

--- a/services/nodecg-io-websocket-server/package.json
+++ b/services/nodecg-io-websocket-server/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-websocket-server",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows to create a custom WebSocket server.",
     "homepage": "https://nodecg.io/RELEASE/samples/websocket-server/",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -37,7 +37,7 @@
     },
     "dependencies": {
         "@types/ws": "^8.2.0",
-        "nodecg-io-core": "^0.2.0",
+        "nodecg-io-core": "^0.3.0",
         "ws": "^8.2.3"
     }
 }

--- a/services/nodecg-io-xdotool/package.json
+++ b/services/nodecg-io-xdotool/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-xdotool",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Allows you to send commands to xdotool.",
     "homepage": "https://nodecg.io/RELEASE/samples/xdotool",
     "author": {
@@ -26,7 +26,7 @@
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
-            "nodecg-io-core": "^0.2.0"
+            "nodecg-io-core": "^0.3.0"
         }
     },
     "license": "MIT",
@@ -39,6 +39,6 @@
     "dependencies": {
         "@rauschma/stringio": "^1.4.0",
         "node-fetch": "^2.6.5",
-        "nodecg-io-core": "^0.2.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/package.json
+++ b/services/package.json
@@ -1,6 +1,6 @@
 {
     "name": "services",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "",
     "private": true,
     "nodecg": {

--- a/utils/nodecg-io-twitch-auth/package.json
+++ b/utils/nodecg-io-twitch-auth/package.json
@@ -1,6 +1,6 @@
 {
     "name": "nodecg-io-twitch-auth",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "Utility package that handles authentication for all nodecg-io twitch services.",
     "author": {
         "name": "CodeOverflow team",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,6 +1,6 @@
 {
     "name": "utils",
-    "version": "0.2.0",
+    "version": "0.3.0",
     "description": "",
     "private": true,
     "nodecg": {


### PR DESCRIPTION
`main` is the current development version which will be `0.3.0` so this PR updates all version numbers after the `0.2.0` release