### PR TITLE
Add replicant with last events to streamelement service

### DIFF
--- a/samples/streamelements-events/extension/index.ts
+++ b/samples/streamelements-events/extension/index.ts
@@ -1,11 +1,12 @@
 import { NodeCG } from "nodecg-types/types/server";
-import { StreamElementsServiceClient } from "nodecg-io-streamelements";
+import { StreamElementsReplicant, StreamElementsServiceClient } from "nodecg-io-streamelements";
 import { requireService } from "nodecg-io-core";
 
 module.exports = function (nodecg: NodeCG) {
     nodecg.log.info("Sample bundle for StreamElements started");
 
     const streamElements = requireService<StreamElementsServiceClient>(nodecg, "streamelements");
+    const streamElementsReplicant = nodecg.Replicant<StreamElementsReplicant>("streamelements");
 
     streamElements?.onAvailable((client) => {
         nodecg.log.info("SE client has been updated, registering handlers now.");
@@ -62,6 +63,8 @@ module.exports = function (nodecg: NodeCG) {
         client.onTest((data) => {
             nodecg.log.info(JSON.stringify(data));
         });
+
+        client.setupReplicant(streamElementsReplicant);
     });
 
     streamElements?.onUnavailable(() => nodecg.log.info("SE client has been unset."));

--- a/samples/streamelements-events/extension/tsconfig.json
+++ b/samples/streamelements-events/extension/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "extends": "nodecg-io-tsconfig",
+    "references": [
+        {
+            "path": "../../../nodecg-io-core"
+        },
+        {
+            "path": "../../../services/nodecg-io-streamelements"
+        }
+    ]
+}

--- a/samples/streamelements-events/graphics/index.html
+++ b/samples/streamelements-events/graphics/index.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <title>streamelements-events sample bundle</title>
+        <style>
+            body {
+                font-family: sans-serif;
+            }
+            /* don't show container until vue has compiled all templates */
+            [v-cloak] {
+                display: none;
+            }
+        </style>
+    </head>
+
+    <body>
+        <h1>streamelements-events sample bundle</h1>
+        <div id="app" v-cloak>
+            <p>Newest events of configured streamelements instance:</p>
+            <p>
+                Last subscriber:
+                <span v-if="se?.lastSubscriber">
+                    {{ se?.lastSubscriber?.data.displayName }} subscribed for {{ se?.lastSubscriber?.data.amount }}
+                    months ({{ subTier }}).
+                </span>
+                <span v-else>none</span>
+            </p>
+            <p>
+                Last tip:
+                <span v-if="se?.lastTip">
+                    {{ se?.lastSubscriber?.data.displayName }} subscribed for {{ se?.lastSubscriber?.data.amount }}
+                    months.
+                </span>
+                <span v-else>none</span>
+            </p>
+            <p>
+                Last cheer:
+                <span v-if="se?.lastCheer">
+                    {{ se?.lastCheer?.data.amount }} bits by {{ se?.lastCheer?.data.displayName }}
+                </span>
+                <span v-else>none</span>
+            </p>
+            <p>
+                Last follow:
+                <span v-if="se?.lastFollow"> {{ se?.lastFollow?.data.displayName }} </span>
+                <span v-else>none</span>
+            </p>
+            <p>
+                Last raid:
+                <span v-if="se?.lastRaid">
+                    {{ se?.lastRaid?.data.displayName }} raided with {{ se?.lastRaid?.data.amount }} viewers
+                </span>
+                <span v-else>none</span>
+            </p>
+            <p>
+                Last host:
+                <span v-if="se?.lastHost">
+                    {{ se?.lastHost?.data.displayName }} hosted with {{ se?.lastHost?.data.viewers }} viewers
+                </span>
+                <span v-else>none</span>
+            </p>
+        </div>
+
+        <script src="index.js"></script>
+    </body>
+</html>

--- a/samples/streamelements-events/graphics/index.ts
+++ b/samples/streamelements-events/graphics/index.ts
@@ -1,0 +1,32 @@
+/// <reference types="nodecg-types/types/browser" />
+import { createApp, defineComponent } from "vue/dist/vue.esm-bundler.js";
+import type { StreamElementsReplicant } from "nodecg-io-streamelements";
+
+const replicant = nodecg.Replicant<StreamElementsReplicant>("streamelements");
+
+const mainComponent = defineComponent<{}, {}, { se: StreamElementsReplicant }>({
+    data() {
+        return {
+            se: {},
+        };
+    },
+    created() {
+        replicant.on("change", (newVal) => {
+            this.se = newVal;
+        });
+    },
+    computed: {
+        subTier() {
+            const sub = this.se.lastSubscriber;
+            if (!sub || !sub.data.tier) return undefined;
+
+            if (sub.data.tier === "prime") {
+                return "Twitch Prime";
+            }
+
+            return `Tier ${Number.parseInt(sub.data.tier) / 1000}`;
+        },
+    },
+});
+
+createApp(mainComponent).mount("#app");

--- a/samples/streamelements-events/graphics/tsconfig.json
+++ b/samples/streamelements-events/graphics/tsconfig.json
@@ -1,0 +1,22 @@
+{
+    "extends": "nodecg-io-tsconfig",
+    "compilerOptions": {
+        "target": "ES2015",
+        "lib": ["ES2015", "dom"],
+        "module": "ES2015",
+        "noEmit": true,
+        "paths": {
+            // TODO: properly set an alias from vue -> vue/dist/vue.esm.bundler.js in esbuild
+            // so typings can be loaded properly without this workaround
+            "vue/dist/vue.esm-bundler.js": ["../../../node_modules/vue/dist/vue"]
+        }
+    },
+    "references": [
+        {
+            "path": "../../../nodecg-io-core"
+        },
+        {
+            "path": "../../../services/nodecg-io-streamelements"
+        }
+    ]
+}

--- a/samples/streamelements-events/package.json
+++ b/samples/streamelements-events/package.json
@@ -2,19 +2,32 @@
     "name": "streamelements-events",
     "version": "0.3.0",
     "private": true,
+    "scripts": {
+        "build": "esbuild graphics/index.ts --bundle --outfile=graphics/index.js --log-level=silent",
+        "watch": "npm run build -- --watch"
+    },
     "nodecg": {
         "compatibleRange": "^1.1.1",
         "bundleDependencies": {
             "nodecg-io-streamelements": "^0.3.0"
-        }
+        },
+        "graphics": [
+            {
+                "file": "index.html",
+                "width": "1920",
+                "height": "1080"
+            }
+        ]
     },
     "license": "MIT",
     "dependencies": {
         "@types/node": "^17.0.21",
-        "nodecg-types": "^1.8.3",
+        "esbuild": "^0.14.23",
         "nodecg-io-core": "^0.3.0",
         "nodecg-io-streamelements": "^0.3.0",
-        "typescript": "^4.5.5",
-        "nodecg-io-tsconfig": "^1.0.0"
+        "nodecg-io-tsconfig": "^1.0.0",
+        "nodecg-types": "^1.8.3",
+        "vue": "^3.2.31",
+        "typescript": "^4.5.5"
     }
 }

