### PR TITLE
Make OAuth redirect URLs match nodecg's baseUrl & protocol

### DIFF
--- a/services/nodecg-io-googleapis/extension/index.ts
+++ b/services/nodecg-io-googleapis/extension/index.ts
@@ -11,6 +11,7 @@ interface GoogleApisServiceConfig {
     clientSecret: string;
     refreshToken?: string;
     scopes?: string | string[];
+    httpsRedirect?: boolean;
 }
 
 export type GoogleApisServiceClient = GoogleApis;
@@ -28,7 +29,9 @@ class GoogleApisService extends ServiceBundle<GoogleApisServiceConfig, GoogleApi
         const auth = new google.auth.OAuth2({
             clientId: config.clientID,
             clientSecret: config.clientSecret,
-            redirectUri: "http://localhost:9090/nodecg-io-googleapis/oauth2callback",
+            redirectUri: `${config.httpsRedirect ? "https" : "http"}://${
+                this.nodecg.config.baseURL
+            }/nodecg-io-googleapis/oauth2callback`,
         });
 
         await this.refreshTokens(config, auth, logger);

--- a/services/nodecg-io-googleapis/googleapis-schema.json
+++ b/services/nodecg-io-googleapis/googleapis-schema.json
@@ -18,6 +18,10 @@
         "scopes": {
             "type": "array",
             "description": "Scope URLs for all used services."
+        },
+        "httpsRedirect": {
+            "type": "boolean",
+            "description": "Should the OAuth redirect URL use the https protocol"
         }
     },
     "required": ["clientID", "clientSecret"]

--- a/services/nodecg-io-spotify/extension/index.ts
+++ b/services/nodecg-io-spotify/extension/index.ts
@@ -10,18 +10,16 @@ interface SpotifyServiceConfig {
     clientSecret: string;
     scopes: Array<string>;
     refreshToken?: string;
+    httpsRedirect?: boolean;
 }
 
 export type SpotifyServiceClient = SpotifyWebApi;
 
-let callbackUrl = "";
 const callbackEndpoint = "/nodecg-io-spotify/spotifycallback";
 const defaultState = "defaultState";
 const refreshInterval = 1800000;
 
 module.exports = (nodecg: NodeCG) => {
-    callbackUrl = `http://${nodecg.config.baseURL}${callbackEndpoint}`;
-
     new SpotifyService(nodecg, "spotify", __dirname, "../spotify-schema.json").register();
 };
 
@@ -40,7 +38,9 @@ class SpotifyService extends ServiceBundle<SpotifyServiceConfig, SpotifyServiceC
         const spotifyApi = new SpotifyWebApi({
             clientId: config.clientId,
             clientSecret: config.clientSecret,
-            redirectUri: callbackUrl,
+            redirectUri: `${config.httpsRedirect ? "https" : "http"}://${
+                this.nodecg.config.baseURL
+            }${callbackEndpoint}`,
         });
 
         // if we already have a refresh token is available we can use it to create a access token without the need to annoy the user

--- a/services/nodecg-io-spotify/spotify-schema.json
+++ b/services/nodecg-io-spotify/spotify-schema.json
@@ -21,6 +21,10 @@
         "refreshToken": {
             "type": "string",
             "description": "A refresh token to get and refresh access tokens. Gets set by nodecg-io. You don't need to set this!"
+        },
+        "httpsRedirect": {
+            "type": "boolean",
+            "description": "Should the OAuth redirect URL use the https protocol"
         }
     },
     "required": ["clientId", "clientSecret", "scopes"]


### PR DESCRIPTION
- Adds an optional config option `httpsRedirect` to spotify and googleapis services
- Makes googleapis service use NodeCG's `config.baseURL` for redirect URL as the spotify service already does