### PR TITLE
Remove @types/gapi dependency from googleapis service

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2233,10 +2233,6 @@
                 "@types/range-parser": "*"
             }
         },
-        "node_modules/@types/gapi": {
-            "version": "0.0.42",
-            "license": "MIT"
-        },
         "node_modules/@types/graceful-fs": {
             "version": "4.1.5",
             "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -14003,7 +13999,6 @@
             "version": "0.3.0",
             "license": "MIT",
             "dependencies": {
-                "@types/gapi": "^0.0.42",
                 "googleapis": "^107.0.0",
                 "nodecg-io-core": "^0.3.0",
                 "open": "^8.4.0"
@@ -16410,9 +16405,6 @@
                 "@types/qs": "*",
                 "@types/range-parser": "*"
             }
-        },
-        "@types/gapi": {
-            "version": "0.0.42"
         },
         "@types/graceful-fs": {
             "version": "4.1.5",
@@ -21670,7 +21662,6 @@
         "nodecg-io-googleapis": {
             "version": "file:services/nodecg-io-googleapis",
             "requires": {
-                "@types/gapi": "^0.0.42",
                 "@types/node": "^18.7.18",
                 "googleapis": "^107.0.0",
                 "nodecg-io-core": "^0.3.0",

--- a/services/nodecg-io-googleapis/package.json
+++ b/services/nodecg-io-googleapis/package.json
@@ -37,7 +37,6 @@
         "nodecg-io-tsconfig": "^1.0.0"
     },
     "dependencies": {
-        "@types/gapi": "^0.0.42",
         "googleapis": "^107.0.0",
         "nodecg-io-core": "^0.3.0",
         "open": "^8.4.0"


### PR DESCRIPTION
The `nodecg-io-googleapis` service depends on the `googleapis` package for the service implementation.
The service was added in ed7eb2f71807378dae9a5462f7a481df126b2987 with an additional dependency to `@types/gapi` for types. However the used `googleapis` package provides its own typings out of the box and `@types/gapi` is for the outdated `gapi` package which is not used here.

Removes the mentioned unused typing package as it is not used.