### PR TITLE
Add NodeCG v2 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,16 +79,28 @@ jobs:
               run: echo "NODECG_HASH=$(git rev-parse HEAD)" >> $GITHUB_ENV
 
             - name: Cache NodeCG dependencies
-              id: cache-nodecg
+              id: cache-nodecg-deps
               uses: actions/cache@v3
               with:
                 path: 'node_modules'
-                key: ${{ runner.os }}-${{ env.NODECG_HASH }}-nodecg
+                key: ${{ runner.os }}-${{ env.NODECG_HASH }}-nodecg-deps
+
+            - name: Cache NodeCG compilation outputs
+              id: cache-nodecg-build
+              uses: actions/cache@v3
+              with:
+                path: 'build'
+                key: ${{ runner.os }}-${{ env.NODECG_HASH }}-nodecg-build
 
             - name: Install NodeCG dependencies
               # Only get dependencies if we didn't get them from the cache
-              if: steps.cache-nodecg.outputs.cache-hit != 'true'
-              run: npm install --prod
+              if: steps.cache-nodecg-deps.outputs.cache-hit != 'true'
+              run: npm install
+
+            - name: Build NodeCG
+              # Only build NodeCG if we didn't have cached compilation results
+              if: steps.cache-nodecg-build.outputs.cache-hit != 'true'
+              run: npm run build
 
             - name: Setup NodeCG config linux
               if: matrix.os == 'ubuntu-latest'

--- a/.scripts/ci-nodecg-integration.mjs
+++ b/.scripts/ci-nodecg-integration.mjs
@@ -39,7 +39,8 @@ child.once("exit", (exitCode, signal) => {
     console.log("Stopped NodeCG\n");
 
     // Check exit code for failure
-    if (exitCode !== null && exitCode !== 0) {
+    // 143 is the exit code when the process is killed by the timeout (SIGTERM)
+    if (exitCode !== null && exitCode !== 143) {
         throw new Error(`NodeCG exited with code ${exitCode} ${signal}`);
     }
 
@@ -47,7 +48,7 @@ child.once("exit", (exitCode, signal) => {
 
     // Try to find each bundle in the logs.
     const missing = bundles.filter(
-        (i) => !log.includes(`[nodecg/lib/server/extensions] Mounted ${i.packageJson.name} extension`),
+        (bundle) => !log.includes(` [extensions] Mounted ${bundle.packageJson.name} extension`),
     );
 
     // Fail the run if there are missing bundles.

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -31,7 +31,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "dashboardPanels": [
             {
                 "name": "nodecg-io",

--- a/nodecg-io-core/package.json
+++ b/nodecg-io-core/package.json
@@ -31,7 +31,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "dashboardPanels": [
             {
                 "name": "nodecg-io",

--- a/samples/ahk-sendcommand/package.json
+++ b/samples/ahk-sendcommand/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-ahk": "^0.3.0"
         }

--- a/samples/ahk-sendcommand/package.json
+++ b/samples/ahk-sendcommand/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-ahk": "^0.3.0"
         }

--- a/samples/android/package.json
+++ b/samples/android/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-android": "^0.3.0"
         }

--- a/samples/android/package.json
+++ b/samples/android/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-android": "^0.3.0"
         }

--- a/samples/artnet-console/package.json
+++ b/samples/artnet-console/package.json
@@ -13,7 +13,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-artnet": "^0.3.0"
         }

--- a/samples/artnet-console/package.json
+++ b/samples/artnet-console/package.json
@@ -13,7 +13,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-artnet": "^0.3.0"
         }

--- a/samples/atem/package.json
+++ b/samples/atem/package.json
@@ -13,7 +13,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-atem": "^0.3.0"
         }

--- a/samples/atem/package.json
+++ b/samples/atem/package.json
@@ -13,7 +13,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-atem": "^0.3.0"
         }

--- a/samples/dbus-ratbagd/package.json
+++ b/samples/dbus-ratbagd/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-dbus": "0.3.0"
         }

--- a/samples/dbus-ratbagd/package.json
+++ b/samples/dbus-ratbagd/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-dbus": "0.3.0"
         }

--- a/samples/debug/package.json
+++ b/samples/debug/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-debug": "^0.3.0"
         }

--- a/samples/debug/package.json
+++ b/samples/debug/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-debug": "^0.3.0"
         }

