### PR TITLE
Run NodeCG test in CI on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,10 @@ jobs:
         # are mounted by NodeCG. It will fail if one of them is not mounted.
         # You may check for other NodeCG runtime errors in the output (these
         # may not fail the run).
-        runs-on: ubuntu-latest
+        strategy:
+          matrix:
+            os: [ubuntu-latest, windows-latest]
+        runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/setup-node@v2
               with:
@@ -71,10 +74,18 @@ jobs:
             - name: Setup NodeCG
               run: nodecg setup
 
-            - name: Setup NodeCG config
+            - name: Setup NodeCG config linux
+              if: matrix.os == 'ubuntu-latest'
               run: |
                   mkdir cfg
                   echo '{"bundles": {"paths": ["'${GITHUB_WORKSPACE}'/nodecg-io","'${GITHUB_WORKSPACE}'/nodecg-io/services","'${GITHUB_WORKSPACE}'/nodecg-io/samples"]}}' > ./cfg/nodecg.json
+
+            - name: Setup NodeCG config windows
+              if: matrix.os == 'windows-latest'
+              shell: bash
+              run: |
+                  mkdir cfg
+                  echo '{"bundles": {"paths": ["'${GITHUB_WORKSPACE//\\/\\\\}'\\nodecg-io","'${GITHUB_WORKSPACE//\\/\\\\}'\\nodecg-io\\services","'${GITHUB_WORKSPACE//\\/\\\\}'\\nodecg-io\\samples"]}}' > ./cfg/nodecg.json
 
             # nodecg-io needs to be cloned after NodeCG setup because the nodecg-cli requires an empty directory.
             - uses: actions/checkout@v2
@@ -82,7 +93,12 @@ jobs:
                   path: "nodecg-io"
 
             - name: Install system dependencies
+              if: matrix.os == 'ubuntu-latest'
               run: sudo apt update && sudo apt-get -y install libusb-1.0-0-dev libasound2-dev libudev-dev
+
+            - name: Install node native development files
+              shell: bash
+              run: npx node-gyp install
 
             - name: Install nodejs dependencies
               run: npm ci
@@ -93,6 +109,7 @@ jobs:
               working-directory: ./nodecg-io
 
             - name: Run test
+              shell: bash
               run: node .scripts/ci-nodecg-integration.mjs
               working-directory: ./nodecg-io
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,27 @@ jobs:
               with:
                   node-version: "16"
 
-            - name: Install nodecg-cli
-              run: npm install --global nodecg-cli
+            - name: Download NodeCG
+              uses: actions/checkout@v2
+              with:
+                repository: nodecg/nodecg
 
-            - name: Setup NodeCG
-              run: nodecg setup
+            - name: Get NodeCG commit hash
+              id: nodecgHash
+              shell: bash
+              run: echo "::set-output name=nodecgHash::$(git rev-parse HEAD)"
+
+            - name: Cache NodeCG dependencies
+              id: cache-nodecg
+              uses: actions/cache@v2
+              with:
+                path: 'node_modules'
+                key: ${{ runner.os }}-${{ steps.nodecgHash.outputs.nodecgHash }}-nodecg
+
+            - name: Install NodeCG dependencies
+              # Only get dependencies if we didn't get them from the cache
+              if: steps.cache-nodecg.outputs.cache-hit != 'true'
+              run: npm install --prod
 
             - name: Setup NodeCG config linux
               if: matrix.os == 'ubuntu-latest'
@@ -85,9 +101,9 @@ jobs:
               shell: bash
               run: |
                   mkdir cfg
+                  # We need to escape backslashes to get valid json. Replaces each "\" with "\\"
                   echo '{"bundles": {"paths": ["'${GITHUB_WORKSPACE//\\/\\\\}'\\nodecg-io","'${GITHUB_WORKSPACE//\\/\\\\}'\\nodecg-io\\services","'${GITHUB_WORKSPACE//\\/\\\\}'\\nodecg-io\\samples"]}}' > ./cfg/nodecg.json
 
-            # nodecg-io needs to be cloned after NodeCG setup because the nodecg-cli requires an empty directory.
             - uses: actions/checkout@v2
               with:
                   path: "nodecg-io"


### PR DESCRIPTION
Ensures that nodecg-io is loadable on Windows automatically by CI.
We already have this for Linux as of #327, this PR just makes it compatible with Windows and runs it in CI.
The timeout command returns a non-negative exit code for some reason when the timeout is reached so I've ditched it and implemented the timeout in the node.js script.

The test with windows is pretty slow in CI so I've at least cached the NodeCG installation making it (more or less) acceptable.