### PR TITLE
Increase timeout in NodeCG integration test to fix test flakiness

### DIFF
--- a/.scripts/ci-nodecg-integration.mjs
+++ b/.scripts/ci-nodecg-integration.mjs
@@ -26,7 +26,7 @@ console.log("\nStarted NodeCG");
 console.log("--------------------------------------------------------------------------------");
 
 // Spawn a process that runs NodeCG and let it run for 15 seconds to load all bundles
-const child = child_process.spawn("node", ["index.js"], { cwd: cwd.dir, timeout: 15000 });
+const child = child_process.spawn("node", ["index.js"], { cwd: cwd.dir, timeout: 20000 });
 
 // Store stdout and pipe the output of the child process to the output of this process
 const buffer = [];


### PR DESCRIPTION
Since NodeCG v2 the NodeCG integration test that ensures all bundles are öoadable by the current NodeCG version is flaky under windows. This is caused by NodeCG being stopped before even having a chance to load all
bundles. Seems like NodeCG v2 takes longer to start up so this PR increases the timeout from 15 seconds to 20 seconds.
