### PR TITLE
Only run dependabot once a month

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,9 +3,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "weekly"
-      day: "saturday"
+      interval: "monthly"


### PR DESCRIPTION
Merging dependabot PRs each week has kinda become a burden. Since there is not that much development currently anyway, updating the dependencies only once a month is fine, and I can hopefully use the saved time to do actual work.