### PR TITLE
Add built assets to tarball of the dashboard

### DIFF
--- a/nodecg-io-core/dashboard/package.json
+++ b/nodecg-io-core/dashboard/package.json
@@ -3,6 +3,11 @@
     "version": "0.3.0",
     "description": "Dashboard that is used to manage your nodecg-io configuration.",
     "homepage": "https://nodecg.io/RELEASE",
+    "files": [
+        "dist",
+        "*.css",
+        "*.html"
+    ],
     "author": {
         "name": "CodeOverflow team",
         "url": "https://github.com/codeoverflow-org"


### PR DESCRIPTION
Previously no `files` key was specified in the package.json of the dashboard.
Because of this only the source files were added to the dashboard v0.3.0 tarball.
This PR updates the package.json to include the built version that is used by the production installations that are made using the nodecg-io-cli.

After this PR has been merged it will be backported to the `release/0.3` branch and v0.3.1 of the dashboard will be released.