--- a/samples/discord-guild-chat/package.json
+++ b/samples/discord-guild-chat/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/Tim-Tech-Dev"
     },
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-discord": "^0.3.0"
         }

--- a/samples/discord-guild-chat/package.json
+++ b/samples/discord-guild-chat/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/Tim-Tech-Dev"
     },
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-discord": "^0.3.0"
         }

--- a/samples/discord-rpc/package.json
+++ b/samples/discord-rpc/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-discord-rpc": "0.3.0"
         }

--- a/samples/discord-rpc/package.json
+++ b/samples/discord-rpc/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-discord-rpc": "0.3.0"
         }

--- a/samples/elgato-light/package.json
+++ b/samples/elgato-light/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-elgato-light": "^0.3.0"
         }

--- a/samples/elgato-light/package.json
+++ b/samples/elgato-light/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-elgato-light": "^0.3.0"
         }

--- a/samples/github/package.json
+++ b/samples/github/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-github": "0.3.0"
         }

--- a/samples/github/package.json
+++ b/samples/github/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-github": "0.3.0"
         }

--- a/samples/google-cast/package.json
+++ b/samples/google-cast/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-template": "^0.3.0"
         }

--- a/samples/google-cast/package.json
+++ b/samples/google-cast/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-template": "^0.3.0"
         }

--- a/samples/gsheets/package.json
+++ b/samples/gsheets/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-googleapis": "^0.3.0"
         }

--- a/samples/gsheets/package.json
+++ b/samples/gsheets/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-googleapis": "^0.3.0"
         }

--- a/samples/intellij/package.json
+++ b/samples/intellij/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-intellij": "^0.3.0"
         }

--- a/samples/intellij/package.json
+++ b/samples/intellij/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-intellij": "^0.3.0"
         }

--- a/samples/irc/package.json
+++ b/samples/irc/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-irc": "^0.3.0"
         }

--- a/samples/irc/package.json
+++ b/samples/irc/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-irc": "^0.3.0"
         }

--- a/samples/midi-input/package.json
+++ b/samples/midi-input/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-midi-input": "^0.3.0"
         }

--- a/samples/midi-input/package.json
+++ b/samples/midi-input/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-midi-input": "^0.3.0"
         }

--- a/samples/midi-io/package.json
+++ b/samples/midi-io/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-midi-input": "^0.3.0",
             "nodecg-io-midi-output": "^0.3.0"

--- a/samples/midi-io/package.json
+++ b/samples/midi-io/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-midi-input": "^0.3.0",
             "nodecg-io-midi-output": "^0.3.0"

--- a/samples/midi-output/package.json
+++ b/samples/midi-output/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-midi-output": "^0.3.0"
         }

--- a/samples/midi-output/package.json
+++ b/samples/midi-output/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-midi-output": "^0.3.0"
         }

--- a/samples/mqtt-client/package.json
+++ b/samples/mqtt-client/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-mqtt-client": "^0.3.0"
         }

--- a/samples/mqtt-client/package.json
+++ b/samples/mqtt-client/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-mqtt-client": "^0.3.0"
         }

--- a/samples/nanoleaf/package.json
+++ b/samples/nanoleaf/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-nanoleaf": "^0.3.0"
         }

--- a/samples/nanoleaf/package.json
+++ b/samples/nanoleaf/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-nanoleaf": "^0.3.0"
         }

--- a/samples/obs-scenelist/package.json
+++ b/samples/obs-scenelist/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-obs": "^0.3.0"
         }

--- a/samples/obs-scenelist/package.json
+++ b/samples/obs-scenelist/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-obs": "^0.3.0"
         }

--- a/samples/opentts/package.json
+++ b/samples/opentts/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-template": "^0.3.0"
         },

--- a/samples/opentts/package.json
+++ b/samples/opentts/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-template": "^0.3.0"
         },

--- a/samples/package.json
+++ b/samples/package.json
@@ -4,6 +4,6 @@
     "description": "",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1"
+        "compatibleRange": ">=1.1.1"
     }
 }

--- a/samples/package.json
+++ b/samples/package.json
@@ -4,6 +4,6 @@
     "description": "",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1"
+        "compatibleRange": ">=1.1.1 <3.0.0"
     }
 }

