### PR TITLE
chore:Format configs & scripts

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,13 +1,11 @@
+/** @type {import("eslint").ESLint.Options} */
 module.exports = {
     parser: "@typescript-eslint/parser",
     parserOptions: {
         ecmaVersion: 2017,
         sourceType: "module",
     },
-    extends: [
-        "eslint:recommended",
-        "plugin:@typescript-eslint/recommended",
-    ],
+    extends: ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
     // Don't traverse fs up to root.
     // This caused problems when nodecg-io was cloned into a NodeCG installation as it then
     // tried to lint nodecg-io with that config.
@@ -15,7 +13,7 @@ module.exports = {
     rules: {
         // Allow for unused function arguments when they are prefixed with an underscore.
         // This is the TypeScript convention to mark unused arguments.
-        "@typescript-eslint/no-unused-vars": ["warn", {argsIgnorePattern: "^_"}],
+        "@typescript-eslint/no-unused-vars": ["warn", { argsIgnorePattern: "^_" }],
 
         // We simply have empty functions at some places, so we ignore this rule.
         "@typescript-eslint/no-empty-function": ["warn", { allow: ["arrowFunctions"] }],
@@ -24,6 +22,6 @@ module.exports = {
         "no-console": ["warn"],
 
         // Enforce triple equals for comparisons
-        "eqeqeq": ["warn"]
+        "eqeqeq": ["warn"],
     },
 };

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,9 +1,16 @@
+/** @type {import("prettier").RequiredOptions} */
 module.exports = {
-    semi: true,
-    trailingComma: "all",
-    singleQuote: false,
     printWidth: 120,
     tabWidth: 4,
     useTabs: false,
-    endOfLine: "auto"
+    semi: true,
+    singleQuote: false,
+    quoteProps: "consistent",
+    jsxSingleQuote: false,
+    trailingComma: "all",
+    bracketSpacing: true,
+    arrowParens: "always",
+    proseWrap: "preserve",
+    vueIndentScriptAndStyle: false,
+    endOfLine: "lf",
 };

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,5 +13,6 @@
         "**/*.tsbuildinfo": true
     },
     "typescript.tsc.autoDetect": "off",
-    "npm.autoDetect": "off"
+    "npm.autoDetect": "off",
+    "js/ts.implicitProjectConfig.checkJs": true
 }

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,4 +1,0 @@
-/** @type import("@jest/types/build/Config").DefaultOptions */
-module.exports = {
-    projects: ["<rootDir>/nodecg-io-*"],
-};

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,4 @@
+/** @type import("@jest/types/build/Config").DefaultOptions */
 module.exports = {
-    projects: ["<rootDir>/nodecg-io-*"]
-}
+    projects: ["<rootDir>/nodecg-io-*"],
+};

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -1,0 +1,33 @@
+import path from "path";
+import { readdirSync } from "fs";
+import { cwd } from "process";
+import { getPackages } from "@manypkg/get-packages";
+
+let projects = [];
+// @ts-ignore
+const { root, packages } = await getPackages(cwd());
+
+/** @param pkg {import("@manypkg/get-packages").Package} */
+function hasJestConfig(pkg) {
+    return (
+        readdirSync(pkg.dir).some(
+            (file) =>
+                file === "jest.config.js" ||
+                file === "jest.config.ts" ||
+                file === "jest.config.cjs" ||
+                file === "jest.config.mjs" ||
+                file === "jest.config.json",
+        ) || pkg.packageJson["jest"]
+    );
+}
+
+projects = packages.filter((pkg) => hasJestConfig(pkg)).map((v) => `<rootDir>/${path.relative(root.dir, v.dir)}`);
+
+console.log(projects);
+
+/** @type {import('@jest/types').Config.InitialOptions} */
+const config = {
+    projects,
+};
+
+export default config;

--- a/nodecg-io-core/dashboard/esbuild.config.js
+++ b/nodecg-io-core/dashboard/esbuild.config.js
@@ -8,7 +8,7 @@ const path = require("path");
 const process = require("process");
 const fs = require("fs");
 
