### PR TITLE
Increase dependabot open PR limit

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
       interval: "monthly"
   - package-ecosystem: "npm"
     directory: "/"
+    open-pull-requests-limit: 15
     schedule:
       interval: "monthly"
   - package-ecosystem: "docker"


### PR DESCRIPTION
When using dependabot with a weekly schedule it will open the default count of pull requests (5). If you merge some of them it will create new ones as long as there are still updates available.
When using dependabot with a monthly schedule for some reason it won't open any more pull requests when merging some (unless next month).
Because we have about 7-13 dependencies with frequent upgrades the limit needs to be adjusted if we want to have up to date versions.
