### PR TITLE
Add vscode devcontainer config files

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,15 @@
+# Base devcontainer for node.js development
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-18-bullseye
+USER node
+
+# Install required system dependencies
+RUN sudo apt update && sudo apt-get -y install libusb-1.0-0-dev libasound2-dev libudev-dev libc-bin
+
+# Create a NodeCG installation
+WORKDIR /workspaces
+RUN git clone https://github.com/nodecg/nodecg.git
+
+# Install dependencies and add configuration that includes the nodecg-io install
+RUN cd nodecg && npm install --prod && mkdir cfg
+COPY ./nodecg.json /workspaces/nodecg/cfg/nodecg.json
+

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,30 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.245.2/containers/typescript-node
+{
+    "name": "nodecg-io inside a NodeCG installation",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+
+    // Configure tool-specific properties.
+    "customizations": {
+        // Configure properties specific to VS Code.
+        "vscode": {
+            // Add the IDs of extensions you want installed when the container is created.
+            "extensions": ["dbaeumer.vscode-eslint", "streetsidesoftware.code-spell-checker", "esbenp.prettier-vscode"]
+        }
+    },
+
+    "forwardPorts": [
+        9090 // NodeCG dashboard port
+    ],
+
+    // Install node.js dependencies and build project after the container has been created.
+    "postCreateCommand": "npm install && npm run build",
+
+    // Change directory from /workspaces/nodecg-io to /workspaces/nodecg/nodecg-io inside the NodeCG installation
+    "workspaceFolder": "/workspaces/nodecg/nodecg-io",
+    "workspaceMount": "source=${localWorkspaceFolder},target=/workspaces/nodecg/nodecg-io,type=bind",
+
+    "remoteUser": "node"
+}

--- a/.devcontainer/nodecg.json
+++ b/.devcontainer/nodecg.json
@@ -1,0 +1,9 @@
+{
+    "bundles": {
+        "paths": [
+            "/workspaces/nodecg/nodecg-io",
+            "/workspaces/nodecg/nodecg-io/services",
+            "/workspaces/nodecg/nodecg-io/samples"
+        ]
+    }
+}


### PR DESCRIPTION
Allows getting a development environment by using the VS Code devcontainer plugin. It builds a container with node.js, all system dependencies and NodeCG already installed. The NodeCG installation is already configured to use nodecg-io from the current workspace directory.
After creating the container all dependencies are installed and nodecg-io
 is built once automatically.
After opening the workspace in the devcontainer you can directly run it by pressing F5.

This allows to get started with coding on nodecg-io quickly because
 you don't need to install NodeCG, have node.js installed etc...