--- a/samples/philipshue-lights/package.json
+++ b/samples/philipshue-lights/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-philipshue": "^0.3.0"
         }

--- a/samples/philipshue-lights/package.json
+++ b/samples/philipshue-lights/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-philipshue": "^0.3.0"
         }

--- a/samples/rcon-minecraft/package.json
+++ b/samples/rcon-minecraft/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/derNiklaas"
     },
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-rcon": "^0.3.0"
         }

--- a/samples/rcon-minecraft/package.json
+++ b/samples/rcon-minecraft/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/derNiklaas"
     },
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-rcon": "^0.3.0"
         }

--- a/samples/reddit-msg-read/package.json
+++ b/samples/reddit-msg-read/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/noeppi-noeppi"
     },
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-reddit": "^0.3.0"
         }

--- a/samples/reddit-msg-read/package.json
+++ b/samples/reddit-msg-read/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/noeppi-noeppi"
     },
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-reddit": "^0.3.0"
         }

--- a/samples/sacn-receiver/package.json
+++ b/samples/sacn-receiver/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/Tim-Tech-Dev"
     },
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-sacn-receiver": "^0.3.0"
         }

--- a/samples/sacn-receiver/package.json
+++ b/samples/sacn-receiver/package.json
@@ -8,7 +8,7 @@
         "url": "https://github.com/Tim-Tech-Dev"
     },
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-sacn-receiver": "^0.3.0"
         }

--- a/samples/sacn-sender/package.json
+++ b/samples/sacn-sender/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-sacn-sender": "^0.3.0"
         }

--- a/samples/sacn-sender/package.json
+++ b/samples/sacn-sender/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-sacn-sender": "^0.3.0"
         }

--- a/samples/serial/package.json
+++ b/samples/serial/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-serial": "^0.3.0"
         }

--- a/samples/serial/package.json
+++ b/samples/serial/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-serial": "^0.3.0"
         }

--- a/samples/shlink-list-short-urls/package.json
+++ b/samples/shlink-list-short-urls/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-shlink": "^0.3.0"
         }

--- a/samples/shlink-list-short-urls/package.json
+++ b/samples/shlink-list-short-urls/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-shlink": "^0.3.0"
         }

--- a/samples/slack-post/package.json
+++ b/samples/slack-post/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-slack": "^0.3.0"
         }

--- a/samples/slack-post/package.json
+++ b/samples/slack-post/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-slack": "^0.3.0"
         }

--- a/samples/spotify-current-song/package.json
+++ b/samples/spotify-current-song/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "version": "0.3.0",
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-spotify": "^0.3.0"
         }

--- a/samples/spotify-current-song/package.json
+++ b/samples/spotify-current-song/package.json
@@ -3,7 +3,7 @@
     "private": true,
     "version": "0.3.0",
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-spotify": "^0.3.0"
         }

--- a/samples/sql/package.json
+++ b/samples/sql/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-sql": "^0.3.0"
         }

--- a/samples/sql/package.json
+++ b/samples/sql/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-sql": "^0.3.0"
         }

--- a/samples/streamdeck-rainbow/package.json
+++ b/samples/streamdeck-rainbow/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-streamdeck": "^0.3.0"
         }

--- a/samples/streamdeck-rainbow/package.json
+++ b/samples/streamdeck-rainbow/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-streamdeck": "^0.3.0"
         }

--- a/samples/streamelements-events/package.json
+++ b/samples/streamelements-events/package.json
@@ -7,7 +7,7 @@
         "watch": "npm run build -- --watch"
     },
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-streamelements": "^0.3.0"
         },

--- a/samples/streamelements-events/package.json
+++ b/samples/streamelements-events/package.json
@@ -7,7 +7,7 @@
         "watch": "npm run build -- --watch"
     },
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-streamelements": "^0.3.0"
         },

--- a/samples/telegram-bot/package.json
+++ b/samples/telegram-bot/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-telegram": "^0.3.0"
         }

--- a/samples/telegram-bot/package.json
+++ b/samples/telegram-bot/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-telegram": "^0.3.0"
         }

--- a/samples/template/package.json
+++ b/samples/template/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-template": "^0.3.0"
         }

--- a/samples/template/package.json
+++ b/samples/template/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-template": "^0.3.0"
         }

