### PR TITLE
Move nodecg-types to be a dev dependency everywhere

### DIFF
--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -21,12 +21,12 @@
     "devDependencies": {
         "esbuild": "^0.15.6",
         "monaco-editor": "^0.34.0",
+        "nodecg-types": "^1.9.0",
         "typescript": "^4.8.2"
     },
     "dependencies": {
         "crypto-js": "^4.1.1",
         "nodecg-io-core": "^0.3.0",
-        "nodecg-types": "^1.9.0",
         "events": "^3.3.0"
     },
     "license": "MIT"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11808,12 +11808,12 @@
             "dependencies": {
                 "crypto-js": "^4.1.1",
                 "events": "^3.3.0",
-                "nodecg-io-core": "^0.3.0",
-                "nodecg-types": "^1.9.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "esbuild": "^0.15.6",
                 "monaco-editor": "^0.34.0",
+                "nodecg-types": "^1.9.0",
                 "typescript": "^4.8.2"
             }
         },
@@ -13468,14 +13468,14 @@
             "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "nodecg-io-core": "^0.3.0",
-                "nodecg-types": "^1.9.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^18.7.14",
                 "esbuild": "^0.15.6",
                 "monaco-editor": "^0.34.0",
                 "nodecg-io-tsconfig": "^1.0.0",
+                "nodecg-types": "^1.9.0",
                 "typescript": "^4.8.2"
             }
         },
@@ -14117,12 +14117,12 @@
             "dependencies": {
                 "@types/node-fetch": "^2.6.1",
                 "node-fetch": "^2.6.7",
-                "nodecg-io-core": "^0.3.0",
-                "nodecg-types": "^1.9.0"
+                "nodecg-io-core": "^0.3.0"
             },
             "devDependencies": {
                 "@types/node": "^18.7.14",
                 "nodecg-io-tsconfig": "^1.0.0",
+                "nodecg-types": "^1.9.0",
                 "typescript": "^4.8.2"
             }
         },
@@ -14219,7 +14219,7 @@
             "license": "MIT",
             "dependencies": {
                 "nodecg-io-core": "^0.3.0",
-                "reddit-ts": "git+ssh://git@github.com/noeppi-noeppi/npm-reddit-ts.git#40a1ff7c115ab4bf860d13179ebf28c6e9e69286"
+                "reddit-ts": "https://github.com/noeppi-noeppi/npm-reddit-ts.git#build"
             },
             "devDependencies": {
                 "@types/node": "^18.7.14",
@@ -21883,7 +21883,7 @@
                 "nodecg-io-core": "^0.3.0",
                 "nodecg-io-tsconfig": "^1.0.0",
                 "nodecg-types": "^1.9.0",
-                "reddit-ts": "git+ssh://git@github.com/noeppi-noeppi/npm-reddit-ts.git#40a1ff7c115ab4bf860d13179ebf28c6e9e69286",
+                "reddit-ts": "https://github.com/noeppi-noeppi/npm-reddit-ts.git#build",
                 "typescript": "^4.8.2"
             },
             "dependencies": {

--- a/services/nodecg-io-debug/package.json
+++ b/services/nodecg-io-debug/package.json
@@ -49,12 +49,12 @@
     "devDependencies": {
         "@types/node": "^18.7.14",
         "esbuild": "^0.15.6",
-        "nodecg-io-tsconfig": "^1.0.0",
         "monaco-editor": "^0.34.0",
+        "nodecg-io-tsconfig": "^1.0.0",
+        "nodecg-types": "^1.9.0",
         "typescript": "^4.8.2"
     },
     "dependencies": {
-        "nodecg-io-core": "^0.3.0",
-        "nodecg-types": "^1.9.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }

--- a/services/nodecg-io-nanoleaf/package.json
+++ b/services/nodecg-io-nanoleaf/package.json
@@ -32,12 +32,12 @@
     "devDependencies": {
         "@types/node": "^18.7.14",
         "nodecg-io-tsconfig": "^1.0.0",
+        "nodecg-types": "^1.9.0",
         "typescript": "^4.8.2"
     },
     "dependencies": {
         "@types/node-fetch": "^2.6.1",
         "node-fetch": "^2.6.7",
-        "nodecg-io-core": "^0.3.0",
-        "nodecg-types": "^1.9.0"
+        "nodecg-io-core": "^0.3.0"
     }
 }


### PR DESCRIPTION
`nodecg-types` is only used when compiling typescript at dev time and not required when running nodecg-io. This PR moves it to be a dev dependency everywhere because it was mistakenly a prod dependency in some bundles.