### PR TITLE
Update node midi dependency in lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1412,9 +1412,8 @@
             "peer": true
         },
         "node_modules/@julusian/midi": {
-            "version": "3.0.0-3",
-            "resolved": "https://registry.npmjs.org/@julusian/midi/-/midi-3.0.0-3.tgz",
-            "integrity": "sha512-h09ne0W3pFLoEr//IK+d2PnHyDvTUw8SpxzXjvM5t/AzZIHnpmRZSLhxgAolThEHLVRoiYWKWmc+kXFVVeaCBQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@julusian/midi/-/midi-3.0.1.tgz",
             "hasInstallScript": true,
             "dependencies": {
                 "node-addon-api": "^5.0.0",
@@ -15159,9 +15158,8 @@
             }
         },
         "@julusian/midi": {
-            "version": "3.0.0-3",
-            "resolved": "https://registry.npmjs.org/@julusian/midi/-/midi-3.0.0-3.tgz",
-            "integrity": "sha512-h09ne0W3pFLoEr//IK+d2PnHyDvTUw8SpxzXjvM5t/AzZIHnpmRZSLhxgAolThEHLVRoiYWKWmc+kXFVVeaCBQ==",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@julusian/midi/-/midi-3.0.1.tgz",
             "requires": {
                 "node-addon-api": "^5.0.0",
                 "pkg-prebuilds": "^0.1.0"


### PR DESCRIPTION
Fixes #832 by updating the midi dependency to use the fix provided in https://github.com/Julusian/node-midi/pull/5.
