### PR TITLE
Downgrade monaco-editor from 0.31.1 to 0.30.1

### DIFF
--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -24,7 +24,7 @@
         "style-loader": "^3.3.1",
         "css-loader": "^6.5.1",
         "monaco-editor-webpack-plugin": "^7.0.1",
-        "monaco-editor": "^0.31.1"
+        "monaco-editor": "^0.30.1"
     },
     "dependencies": {
         "crypto-js": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9244,7 +9244,8 @@
             "version": "0.31.1",
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
             "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "node_modules/monaco-editor-webpack-plugin": {
             "version": "7.0.1",
@@ -14030,7 +14031,7 @@
             "devDependencies": {
                 "clean-webpack-plugin": "^4.0.0",
                 "css-loader": "^6.5.1",
-                "monaco-editor": "^0.31.1",
+                "monaco-editor": "^0.30.1",
                 "monaco-editor-webpack-plugin": "^7.0.1",
                 "style-loader": "^3.3.1",
                 "typescript": "^4.5.4",
@@ -14063,6 +14064,12 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+        },
+        "nodecg-io-core/node_modules/monaco-editor": {
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
+            "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg==",
+            "dev": true
         },
         "samples/ahk-sendcommand": {
             "version": "0.3.0",
@@ -14898,7 +14905,7 @@
             "devDependencies": {
                 "@types/node": "^17.0.0",
                 "css-loader": "^6.5.1",
-                "monaco-editor": "^0.31.1",
+                "monaco-editor": "^0.30.1",
                 "monaco-editor-webpack-plugin": "^7.0.1",
                 "style-loader": "^3.3.1",
                 "typescript": "^4.5.4",
@@ -14910,6 +14917,12 @@
             "version": "17.0.0",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
             "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
+            "dev": true
+        },
+        "services/nodecg-io-debug/node_modules/monaco-editor": {
+            "version": "0.30.1",
+            "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
+            "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg==",
             "dev": true
         },
         "services/nodecg-io-discord": {
@@ -15221,7 +15234,7 @@
             "license": "MIT",
             "dependencies": {
                 "nodecg-io-core": "^0.3.0",
-                "reddit-ts": "git+ssh://git@github.com/noeppi-noeppi/npm-reddit-ts.git#a776adfa960a73e5d6897b8bfe54ee3b6249b7bf"
+                "reddit-ts": "noeppi-noeppi/npm-reddit-ts#build"
             },
             "devDependencies": {
                 "@types/node": "^17.0.0",
@@ -23050,7 +23063,8 @@
             "version": "0.31.1",
             "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.31.1.tgz",
             "integrity": "sha512-FYPwxGZAeP6mRRyrr5XTGHD9gRXVjy7GUzF4IPChnyt3fS5WrNxIkS8DNujWf6EQy0Zlzpxw8oTVE+mWI2/D1Q==",
-            "dev": true
+            "dev": true,
+            "peer": true
         },
         "monaco-editor-webpack-plugin": {
             "version": "7.0.1",
@@ -23769,6 +23783,12 @@
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
                     "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
+                },
+                "monaco-editor": {
+                    "version": "0.30.1",
+                    "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
+                    "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg==",
+                    "dev": true
                 }
             }
         },
@@ -23797,7 +23817,7 @@
                 "clean-webpack-plugin": "^4.0.0",
                 "crypto-js": "^4.1.1",
                 "css-loader": "^6.5.1",
-                "monaco-editor": "^0.31.1",
+                "monaco-editor": "^0.30.1",
                 "monaco-editor-webpack-plugin": "^7.0.1",
                 "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
@@ -23830,7 +23850,7 @@
             "requires": {
                 "@types/node": "^17.0.0",
                 "css-loader": "^6.5.1",
-                "monaco-editor": "^0.31.1",
+                "monaco-editor": "^0.30.1",
                 "monaco-editor-webpack-plugin": "^7.0.1",
                 "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
@@ -23844,6 +23864,12 @@
                     "version": "17.0.0",
                     "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.0.tgz",
                     "integrity": "sha512-eMhwJXc931Ihh4tkU+Y7GiLzT/y/DBNpNtr4yU9O2w3SYBsr9NaOPhQlLKRmoWtI54uNwuo0IOUFQjVOTZYRvw==",
+                    "dev": true
+                },
+                "monaco-editor": {
+                    "version": "0.30.1",
+                    "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.30.1.tgz",
+                    "integrity": "sha512-B/y4+b2O5G2gjuxIFtCE2EkM17R2NM7/3F8x0qcPsqy4V83bitJTIO4TIeZpYlzu/xy6INiY/+84BEm6+7Cmzg==",
                     "dev": true
                 }
             }
@@ -24137,7 +24163,7 @@
                 "@types/node": "^17.0.0",
                 "nodecg-io-core": "^0.3.0",
                 "nodecg-types": "^1.8.3",
-                "reddit-ts": "git+ssh://git@github.com/noeppi-noeppi/npm-reddit-ts.git#a776adfa960a73e5d6897b8bfe54ee3b6249b7bf",
+                "reddit-ts": "noeppi-noeppi/npm-reddit-ts#build",
                 "typescript": "^4.5.4"
             },
             "dependencies": {

--- a/services/nodecg-io-debug/package.json
+++ b/services/nodecg-io-debug/package.json
@@ -52,7 +52,7 @@
         "style-loader": "^3.3.1",
         "css-loader": "^6.5.1",
         "monaco-editor-webpack-plugin": "^7.0.1",
-        "monaco-editor": "^0.31.1"
+        "monaco-editor": "^0.30.1"
     },
     "dependencies": {
         "nodecg-io-core": "^0.3.0",


### PR DESCRIPTION
Reverts d1da66337a6c0c141d174bd5aaa8a4be4baf545a / #377

There is some change with `0.30.0` that results in a build output by webpack that
is incompatible with the Chromium version that is used by custom OBS Docks.

I don't know what the exact problem is yet with this specific update,
this PR is just here to fix this bug till I figure out if we can make
the new version compatible with OBS Docks or not.