--- a/samples/tiane-discord/package.json
+++ b/samples/tiane-discord/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-discord": "^0.3.0",
             "nodecg-io-tiane": "^0.3.0"

--- a/samples/tiane-discord/package.json
+++ b/samples/tiane-discord/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-discord": "^0.3.0",
             "nodecg-io-tiane": "^0.3.0"

--- a/samples/twitch-addons/package.json
+++ b/samples/twitch-addons/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-twitch-addons": "^0.3.0"
         }

--- a/samples/twitch-addons/package.json
+++ b/samples/twitch-addons/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-twitch-addons": "^0.3.0"
         }

--- a/samples/twitch-api/package.json
+++ b/samples/twitch-api/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-twitch-api": "^0.3.0"
         }

--- a/samples/twitch-api/package.json
+++ b/samples/twitch-api/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-twitch-api": "^0.3.0"
         }

--- a/samples/twitch-chat/package.json
+++ b/samples/twitch-chat/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-twitch-chat": "^0.3.0"
         }

--- a/samples/twitch-chat/package.json
+++ b/samples/twitch-chat/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-twitch-chat": "^0.3.0"
         }

--- a/samples/twitch-pubsub/package.json
+++ b/samples/twitch-pubsub/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-twitch-pubsub": "^0.3.0"
         }

--- a/samples/twitch-pubsub/package.json
+++ b/samples/twitch-pubsub/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-twitch-pubsub": "^0.3.0"
         }

--- a/samples/twitter-timeline/package.json
+++ b/samples/twitter-timeline/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-twitter": "^0.3.0"
         }

--- a/samples/twitter-timeline/package.json
+++ b/samples/twitter-timeline/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-twitter": "^0.3.0"
         }

--- a/samples/websocket-client/package.json
+++ b/samples/websocket-client/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-websocket-client": "^0.3.0"
         }

--- a/samples/websocket-client/package.json
+++ b/samples/websocket-client/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-websocket-client": "^0.3.0"
         }

--- a/samples/websocket-server/package.json
+++ b/samples/websocket-server/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-websocket-server": "^0.3.0"
         }

--- a/samples/websocket-server/package.json
+++ b/samples/websocket-server/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-websocket-server": "^0.3.0"
         }

--- a/samples/xdotool-windowminimize/package.json
+++ b/samples/xdotool-windowminimize/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-xdotool": "^0.3.0"
         }

--- a/samples/xdotool-windowminimize/package.json
+++ b/samples/xdotool-windowminimize/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-xdotool": "^0.3.0"
         }

--- a/samples/youtube-playlist/package.json
+++ b/samples/youtube-playlist/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-googleapis": "^0.3.0"
         }

--- a/samples/youtube-playlist/package.json
+++ b/samples/youtube-playlist/package.json
@@ -3,7 +3,7 @@
     "version": "0.3.0",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-googleapis": "^0.3.0"
         }

--- a/services/nodecg-io-ahk/package.json
+++ b/services/nodecg-io-ahk/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-ahk/package.json
+++ b/services/nodecg-io-ahk/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-android/package.json
+++ b/services/nodecg-io-android/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-android/package.json
+++ b/services/nodecg-io-android/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-artnet/package.json
+++ b/services/nodecg-io-artnet/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-artnet/package.json
+++ b/services/nodecg-io-artnet/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-atem/package.json
+++ b/services/nodecg-io-atem/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-atem/package.json
+++ b/services/nodecg-io-atem/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-dbus/package.json
+++ b/services/nodecg-io-dbus/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-dbus/package.json
+++ b/services/nodecg-io-dbus/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-debug/package.json
+++ b/services/nodecg-io-debug/package.json
@@ -31,7 +31,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         },

--- a/services/nodecg-io-debug/package.json
+++ b/services/nodecg-io-debug/package.json
@@ -31,7 +31,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         },

