### PR TITLE
Patch version of twitch-auth package in published tarballs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,20 @@ jobs:
             - name: Extract compilation results
               run: tar xvf compilation-results.tar.gz
 
+              # All twitch services depend on the utility package `nodecg-io-twitch-auth`.
+              # In the repository the services depend on the latest development version which is not yet published.
+              # If someone installs the service using the published tarball npm would try to get the
+              # unpublished version of twitch-auth from the npm registry which is not possible.
+              # To fix this we update the version of the twitch-auth package in all usages
+              # to also reference the published tarball.
+            - name: Patch twitch-auth dependency to use published current tarball
+              run: |
+                # Get current version as it is needed for the tarball file name
+                TWITCH_AUTH_VERSION=$(cat utils/nodecg-io-twitch-auth/package.json| jq .version -r)
+                # Find usages in all package.json files and replace with the corresponding tarball url
+                rg -g 'package.json' -l -t json -o '"nodecg-io-twitch-auth": ".+"' | \
+                  xargs sed -i "s/\"nodecg-io-twitch-auth\": \".*\"/\"nodecg-io-twitch-auth\": \"https:\/\/codeoverflow-org.github.io\/nodecg-io-publish\/nodecg-io-twitch-auth-${TWITCH_AUTH_VERSION}.tgz\"/g"
+
             - name: Create npm tarballs
               run: npm pack --workspaces
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,9 +178,11 @@ jobs:
             - name: Patch twitch-auth dependency to use published current tarball
               run: |
                 # Get current version as it is needed for the tarball file name
-                TWITCH_AUTH_VERSION=$(cat utils/nodecg-io-twitch-auth/package.json| jq .version -r)
+                TWITCH_AUTH_VERSION=$(cat utils/nodecg-io-twitch-auth/package.json | jq .version -r)
+                echo "$TWITCH_AUTH_VERSION"
                 # Find usages in all package.json files and replace with the corresponding tarball url
-                rg -g 'package.json' -l -t json -o '"nodecg-io-twitch-auth": ".+"' | \
+                rg -g 'package.json' -l '"nodecg-io-twitch-auth": ".+"'
+                rg -g 'package.json' -l '"nodecg-io-twitch-auth": ".+"' | \
                   xargs sed -i "s/\"nodecg-io-twitch-auth\": \".*\"/\"nodecg-io-twitch-auth\": \"https:\/\/codeoverflow-org.github.io\/nodecg-io-publish\/nodecg-io-twitch-auth-${TWITCH_AUTH_VERSION}.tgz\"/g"
 
             - name: Create npm tarballs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,9 @@ jobs:
               with:
                 node-version: "18"
 
+            - name: Install ripgrep
+              run: sudo apt install ripgrep -y
+
             - name: Download compilation results # From the build step
               uses: actions/download-artifact@v3
               with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,9 +158,6 @@ jobs:
               with:
                 node-version: "18"
 
-            - name: Install ripgrep
-              run: sudo apt install ripgrep -y
-
             - name: Download compilation results # From the build step
               uses: actions/download-artifact@v3
               with:
@@ -179,11 +176,11 @@ jobs:
               run: |
                 # Get current version as it is needed for the tarball file name
                 TWITCH_AUTH_VERSION=$(cat utils/nodecg-io-twitch-auth/package.json | jq .version -r)
-                echo "$TWITCH_AUTH_VERSION"
+
                 # Find usages in all package.json files and replace with the corresponding tarball url
-                rg -g 'package.json' -l '"nodecg-io-twitch-auth": ".+"'
-                rg -g 'package.json' -l '"nodecg-io-twitch-auth": ".+"' | \
-                  xargs sed -i "s/\"nodecg-io-twitch-auth\": \".*\"/\"nodecg-io-twitch-auth\": \"https:\/\/codeoverflow-org.github.io\/nodecg-io-publish\/nodecg-io-twitch-auth-${TWITCH_AUTH_VERSION}.tgz\"/g"
+                find . -name 'package.json' -exec grep -q -E '"nodecg-io-twitch-auth": ".+"' {} \; -print # Print found files for debug purposes
+                find . -name 'package.json' -exec grep -q -E '"nodecg-io-twitch-auth": ".+"' {} \; -print0 | \
+                    xargs -0 sed -i "s/\"nodecg-io-twitch-auth\": \".*\"/\"nodecg-io-twitch-auth\": \"https:\/\/codeoverflow-org.github.io\/nodecg-io-publish\/nodecg-io-twitch-auth-${TWITCH_AUTH_VERSION}.tgz\"/g"
 
             - name: Create npm tarballs
               run: npm pack --workspaces


### PR DESCRIPTION
Makes twitch services work in generated bundles of nodecg-io-cli development environments. See https://github.com/codeoverflow-org/nodecg-io/discussions/893#discussioncomment-5280262 for a more detailed explanation.