### PR TITLE
Fix enum suggestions in editor

### DIFF
--- a/nodecg-io-core/dashboard/utils/deepCopy.ts
+++ b/nodecg-io-core/dashboard/utils/deepCopy.ts
@@ -7,11 +7,15 @@
  */
 export function objectDeepCopy<T extends Object>(obj: T | any): T {
     if (typeof obj === "object") {
-        const copy = {} as any;
-        for (var attr in obj) {
-            if (obj.hasOwnProperty(attr)) copy[attr] = objectDeepCopy(obj[attr]);
+        if (Array.isArray(obj)) {
+            return obj.map((entry) => objectDeepCopy(entry)) as any;
+        } else {
+            const copy = {} as any;
+            for (var attr in obj) {
+                if (obj.hasOwnProperty(attr)) copy[attr] = objectDeepCopy(obj[attr]);
+            }
+            return copy;
         }
-        return copy;
     } else {
         return obj;
     }


### PR DESCRIPTION
Suggestions for enum types did not work correctly because `objectDeepCopy` turned Arrays into Objects.
This fixes for example the `lightType` property in elgato-light configs, as well as many properties of the serial service config.