--- a/services/nodecg-io-discord-rpc/package.json
+++ b/services/nodecg-io-discord-rpc/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-discord-rpc/package.json
+++ b/services/nodecg-io-discord-rpc/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-discord/package.json
+++ b/services/nodecg-io-discord/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-discord/package.json
+++ b/services/nodecg-io-discord/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-elgato-light/package.json
+++ b/services/nodecg-io-elgato-light/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-elgato-light/package.json
+++ b/services/nodecg-io-elgato-light/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-github/package.json
+++ b/services/nodecg-io-github/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-github/package.json
+++ b/services/nodecg-io-github/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-google-cast/package.json
+++ b/services/nodecg-io-google-cast/package.json
@@ -30,7 +30,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-google-cast/package.json
+++ b/services/nodecg-io-google-cast/package.json
@@ -30,7 +30,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-googleapis/package.json
+++ b/services/nodecg-io-googleapis/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-googleapis/package.json
+++ b/services/nodecg-io-googleapis/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-intellij/package.json
+++ b/services/nodecg-io-intellij/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-intellij/package.json
+++ b/services/nodecg-io-intellij/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-irc/package.json
+++ b/services/nodecg-io-irc/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-irc/package.json
+++ b/services/nodecg-io-irc/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-midi-input/package.json
+++ b/services/nodecg-io-midi-input/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-midi-input/package.json
+++ b/services/nodecg-io-midi-input/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-midi-output/package.json
+++ b/services/nodecg-io-midi-output/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-midi-output/package.json
+++ b/services/nodecg-io-midi-output/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-mqtt-client/package.json
+++ b/services/nodecg-io-mqtt-client/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-mqtt-client/package.json
+++ b/services/nodecg-io-mqtt-client/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-nanoleaf/package.json
+++ b/services/nodecg-io-nanoleaf/package.json
@@ -23,7 +23,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-nanoleaf/package.json
+++ b/services/nodecg-io-nanoleaf/package.json
@@ -23,7 +23,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-obs/package.json
+++ b/services/nodecg-io-obs/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-obs/package.json
+++ b/services/nodecg-io-obs/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-opentts/package.json
+++ b/services/nodecg-io-opentts/package.json
@@ -30,7 +30,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-opentts/package.json
+++ b/services/nodecg-io-opentts/package.json
@@ -30,7 +30,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-philipshue/package.json
+++ b/services/nodecg-io-philipshue/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-philipshue/package.json
+++ b/services/nodecg-io-philipshue/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-rcon/package.json
+++ b/services/nodecg-io-rcon/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-rcon/package.json
+++ b/services/nodecg-io-rcon/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-reddit/package.json
+++ b/services/nodecg-io-reddit/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-reddit/package.json
+++ b/services/nodecg-io-reddit/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-sacn-receiver/package.json
+++ b/services/nodecg-io-sacn-receiver/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-sacn-receiver/package.json
+++ b/services/nodecg-io-sacn-receiver/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-sacn-sender/package.json
+++ b/services/nodecg-io-sacn-sender/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-sacn-sender/package.json
+++ b/services/nodecg-io-sacn-sender/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-serial/package.json
+++ b/services/nodecg-io-serial/package.json
@@ -27,7 +27,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-serial/package.json
+++ b/services/nodecg-io-serial/package.json
@@ -27,7 +27,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-shlink/package.json
+++ b/services/nodecg-io-shlink/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-shlink/package.json
+++ b/services/nodecg-io-shlink/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-slack/package.json
+++ b/services/nodecg-io-slack/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-slack/package.json
+++ b/services/nodecg-io-slack/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-spotify/package.json
+++ b/services/nodecg-io-spotify/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-spotify/package.json
+++ b/services/nodecg-io-spotify/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-sql/package.json
+++ b/services/nodecg-io-sql/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-sql/package.json
+++ b/services/nodecg-io-sql/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-streamdeck/package.json
+++ b/services/nodecg-io-streamdeck/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-streamdeck/package.json
+++ b/services/nodecg-io-streamdeck/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-streamelements/package.json
+++ b/services/nodecg-io-streamelements/package.json
@@ -29,7 +29,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-streamelements/package.json
+++ b/services/nodecg-io-streamelements/package.json
@@ -29,7 +29,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-telegram/package.json
+++ b/services/nodecg-io-telegram/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-telegram/package.json
+++ b/services/nodecg-io-telegram/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-template/package.json
+++ b/services/nodecg-io-template/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-template/package.json
+++ b/services/nodecg-io-template/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-tiane/package.json
+++ b/services/nodecg-io-tiane/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-tiane/package.json
+++ b/services/nodecg-io-tiane/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitch-addons/package.json
+++ b/services/nodecg-io-twitch-addons/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitch-addons/package.json
+++ b/services/nodecg-io-twitch-addons/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitch-api/package.json
+++ b/services/nodecg-io-twitch-api/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitch-api/package.json
+++ b/services/nodecg-io-twitch-api/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitch-chat/package.json
+++ b/services/nodecg-io-twitch-chat/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitch-chat/package.json
+++ b/services/nodecg-io-twitch-chat/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitch-pubsub/package.json
+++ b/services/nodecg-io-twitch-pubsub/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitch-pubsub/package.json
+++ b/services/nodecg-io-twitch-pubsub/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitter/package.json
+++ b/services/nodecg-io-twitter/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-twitter/package.json
+++ b/services/nodecg-io-twitter/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-websocket-client/package.json
+++ b/services/nodecg-io-websocket-client/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-websocket-client/package.json
+++ b/services/nodecg-io-websocket-client/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-websocket-server/package.json
+++ b/services/nodecg-io-websocket-server/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-websocket-server/package.json
+++ b/services/nodecg-io-websocket-server/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-xdotool/package.json
+++ b/services/nodecg-io-xdotool/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1",
+        "compatibleRange": ">=1.1.1",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/nodecg-io-xdotool/package.json
+++ b/services/nodecg-io-xdotool/package.json
@@ -24,7 +24,7 @@
         "nodecg-bundle"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1",
