### PR TITLE
Publish tarballs and compilation results on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,9 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         name: Publish compilation results
-        # Don't run this in forks. This pushes to our separate repository that external contributors don't have access to
-        if: startsWith(github.repository, 'codeoverflow-org') && github.actor != 'dependabot[bot]'
+        # Don't run this in forks. This pushes to our separate repository that external contributors don't have access to.
+        # We also only want to publish if we have pushed a branch, not on a pull request. Otherwise we would publish everything twice.
+        if: startsWith(github.repository, 'codeoverflow-org') && github.actor != 'dependabot[bot]' && github.event_name != 'pull_request'
         # Only publish anything if we're sure this version compiles (obviously) and all tests pass.
         needs:
         - build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,17 @@ jobs:
             - name: Build TS
               run: npm run build
 
+            - name: Create tar with compilation results
+              run: |
+                  shopt -s globstar
+                  tar cvzf compilation-results.tar.gz --exclude "node_modules" **/*.js **/*.js.map **/*.d.ts **/*.d.ts.map **/*.tsbuildinfo **/*.ttf
+
+            - name: Upload compilation results
+              uses: actions/upload-artifact@v2
+              with:
+                name: compilation-results
+                path: compilation-results.tar.gz
+
     tests:
         runs-on: ubuntu-latest
         steps:
@@ -35,3 +46,70 @@ jobs:
 
             - name: Run tests
               run: npm run coverage -- --verbose
+
+    publish:
+        runs-on: ubuntu-latest
+        name: Publish compilation results
+        # Don't run this in forks. This pushes to our separate repository that external contributors don't have access to
+        if: startsWith(github.repository, 'codeoverflow-org') && github.actor != 'dependabot[bot]'
+        # Only publish anything if we're sure this version compiles (obviously) and all tests pass.
+        needs:
+        - build
+        - tests
+        steps:
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2
+              with:
+                node-version: "16"
+
+            - name: Download compilation results # From the build step
+              uses: actions/download-artifact@v2
+              with:
+                name: compilation-results
+
+            - name: Extract compilation results
+              run: tar xvf compilation-results.tar.gz
+
+            - name: Create npm tarballs
+              run: npm pack --workspaces
+
+            - name: Clone publish repository
+              uses: actions/checkout@v2
+              with:
+                  repository: codeoverflow-org/nodecg-io-publish
+                  ssh-key: ${{ secrets.PUBLISH_SSH_KEY }}
+                  path: publish
+
+            - name: Checkout branch in publish repository
+              working-directory: publish
+              # Create a local branch with the same name as in the nodecg-io repository
+              # If the branch already exists on the remote we set the upstream to it,
+              # if not we push the branch and set the upstream to it as well.
+              run: |
+                  git fetch
+                  git switch -c ${GITHUB_REF##refs/heads/}
+                  (git branch -u origin/${GITHUB_REF##refs/heads/} && git pull) || git push -u origin ${GITHUB_REF##refs/heads/}
+
+            - name: Clear publish directory
+              run: rm -rf publish/*
+
+            - name: Copy tarballs into publish directory
+              run: cp *.tgz publish
+
+            - name: Extract tarballs
+              working-directory: publish
+              run: |
+                  for tarPath in $(ls *.tgz); do
+                      tar xf $tarPath package;
+                      dirname=$(echo "$tarPath" | sed "s/-[0-9]\+\.[0-9]\+\.[0-9]\+\.tgz//"); # Strip away tgz extension and version
+                      mv package $dirname;
+                  done;
+
+            - name: Publish
+              uses: stefanzweifel/git-auto-commit-action@v4
+              with:
+                  commit_message: Publish codeoverflow-org/nodecg-io@${{ github.sha }}
+                  commit_user_name: codeoverflow-org
+                  commit_user_email: ""
+                  commit_author: codeoverflow-org <>
+                  repository: publish


### PR DESCRIPTION
Closes #235.

I've decided to do both: publishing tarballs and the compilation results.
Extracting the tar files in the action step isn't that much work and we still can change it in the future.

Also uploads the compilation results as a Actions artifact so that the publish job doesn't need to recompile the whole project again.

Published version of this branch: https://github.com/codeoverflow-org/nodecg-io-publish/tree/feat/235-dev-publish