### PR TITLE
Automatically update docs and tarballs using a cronjob

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,7 @@ jobs:
               # if not we push the branch and set the upstream to it as well.
               run: |
                   git fetch
-                  git switch ${GITHUB_REF##refs/heads/} || git checkout -b ${GITHUB_REF##refs/heads/}
+                  git switch ${GITHUB_REF##refs/heads/} || (git checkout -b ${GITHUB_REF##refs/heads/} && git push -u origin ${GITHUB_REF##refs/heads/})
 
             - name: Clear publish directory
               run: rm -rf publish/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+    push:
+    pull_request:
+    schedule:
+        # https://crontab.guru/#3_21_*_*_6
+        - cron: "3 21 * * 6"
+
 jobs:
     build:
         runs-on: ubuntu-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
         branches:
             - main
             - "release/**"
+    schedule:
+        # https://crontab.guru/#3_21_*_*_6
+        - cron: "3 21 * * 6"
 
 jobs:
     build:


### PR DESCRIPTION
Because events triggered by dependabot don't have access to encrypted secrets we don't update the documentation and tarballs for commits by dependabot.
However this means that the documentation and tarballs can be pretty outdated till the next manual commit.
Becuase we have all dependabot PRs at Saturday this PR adds a cronjob on Saturday evening to update the docs/tarballs after all PRs by dependabot have been merged.
Discussion on Discord about this: https://discord.com/channels/577412066994946060/581828193196179457/920977923991814195