-const args = process.argv.slice(2);
+const args = new Set(process.argv.slice(2));
 const prod = process.env.NODE_ENV === "production";
 
 const entryPoints = [
@@ -17,19 +17,20 @@ const entryPoints = [
     "main.ts",
 ];
 
-if (args.includes("--clean") || args.includes("--rebuild")) {
-    // remove dist folder
+if (args.has("--clean") || args.has("--rebuild")) {
+    // Remove dist folder
     try {
         fs.rmSync(path.join(__dirname, "dist"), { recursive: true, force: true });
-    } catch (err) {
-        console.log(err);
+    } catch (error) {
+        console.log(error);
     }
-    if (!args.includes("--rebuild")) {
+
+    if (!args.has("--rebuild")) {
         process.exit(0);
     }
 }
 
-/**@type {import('esbuild').BuildOptions}*/
+/** @type {import('esbuild').BuildOptions} */
 const BuildOptions = {
     /**
      * By default, esbuild will not bundle the input files. Bundling must be
@@ -45,7 +46,7 @@ const BuildOptions = {
      * This is an array of files that each serve as an input to the bundling
      * algorithm.
      */
-    entryPoints: entryPoints,
+    entryPoints,
     /**
      * This sets the output format for the generated JavaScript files. We are
      * using the `iife`, which format stands for "immediately-invoked function
@@ -88,7 +89,7 @@ const BuildOptions = {
      * on the file system and to rebuild whenever a file changes that could
      * invalidate the build.
      */
-    watch: args.includes("--watch")
+    watch: args.has("--watch"),
 };
 
 esbuild
@@ -98,6 +99,7 @@ esbuild
         if (result.errors.length > 0) {
             console.error(result.errors);
         }
+
         if (result.warnings.length > 0) {
             console.error(result.warnings);
         }

--- a/nodecg-io-core/jest.config.js
+++ b/nodecg-io-core/jest.config.js
@@ -1,8 +1,9 @@
+/** @type import("@jest/types/build/Config").DefaultOptions */
 module.exports = {
-  preset: "ts-jest",
-  testEnvironment: "node",
-  testMatch: ["<rootDir>/extension/__tests__/**/*.ts", "!**/extension/__tests__/mocks.ts"],
-  // Exclude mocks.ts from coverage. It doesn't matter because it is mock code not used
-  // but required to make TypeScript compile it.
-  coveragePathIgnorePatterns: ["<rootDir>/extension/__tests__/"]
+    preset: "ts-jest",
+    testEnvironment: "node",
+    testMatch: ["<rootDir>/extension/__tests__/**/*.ts", "!**/extension/__tests__/mocks.ts"],
+    // Exclude mocks.ts from coverage. It doesn't matter because it is mock code not used
+    // but required to make TypeScript compile it.
+    coveragePathIgnorePatterns: ["<rootDir>/extension/__tests__/"],
 };

--- a/nodecg-io-core/jest.config.mjs
+++ b/nodecg-io-core/jest.config.mjs
@@ -1,5 +1,5 @@
-/** @type import("@jest/types/build/Config").DefaultOptions */
-module.exports = {
+/** @type {import('@jest/types').Config.InitialOptions} */
+const config = {
     preset: "ts-jest",
     testEnvironment: "node",
     testMatch: ["<rootDir>/extension/__tests__/**/*.ts", "!**/extension/__tests__/mocks.ts"],
@@ -7,3 +7,5 @@ module.exports = {
     // but required to make TypeScript compile it.
     coveragePathIgnorePatterns: ["<rootDir>/extension/__tests__/"],
 };
+
+export default config;

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
         "watch": "node .scripts/exec.mjs watch",
         "watch:root": "tsc -b -w --pretty --preserveWatchOutput",
         "lint": "eslint . --ext ts --ignore-pattern '**/*.d.ts'",
-        "format": "prettier --write \"./**/*.{ts,html,css,json}\"",
-        "format-pre-commit": "pretty-quick --staged --pattern '*/**/*.{ts,html,css,json}'",
+        "format": "prettier --write \"./**/*.{ts,html,css,json,mjs}\"",
+        "format-pre-commit": "pretty-quick --staged --pattern '*/**/*.{ts,html,css,json,mjs}'",
         "prepare": "husky install"
     },
     "devDependencies": {

--- a/services/nodecg-io-curseforge/extension/curseforgeClient.ts
+++ b/services/nodecg-io-curseforge/extension/curseforgeClient.ts
@@ -168,7 +168,7 @@ export class CurseForge {
         const response = await fetch(`https://addons-ecs.forgesvc.net/api/v2/${endpoint}`, {
             method: method,
             headers: {
-                Accept: "application/json",
+                "Accept": "application/json",
                 "Content-Type": "application/json",
             },
             body: data === undefined ? undefined : JSON.stringify(data),

--- a/services/nodecg-io-dbus/extension/ratbag.ts
+++ b/services/nodecg-io-dbus/extension/ratbag.ts
@@ -332,8 +332,8 @@ export class RatBagResolution extends DBusObject {
  */
 export class RatBagButton extends DBusObject {
     private static readonly SPECIAL_ACTION_MAP: Record<RatBagSpecialAction, number> = {
-        unknown: 0x40000000,
-        doubleclick: 0x40000001,
+        "unknown": 0x40000000,
+        "doubleclick": 0x40000001,
         "wheel left": 0x40000002,
         "wheel right": 0x40000003,
         "wheel up": 0x40000004,

--- a/services/nodecg-io-debug/esbuild.config.js
+++ b/services/nodecg-io-debug/esbuild.config.js
@@ -8,7 +8,7 @@ const path = require("path");
 const process = require("process");
 const fs = require("fs");
 
-const args = process.argv.slice(2);
+const args = new Set(process.argv.slice(2));
 const prod = process.env.NODE_ENV === "production";
 
 const entryPoints = [
@@ -17,19 +17,20 @@ const entryPoints = [
     "dashboard/debug-helper.ts",
 ];
 
-if (args.includes("--clean") || args.includes("--rebuild")) {
-    // remove dist folder
+if (args.has("--clean") || args.has("--rebuild")) {
+    // Remove dist folder
     try {
         fs.rmSync(path.join(__dirname, "dist"), { recursive: true, force: true });
-    } catch (err) {
-        console.log(err);
+    } catch (error) {
+        console.log(error);
     }
-    if (!args.includes("--rebuild")) {
+
+    if (!args.has("--rebuild")) {
         process.exit(0);
     }
 }
 
-/**@type {import('esbuild').BuildOptions}*/
+/** @type {import('esbuild').BuildOptions} */
 const BuildOptions = {
     /**
      * By default, esbuild will not bundle the input files. Bundling must be
@@ -45,7 +46,7 @@ const BuildOptions = {
      * This is an array of files that each serve as an input to the bundling
      * algorithm.
      */
-    entryPoints: entryPoints,
+    entryPoints,
     /**
      * This sets the output format for the generated JavaScript files. We are
      * using the `iife`, which format stands for "immediately-invoked function
@@ -88,7 +89,7 @@ const BuildOptions = {
      * on the file system and to rebuild whenever a file changes that could
      * invalidate the build.
      */
-    watch: args.includes("--watch")
+    watch: args.has("--watch"),
 };
 
 esbuild
@@ -98,6 +99,7 @@ esbuild
         if (result.errors.length > 0) {
             console.error(result.errors);
         }
+
         if (result.warnings.length > 0) {
             console.error(result.warnings);
         }

--- a/services/nodecg-io-twitch-addons/extension/twitchAddonsClient.ts
+++ b/services/nodecg-io-twitch-addons/extension/twitchAddonsClient.ts
@@ -237,7 +237,7 @@ export class TwitchAddonsClient {
             await fetch(`https://api.twitch.tv/helix/users?login=${username}`, {
                 headers: {
                     "Client-ID": this.clientId,
-                    Authorization: `Bearer ${this.token}`,
+                    "Authorization": `Bearer ${this.token}`,
                 },
             })
         ).json();


### PR DESCRIPTION
- Add JSDoc types to `jest.config.js`, `.eslintrc.js` & `.prettierrc.js`
- Set more prettier configs explicitly to circumvent an issue I experienced with the prettier
  vscode extension, where it would format some stuff based on my global preferences
  and not the defaults.
- Use Set in `esbuild.config.js`
- Format all js and ts files
- Use module syntax in jest config
- Automatically add packages with jest config to root jest projects
- Add .mjs extension to files formatted by prettier
- Enable type checking JS files project wide

    Tim