### PR TITLE
Just log a warning when trying automatic login, but nodecg-io is already loaded

### DIFF
--- a/nodecg-io-core/extension/persistenceManager.ts
+++ b/nodecg-io-core/extension/persistenceManager.ts
@@ -300,7 +300,17 @@ export class PersistenceManager {
                         throw loadResult.errorMessage;
                     }
                 } catch (err) {
-                    this.nodecg.log.error(`Failed to automatically login: ${err}`);
+                    const logMesssage = `Failed to automatically login: ${err}`;
+                    if (this.isLoaded()) {
+                        // load() threw an error but nodecg-io is currently loaded nonetheless.
+                        // Propably because the a already open dashboard automatically logged in after reconnecting.
+                        // Anyway, nodecg-io is loaded which is what we wanted
+                        this.nodecg.log.warn(logMesssage);
+                    } else {
+                        // Something went wrong and nodecg-io is not loaded.
+                        // This is a real error, the password might be wrong or some other issue.
+                        this.nodecg.log.error(logMesssage);
+                    }
                 }
             }
         });


### PR DESCRIPTION
Fixes #365.

If automatic login fails and nodecg-io is not loaded afterwards this will still display a error. This happens when e.g. the password set in the automatic login config is wrong.
However if automatic login fails and nodecg-io is loaded afterwards just a warning will be logged with this PR. This is the case when the dashboard reconnects after a restart and loggs back in.