+        "compatibleRange": ">=1.1.1 <3.0.0",
         "bundleDependencies": {
             "nodecg-io-core": "^0.3.0"
         }

--- a/services/package.json
+++ b/services/package.json
@@ -4,6 +4,6 @@
     "description": "",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1"
+        "compatibleRange": ">=1.1.1"
     }
 }

--- a/services/package.json
+++ b/services/package.json
@@ -4,6 +4,6 @@
     "description": "",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1"
+        "compatibleRange": ">=1.1.1 <3.0.0"
     }
 }

--- a/utils/nodecg-io-tsconfig/package.json
+++ b/utils/nodecg-io-tsconfig/package.json
@@ -18,7 +18,7 @@
         "nodecg-io"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1"
+        "compatibleRange": ">=1.1.1 <3.0.0"
     },
     "license": "MIT"
 }

--- a/utils/nodecg-io-tsconfig/package.json
+++ b/utils/nodecg-io-tsconfig/package.json
@@ -18,7 +18,7 @@
         "nodecg-io"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1"
+        "compatibleRange": ">=1.1.1"
     },
     "license": "MIT"
 }

--- a/utils/nodecg-io-twitch-auth/package.json
+++ b/utils/nodecg-io-twitch-auth/package.json
@@ -15,7 +15,7 @@
         "nodecg-io"
     ],
     "nodecg": {
-        "compatibleRange": "^1.1.1"
+        "compatibleRange": ">=1.1.1"
     },
     "license": "MIT",
     "devDependencies": {

--- a/utils/nodecg-io-twitch-auth/package.json
+++ b/utils/nodecg-io-twitch-auth/package.json
@@ -15,7 +15,7 @@
         "nodecg-io"
     ],
     "nodecg": {
-        "compatibleRange": ">=1.1.1"
+        "compatibleRange": ">=1.1.1 <3.0.0"
     },
     "license": "MIT",
     "devDependencies": {

--- a/utils/package.json
+++ b/utils/package.json
@@ -4,6 +4,6 @@
     "description": "",
     "private": true,
     "nodecg": {
-        "compatibleRange": "^1.1.1"
+        "compatibleRange": ">=1.1.1"
     }
 }

--- a/utils/package.json
+++ b/utils/package.json
@@ -4,6 +4,6 @@
     "description": "",
     "private": true,
     "nodecg": {
-        "compatibleRange": ">=1.1.1"
+        "compatibleRange": ">=1.1.1 <3.0.0"
     }
 }


### PR DESCRIPTION
I've tested NodeCG v2 with nodecg-io before NodeCG v2 was released which worked fine.\nNow that it has been released there have been two problems preventing it from fully working:

- NodeCG v2 was not included in the NodeCG version range that our bundles work with because the `^` semver2 operator does not include major updates.

- The NodeCG test CI workflow job was broken because build results are not checked into the NodeCG repository anymore so NodeCG must be built in CI (this is cached)