### PR TITLE
fix: Use correct eventName and event function name in Stream Elements

### DIFF
--- a/samples/streamelements-events/extension/index.ts
+++ b/samples/streamelements-events/extension/index.ts
@@ -35,7 +35,7 @@ module.exports = function (nodecg: NodeCG) {
             nodecg.log.info(`${data.data.displayName} just subscribed for ${data.data.amount} months (${formatSubTier(data.data.tier)}).`);
         });
 
-        client.onTestSubscription((data) => {
+        client.onTestSubscriber((data) => {
             nodecg.log.info(`${data.event.displayName} just subscribed for ${data.event.amount} months (${formatSubTier(data.event.tier)}).`);
         })
 

--- a/services/nodecg-io-streamelements/extension/StreamElements.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElements.ts
@@ -155,12 +155,8 @@ export class StreamElementsServiceClient extends EventEmitter {
         this.on("test", handler);
     }
 
-    public onTestSubscription(handler: (data: StreamElementsTestSubscriberEvent) => void): void {
-        this.on("test:subscription-latest", handler);
-    }
-
-    public onTestCheer(handler: (data: StreamElementsTestCheerEvent) => void): void {
-        this.on("test:cheer-latest", handler);
+    public onTestSubscriber(handler: (data: StreamElementsTestSubscriberEvent) => void): void {
+        this.on("test:subscriber-latest", handler);
     }
 
     public onTestGift(handler: (data: StreamElementsTestSubscriberEvent) => void): void {
@@ -169,6 +165,10 @@ export class StreamElementsServiceClient extends EventEmitter {
                 handler(d);
             }
         });
+    }
+
+    public onTestCheer(handler: (data: StreamElementsTestCheerEvent) => void): void {
+        this.on("test:cheer-latest", handler);
     }
 
     public onTestFollow(handler: (data: StreamElementsTestFollowEvent) => void): void {


### PR DESCRIPTION
I missed the usage of a wrong eventName and with that an inconsistant naming of the onTestSubscriber function.