--- a/samples/streamelements-events/tsconfig.json
+++ b/samples/streamelements-events/tsconfig.json
@@ -1,11 +1,14 @@
 {
-    "extends": "nodecg-io-tsconfig",
+    "files": [],
+    "compilerOptions": {
+        "composite": true
+    },
     "references": [
         {
-            "path": "../../nodecg-io-core"
+            "path": "./extension"
         },
         {
-            "path": "../../services/nodecg-io-streamelements"
+            "path": "./graphics"
         }
     ]
 }

--- a/services/nodecg-io-serial/extension/SerialClient.ts
+++ b/services/nodecg-io-serial/extension/SerialClient.ts
@@ -23,11 +23,7 @@ export interface SerialServiceConfig {
 
 export class SerialServiceClient extends SerialPort {
     private parser: ReadlineParser;
-    constructor(
-        options: SerialPortOpenOptions<AutoDetectTypes>,
-        protocol?: ReadlineOptions, // TODO: maybe rename this to parseOptions or something
-        callback?: ErrorCallback,
-    ) {
+    constructor(options: SerialPortOpenOptions<AutoDetectTypes>, protocol?: ReadlineOptions, callback?: ErrorCallback) {
         super(options, callback);
         this.parser = this.pipe(new ReadlineParser(protocol));
     }

--- a/services/nodecg-io-streamelements/extension/StreamElements.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElements.ts
@@ -2,6 +2,17 @@ import io = require("socket.io-client");
 import { Result, emptySuccess, error } from "nodecg-io-core";
 import { StreamElementsEvent } from "./StreamElementsEvent";
 import { EventEmitter } from "events";
+import { Replicant } from "nodecg-types/types/server";
+
+export interface StreamElementsReplicant {
+    lastSubscriber?: StreamElementsEvent;
+    lastTip?: StreamElementsEvent;
+    lastCheer?: StreamElementsEvent;
+    lastGift?: StreamElementsEvent;
+    lastFollow?: StreamElementsEvent;
+    lastRaid?: StreamElementsEvent;
+    lastHost?: StreamElementsEvent;
+}
 
 export class StreamElementsServiceClient extends EventEmitter {
     private socket: SocketIOClient.Socket;
@@ -130,5 +141,19 @@ export class StreamElementsServiceClient extends EventEmitter {
 
     public onTest(handler: (data: StreamElementsEvent) => void): void {
         this.on("test", handler);
+    }
+
+    public setupReplicant(rep: Replicant<StreamElementsReplicant>): void {
+        if (rep.value === undefined) {
+            rep.value = {};
+        }
+
+        this.on("subscriber", (data) => (rep.value.lastSubscriber = data));
+        this.on("tip", (data) => (rep.value.lastTip = data));
+        this.on("cheer", (data) => (rep.value.lastCheer = data));
+        this.on("gift", (data) => (rep.value.lastGift = data));
+        this.on("follow", (data) => (rep.value.lastFollow = data));
+        this.on("raid", (data) => (rep.value.lastRaid = data));
+        this.on("host", (data) => (rep.value.lastHost = data));
     }
 }

--- a/services/nodecg-io-streamelements/extension/index.ts
+++ b/services/nodecg-io-streamelements/extension/index.ts
@@ -7,7 +7,7 @@ interface StreamElementsServiceConfig {
     handleTestEvents: boolean;
 }
 
-export { StreamElementsServiceClient } from "./StreamElements";
+export { StreamElementsServiceClient, StreamElementsReplicant } from "./StreamElements";
 
 module.exports = (nodecg: NodeCG) => {
     const schemaPath = [__dirname, "../streamelements-schema.json"];


### PR DESCRIPTION
This is my take on replicants (#65) that I've shared on Discord before.
The bundle that wants a replicant creates it in the extension of the bundle and then calls a method on the service client that sets up handlers to feed data into it. That way the replicant is declared in the context of the bundle using the service, the name of the replicant is freely choosable and, most important, static.

To start I've added a replicant to the streamelements service that contains the last sub, last follow, last tip, etc. To show how the replicant can be used I've added a simple graphic to the `streamelements-events` sample bundle that gets the data from the replicant and displays it using vue.

TODO:
- [x] Initial implementation for streamelements and changes to sample bundle
- [ ] Fix current workaround by properly setting an alias to the esm version for vue in the graphic.
- [ ] Documentation about usage
- [ ] Add replicants to more services