### PR TITLE
Actually move monaco-editor to `devDependency` in dashboard

### DIFF
--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -24,11 +24,11 @@
         "style-loader": "^3.3.1",
         "css-loader": "^6.5.1",
         "monaco-editor-webpack-plugin": "^6.0.0",
-        "nodecg-types": "^1.8.3"
+        "monaco-editor": "^0.30.1"
     },
     "dependencies": {
         "crypto-js": "^4.1.1",
-        "monaco-editor": "^0.30.1",
+        "nodecg-types": "^1.8.3",
         "nodecg-io-core": "^0.3.0"
     },
     "license": "MIT"


### PR DESCRIPTION
Such a dumb error in #317....