### PR TITLE
Fix undefined error message in obs service

### DIFF
--- a/services/nodecg-io-obs/extension/index.ts
+++ b/services/nodecg-io-obs/extension/index.ts
@@ -34,7 +34,7 @@ class OBSService extends ServiceBundle<OBSServiceConfig, OBSServiceClient> {
             await this.connectClient(client, config);
             logger.info("Connected to OBS successfully.");
         } catch (e) {
-            return error(e.error);
+            return error(e.message);
         }
 
         return success(client);


### PR DESCRIPTION
Now outputting correct error when the connection to obs can't be established

Before:
```
error: [nodecg-io-core] The "obs" service with the name "obs" produced an error while creating a client: undefined
```
After:
```
error: [nodecg-io-core] The "obs" service with the name "obs" produced an error while creating a client: connect ECONNREFUSED 127.0.0.1:4444
```