### PR TITLE
fix: Stream Elements replay event not working

### DIFF
--- a/services/nodecg-io-streamelements/extension/StreamElements.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElements.ts
@@ -5,7 +5,8 @@ import {
     StreamElementsEvent,
     StreamElementsFollowEvent,
     StreamElementsHostEvent,
-    StreamElementsRaidEvent, StreamElementsReplayEvent,
+    StreamElementsRaidEvent,
+    StreamElementsReplayEvent,
     StreamElementsSubBombEvent,
     StreamElementsSubscriberEvent,
     StreamElementsTestCheerEvent,
@@ -198,7 +199,7 @@ export class StreamElementsServiceClient extends EventEmitter {
                 handler({
                     event: data.data,
                     listener: data.name,
-                    provider: data.provider
+                    provider: data.provider,
                 } as unknown as StreamElementsTestEvent);
             }
         });

--- a/services/nodecg-io-streamelements/extension/StreamElements.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElements.ts
@@ -5,7 +5,7 @@ import {
     StreamElementsEvent,
     StreamElementsFollowEvent,
     StreamElementsHostEvent,
-    StreamElementsRaidEvent,
+    StreamElementsRaidEvent, StreamElementsReplayEvent,
     StreamElementsSubBombEvent,
     StreamElementsSubscriberEvent,
     StreamElementsTestCheerEvent,
@@ -186,6 +186,20 @@ export class StreamElementsServiceClient extends EventEmitter {
         this.socket.on("event:test", (data: StreamElementsTestEvent) => {
             if (data) {
                 handler(data);
+            }
+        });
+
+        this.socket.on("event:update", (data: StreamElementsReplayEvent) => {
+            // event:update is all replays of previous real events.
+            // Because the structure is similar to the test events and just the keys in the root element
+            // are named differently we rename those to align with the naming in the test events
+            // and handle it as a test event from here on.
+            if (data) {
+                handler({
+                    event: data.data,
+                    listener: data.name,
+                    provider: data.provider
+                } as unknown as StreamElementsTestEvent);
             }
         });
     }

--- a/services/nodecg-io-streamelements/extension/StreamElementsEvent.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElementsEvent.ts
@@ -1,3 +1,5 @@
+import { ObjectMap } from "nodecg-io-core";
+
 interface StreamElementsBaseEvent<TType, TData> {
     /**
      * StreamElements hexadecimal Event ID
@@ -158,7 +160,7 @@ interface StreamElementsBaseTestEvent<TListener, TEvent> {
     /**
      * Event provider
      */
-    provider: "twitch" | "youtube" | "facebook";
+    provider?: "twitch" | "youtube" | "facebook";
     listener: TListener;
     event: TEvent & StreamElementsTestDataBase;
 }
@@ -285,3 +287,15 @@ export type StreamElementsTestEvent =
     | StreamElementsTestRaidEvent
     | StreamElementsTestSubscriberEvent
     | StreamElementsTestTipEvent;
+
+/**
+ * When replaying real events the structure is similar to the test events
+ * except for the keys in the root object.
+ * This is a replay event general for all types.
+ * The data structure and name follows the same schema as the test events.
+ */
+export interface StreamElementsReplayEvent {
+    provider?: "twitch" | "youtube" | "facebook";
+    name: string;
+    data: ObjectMap<string | number>
+}

--- a/services/nodecg-io-streamelements/extension/StreamElementsEvent.ts
+++ b/services/nodecg-io-streamelements/extension/StreamElementsEvent.ts
@@ -297,5 +297,5 @@ export type StreamElementsTestEvent =
 export interface StreamElementsReplayEvent {
     provider?: "twitch" | "youtube" | "facebook";
     name: string;
-    data: ObjectMap<string | number>
+    data: ObjectMap<string | number>;
 }


### PR DESCRIPTION
Add event listener to `event:update`, which is the new endpoint that stream elements uses to display all replays of previous real events.