### PR TITLE
fix: replace express.Router references with nodecg.Router

### DIFF
--- a/services/nodecg-io-googleapis/extension/index.ts
+++ b/services/nodecg-io-googleapis/extension/index.ts
@@ -3,7 +3,6 @@ import { Result, emptySuccess, success, error, ServiceBundle, Logger } from "nod
 import { google, GoogleApis } from "googleapis";
 import type { Credentials } from "google-auth-library/build/src/auth/credentials";
 import type { OAuth2Client } from "google-auth-library/build/src/auth/oauth2client";
-import * as express from "express";
 import opn = require("open");
 
 interface GoogleApisServiceConfig {
@@ -49,7 +48,7 @@ class GoogleApisService extends ServiceBundle<GoogleApisServiceConfig, GoogleApi
         });
 
         return new Promise((resolve, reject) => {
-            const router = express.Router();
+            const router = this.nodecg.Router();
 
             router.get("/nodecg-io-googleapis/oauth2callback", async (req, res) => {
                 try {

--- a/services/nodecg-io-googleapis/package.json
+++ b/services/nodecg-io-googleapis/package.json
@@ -38,7 +38,6 @@
     },
     "dependencies": {
         "@types/gapi": "^0.0.41",
-        "express": "^4.17.2",
         "googleapis": "^92.0.0",
         "nodecg-io-core": "^0.3.0",
         "open": "^8.4.0"

--- a/services/nodecg-io-spotify/extension/index.ts
+++ b/services/nodecg-io-spotify/extension/index.ts
@@ -1,7 +1,5 @@
 import { NodeCG } from "nodecg-types/types/server";
 import { Result, emptySuccess, success, error, ServiceBundle, Logger } from "nodecg-io-core";
-import * as express from "express";
-import { Router } from "express";
 import SpotifyWebApi = require("spotify-web-api-node");
 import open = require("open");
 
@@ -77,7 +75,7 @@ class SpotifyService extends ServiceBundle<SpotifyServiceConfig, SpotifyServiceC
 
     private mountCallBackURL(spotifyApi: SpotifyWebApi, logger: Logger) {
         return new Promise((resolve) => {
-            const router: Router = express.Router();
+            const router = this.nodecg.Router();
 
             router.get(callbackEndpoint, (req, res) => {
                 // Get auth code with is returned as url query parameter if everything was successful

--- a/services/nodecg-io-spotify/package.json
+++ b/services/nodecg-io-spotify/package.json
@@ -38,7 +38,6 @@
     },
     "dependencies": {
         "@types/spotify-web-api-node": "^5.0.3",
-        "express": "^4.17.2",
         "nodecg-io-core": "^0.3.0",
         "open": "^8.4.0",
         "spotify-web-api-node": "^5.0.2"


### PR DESCRIPTION
Saves a dependency from googleapi and spotify services