### PR TITLE
Add StreamElementsTestEventData interface for correct "onTest" types.

### DIFF
--- a/services/nodecg-io-streamelements/extension/StreamElementsEvent.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElementsEvent.ts
@@ -37,7 +37,7 @@ export interface StreamElementsEvent {
     /**
      * Event property for test events
      */
-    event?: StreamElementsEventData;
+    event?: StreamElementsTestEventData;
     [k: string]: unknown;
 }
 
@@ -50,6 +50,63 @@ export interface StreamElementsEventData {
      * Twitch username
      */
     username: string;
+    /**
+     * Twitch channel ID
+     */
+    providerId?: string;
+    /**
+     * Twitch username case sensitive plus regional characters if provided
+     */
+    displayName: string;
+    /**
+     * Amount of currency in tip, months in subs, hosting/raiding viewers, bits in cheer
+     */
+    amount: number;
+    /**
+     * Current months streak (subs only)
+     */
+    streak?: number;
+    /**
+     * Subscriber tier (subs only)
+     */
+    tier?: "1000" | "2000" | "3000" | "prime";
+    /**
+     * true if the sub was a gift (subs only)
+     */
+    gifted: boolean;
+    /**
+     * The sender of a gifted sub (subs only)
+     */
+    sender?: string;
+    /**
+     * Currency symbol (tips)
+     */
+    currency?: string;
+    /**
+     * User provided message
+     */
+    message: string;
+    quantity?: number;
+    /**
+     * Redeemed items
+     */
+    items: unknown[];
+    /**
+     * URI of user avatar
+     */
+    avatar: string;
+    [k: string]: unknown;
+}
+
+export interface StreamElementsTestEventData {
+    /**
+     * StreamElements hexadecimal tip ID
+     */
+    tipId?: string;
+    /**
+     * Twitch username
+     */
+    name: string;
     /**
      * Twitch channel ID
      */


### PR DESCRIPTION
StreamElements sends out `name` instead of `username` in the onTest Event.
This adds the correct type for that specific event.