### PR TITLE
Use windows-2019 instead of windows-latest in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,7 +61,7 @@ jobs:
         # may not fail the run).
         strategy:
           matrix:
-            os: [ubuntu-latest, windows-latest]
+            os: [ubuntu-latest, windows-2019]
         runs-on: ${{ matrix.os }}
         steps:
             - uses: actions/setup-node@v2
@@ -97,7 +97,7 @@ jobs:
                   echo '{"bundles": {"paths": ["'${GITHUB_WORKSPACE}'/nodecg-io","'${GITHUB_WORKSPACE}'/nodecg-io/services","'${GITHUB_WORKSPACE}'/nodecg-io/samples"]}}' > ./cfg/nodecg.json
 
             - name: Setup NodeCG config windows
-              if: matrix.os == 'windows-latest'
+              if: matrix.os == 'windows-2019'
               shell: bash
               run: |
                   mkdir cfg


### PR DESCRIPTION
`windows-latest` was recently switched to be an alias for `windows-2022` instead of `windows-2019`. This causes the recent build failures because node-gyp doesn't work properly with Visual Studio 2022 yet. This PR changes it back to `windows-2019` to fix build failures till node-gyp fully supports Visual Studio 2022.